### PR TITLE
Enable strictNullChecks

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+singleQuote: true
+trailingComma: es5

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     },
     "testRegex": "/src/.*.test.(jsx?|tsx?)$",
     "testPathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/", "/dist/"
     ],
     "collectCoverageFrom": [
       "src/**/*.tsx",

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -1,8 +1,24 @@
-export interface LazyResult<T> {
+export type LazyResult<T> = LazyEmpty<T> | LazyNext<T> | LazyMany<T>;
+
+interface LazyEmpty<T> {
   done: boolean;
-  hasNext: boolean;
-  hasMany?: boolean;
-  next?: T | T[];
+  hasNext: false;
+  hasMany?: false | undefined;
+  next?: undefined;
+}
+
+interface LazyNext<T> {
+  done: boolean;
+  hasNext: true;
+  hasMany?: false | undefined;
+  next: T;
+}
+
+interface LazyMany<T> {
+  done: boolean;
+  hasNext: true;
+  hasMany: true;
+  next: T[];
 }
 
 export function _reduceLazy<T, K>(
@@ -10,11 +26,11 @@ export function _reduceLazy<T, K>(
   lazy: (item: T, index?: number, array?: T[]) => LazyResult<K>,
   indexed?: boolean
 ) {
-  return array.reduce((acc, item, index) => {
+  return array.reduce((acc: K[], item, index) => {
     const result = indexed ? lazy(item, index, array) : lazy(item);
-    if (result.hasMany) {
-      acc.push(...(result.next as K[]));
-    } else if (result.hasNext) {
+    if (result.hasMany === true) {
+      acc.push(...result.next);
+    } else if (result.hasNext === true) {
       acc.push(result.next);
     }
     return acc;

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -5,3 +5,9 @@ export type PredIndexedOptional<T, K> = (
   index?: number,
   array?: T[]
 ) => K;
+
+/** types that may be returned by `keyof` */
+export type Key = string | number | symbol;
+
+/** Mapped type to remove optional, null, and undefined from all props */
+export type NonNull<T> = { [K in keyof T]-?: Exclude<T[K], null | undefined> };

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -33,7 +33,7 @@ export function chunk() {
 
 function _chunk<T>(array: T[], size: number) {
   const ret: T[][] = [];
-  let current: T[] = null;
+  let current: T[] | null = null;
   array.forEach(x => {
     if (!current) {
       current = [];

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -37,7 +37,7 @@ describe('deep clone objects', () => {
   it('clones deep object', () => {
     const obj = { a: { b: { c: 'foo' } } };
     const cloned = clone(obj);
-    obj.a.b.c = null;
+    obj.a.b.c = 'bar';
     eq(cloned, { a: { b: { c: 'foo' } } });
   });
 
@@ -155,7 +155,7 @@ describe('deep clone deep nested mixed objects', () => {
   });
 
   it('clones array with arrays', () => {
-    const list = [[1], [[3]]];
+    const list: any[][] = [[1], [[3]]];
     const cloned = clone(list);
     list[1][0] = null;
     eq(cloned, [[1], [[3]]]);

--- a/src/difference.ts
+++ b/src/difference.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Excludes the values from `other` array.
@@ -44,7 +44,7 @@ function _difference<T>(array: T[], other: T[]) {
 
 export namespace difference {
   export function lazy<T>(other: T[]) {
-    return (value: T) => {
+    return (value: T): LazyResult<T> => {
       const set = new Set(other);
       if (!set.has(value)) {
         return {

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Removes first `n` elements from the `array`.
@@ -40,7 +40,7 @@ function _drop<T>(array: T[], n: number) {
 export namespace drop {
   export function lazy<T>(n: number) {
     let left = n;
-    return (value: T) => {
+    return (value: T): LazyResult<T> => {
       if (left > 0) {
         left--;
         return {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 
@@ -54,12 +54,18 @@ const _filter = (indexed: boolean) => <T>(
 const _lazy = (indexed: boolean) => <T>(
   fn: PredIndexedOptional<T, boolean>
 ) => {
-  return (value: T, index?: number, array?: T[]) => {
+  return (value: T, index?: number, array?: T[]): LazyResult<T> => {
     const valid = indexed ? fn(value, index, array) : fn(value);
+    if (!!valid === true) {
+      return {
+        done: false,
+        hasNext: true,
+        next: value,
+      };
+    }
     return {
       done: false,
-      hasNext: valid,
-      next: value,
+      hasNext: false,
     };
   };
 };

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,4 +1,4 @@
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { purry } from './purry';
 
 type Flatten<T> = T extends Array<infer K> ? K : T;
@@ -32,7 +32,7 @@ function _flatten<T>(items: Array<T>): Array<Flatten<T>> {
 
 export namespace flatten {
   export function lazy<T>() {
-    return (next: T) => {
+    return (next: T): LazyResult<any> => {
       if (Array.isArray(next)) {
         return {
           done: false,

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -1,4 +1,4 @@
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { purry } from './purry';
 
 type FlattenDeep<T> = T extends Array<infer K> ? FlattenDeep2<K> : T;
@@ -49,7 +49,7 @@ function _flattenDeepValue<T>(value: T | Array<T>): T | Array<FlattenDeep<T>> {
 
 export namespace flattenDeep {
   export function lazy() {
-    return (value: any) => {
+    return (value: any): LazyResult<any> => {
       const next = _flattenDeepValue(value);
       if (Array.isArray(next)) {
         return {

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { _toLazyIndexed } from './_toLazyIndexed';
 import { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
@@ -67,7 +67,7 @@ const _forEach = (indexed: boolean) => <T, K>(
 };
 
 const _lazy = (indexed: boolean) => <T>(fn: PredIndexedOptional<T, void>) => {
-  return (value: T, index?: number, array?: T[]) => {
+  return (value: T, index?: number, array?: T[]): LazyResult<T> => {
     if (indexed) {
       fn(value, index, array);
     } else {

--- a/src/intersection.ts
+++ b/src/intersection.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Returns a list of elements that exist in both array.
@@ -40,7 +40,7 @@ function _intersection<T>(array: T[], other: T[]) {
 
 export namespace intersection {
   export function lazy<T>(other: T[]) {
-    return (value: T) => {
+    return (value: T): LazyResult<T> => {
       const set = new Set(other);
       if (set.has(value)) {
         return {

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { _toLazyIndexed } from './_toLazyIndexed';
 import { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
@@ -53,7 +53,7 @@ const _map = (indexed: boolean) => <T, K>(
 };
 
 const _lazy = (indexed: boolean) => <T, K>(fn: PredIndexedOptional<T, K>) => {
-  return (value: T, index?: number, array?: T[]) => {
+  return (value: T, index?: number, array?: T[]): LazyResult<K> => {
     return {
       done: false,
       hasNext: true,

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -37,7 +37,7 @@ describe('data first', () => {
   });
 
   test('should return value (2 level deep)', () => {
-    expect(pathOr(obj, ['a', 'b'], null)).toEqual({ c: 1 });
+    expect(pathOr(obj, ['a', 'b'], { c: 0 })).toEqual({ c: 1 });
   });
 
   test('should return default value (2 level deep)', () => {
@@ -45,7 +45,7 @@ describe('data first', () => {
   });
 
   test('should return value (3 level deep)', () => {
-    expect(pathOr(obj, ['a', 'b', 'c'], null)).toEqual(1);
+    expect(pathOr(obj, ['a', 'b', 'c'], 0)).toEqual(1);
   });
 });
 

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -24,7 +24,8 @@ const obj: SampleType = {
 
 describe('data first', () => {
   test('should return default value (input undefined)', () => {
-    expect(pathOr(undefined as SampleType, ['x'], 2)).toEqual(2);
+    type MaybeSampleType = SampleType | undefined;
+    expect(pathOr(undefined as MaybeSampleType, ['x'], 2)).toEqual(2);
   });
 
   test('should return value', () => {

--- a/src/pathOr.ts
+++ b/src/pathOr.ts
@@ -1,4 +1,65 @@
 import { purry } from './purry';
+import { NonNull, Key } from './_types';
+
+/**
+ * Given a union of indexable types `T`, we derive an indexable type
+ * containing all of the keys of each variant of `T`. If a key is
+ * present in multiple variants of `T`, then the corresponding type in
+ * `Pathable<T>` will be the intersection of all types for that key.
+ * @example
+ *    type T1 = Pathable<{a: number} | {a: string; b: boolean}>
+ *    // {a: number | string; b: boolean}
+ *
+ *    type T2 = Pathable<{a?: {b: string}}
+ *    // {a: {b: string} | undefined}
+ *
+ *    type T3 = Pathable<{a: string} | number>
+ *    // {a: string}
+ *
+ *    type T4 = Pathable<{a: number} | {a: string} | {b: boolean}>
+ *    // {a: number | string; b: boolean}
+ *
+ * This type lets us answer the questions:
+ * - Given some object of type `T`, what keys might this object have?
+ * - If this object did happen to have a particular key, what values
+ *   might that key have?
+ */
+type Pathable<T> = { [K in AllKeys<T>]: TypesForKey<T, K> };
+
+type AllKeys<T> = T extends infer I ? keyof I : never;
+type TypesForKey<T, K extends Key> = T extends infer I
+  ? K extends keyof I ? I[K] : never
+  : never;
+
+/**
+ * Given some `A` which is a key of at least one variant of `T`, derive
+ * `T[A]` for the cases where `A` is present in `T`, and `T[A]` is not
+ * null or undefined.
+ */
+type PathValue1<T, A extends keyof Pathable<T>> = NonNull<Pathable<T>>[A];
+/** All possible options after successfully reaching `T[A]` */
+type Pathable1<T, A extends keyof Pathable<T>> = Pathable<PathValue1<T, A>>;
+
+/** As `PathValue1`, but for `T[A][B]` */
+type PathValue2<
+  T,
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>
+> = NonNull<Pathable1<T, A>>[B];
+/** As `Pathable1`, but for `T[A][B]` */
+type Pathable2<
+  T,
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>
+> = Pathable<PathValue2<T, A, B>>;
+
+/** As `PathValue1`, but for `T[A][B][C]` */
+type PathValue3<
+  T,
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>,
+  C extends keyof Pathable2<T, A, B>
+> = NonNull<Pathable2<T, A, B>>[C];
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is `undefined`, the `defaultValue` is returned in its place.
@@ -12,24 +73,32 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function pathOr<T, A extends keyof T>(
+export function pathOr<T, A extends keyof Pathable<T>>(
   object: T,
   path: [A],
-  defaultValue: T[A]
-): T[A];
-
-export function pathOr<T, A extends keyof T, B extends keyof T[A]>(
-  object: T,
-  path: [A, B],
-  defaultValue: T[A][B]
-): T[A][B];
+  defaultValue: PathValue1<T, A>
+): PathValue1<T, A>;
 
 export function pathOr<
   T,
-  A extends keyof T,
-  B extends keyof T[A],
-  C extends keyof T[A][B]
->(object: T, path: [A, B, C], defaultValue: T[A][B][C]): T[A][B][C];
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>
+>(
+  object: T,
+  path: [A, B],
+  defaultValue: PathValue2<T, A, B>
+): PathValue2<T, A, B>;
+
+export function pathOr<
+  T,
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>,
+  C extends keyof Pathable2<T, A, B>
+>(
+  object: T,
+  path: [A, B, C],
+  defaultValue: PathValue3<T, A, B, C>
+): PathValue3<T, A, B, C>;
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is `undefined`, the `defaultValue` is returned in its place.
@@ -43,22 +112,29 @@ export function pathOr<
  * @data_last
  * @category Object
  */
-export function pathOr<T, A extends keyof T>(
+export function pathOr<T, A extends keyof Pathable<T>>(
   path: [A],
-  defaultValue: T[A]
-): (object: T) => T[A];
-
-export function pathOr<T, A extends keyof T, B extends keyof T[A]>(
-  path: [A, B],
-  defaultValue: T[A][B]
-): (object: T) => T[A][B];
+  defaultValue: PathValue1<T, A>
+): (object: T) => PathValue1<T, A>;
 
 export function pathOr<
   T,
-  A extends keyof T,
-  B extends keyof T[A],
-  C extends keyof T[A][B]
->(path: [A, B, C], defaultValue: T[A][B][C]): (object: T) => T[A][B][C];
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>
+>(
+  path: [A, B],
+  defaultValue: PathValue2<T, A, B>
+): (object: T) => PathValue2<T, A, B>;
+
+export function pathOr<
+  T,
+  A extends keyof Pathable<T>,
+  B extends keyof Pathable1<T, A>,
+  C extends keyof Pathable2<T, A, B>
+>(
+  path: [A, B, C],
+  defaultValue: PathValue3<T, A, B, C>
+): (object: T) => PathValue3<T, A, B, C>;
 
 export function pathOr() {
   return purry(_pathOr, arguments);

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -7,8 +7,8 @@ describe('data first', () => {
     expect(result).toEqual({ a: 1, d: 4 });
   });
   test('allow undefined or null', () => {
-    expect(pick(undefined, ['foo'])).toEqual({});
-    expect(pick(null, ['foo'])).toEqual({});
+    expect(pick(undefined as any, ['foo'])).toEqual({});
+    expect(pick(null as any, ['foo'])).toEqual({});
   });
 });
 

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -148,7 +148,7 @@ function _processItem({
     acc.push(item);
     return false;
   }
-  let lazyResult: LazyResult<any>;
+  let lazyResult: LazyResult<any> = { done: false, hasNext: false };
   for (let i = 0; i < lazySeq.length; i++) {
     const lazyFn = lazySeq[i];
     const indexed = lazyFn.indexed;

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 
@@ -55,12 +55,18 @@ const _reject = (indexed: boolean) => <T>(
 const _lazy = (indexed: boolean) => <T>(
   fn: PredIndexedOptional<T, boolean>
 ) => {
-  return (value: T, index?: number, array?: T[]) => {
+  return (value: T, index?: number, array?: T[]): LazyResult<T> => {
     const valid = indexed ? fn(value, index, array) : fn(value);
+    if (!valid === true) {
+      return {
+        done: false,
+        hasNext: true,
+        next: value,
+      };
+    }
     return {
       done: false,
-      hasNext: !valid,
-      next: value,
+      hasNext: false,
     };
   };
 };

--- a/src/take.ts
+++ b/src/take.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Returns the first `n` elements of `array`.
@@ -38,7 +38,7 @@ function _take<T>(array: T[], n: number) {
 
 export namespace take {
   export function lazy<T>(n: number) {
-    return (value: T) => {
+    return (value: T): LazyResult<T> => {
       if (n === 0) {
         return {
           done: true,

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { _reduceLazy } from './_reduceLazy';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Returns a new array containing only one copy of each element in the original list.
@@ -33,7 +33,7 @@ function _uniq<T>(array: T[]) {
 export namespace uniq {
   export function lazy() {
     const set = new Set<any>();
-    return (value: any) => {
+    return (value: any): LazyResult<any> => {
       if (set.has(value)) {
         return {
           done: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    "strictNullChecks": false /* Enable strict null checks. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */


### PR DESCRIPTION
Addresses #5 

These changes allow remeda to compile with `strictNullChecks: true`, and should ensure that functions such as `pick` and `pathOr` will have the same typing behavior no matter if a project has `strictNullChecks` enabled or disabled.

Changes:
- Add `.prettierrc` and exclude `/dist` from test runs. I had to make these changes to get my environment working correctly, but they can be dropped if they aren't helpful.
- Refactor `LazyResult` to work better with `strictNullChecks`.
- Explicitly allow the `object` argument of `pick` to be `undefined` or `null`, matching the `strictNullChecks: false` behavior.
- Allow `pathOr` to select keys that are possibly missing in the object, matching the `strictNullChecks: false` behavior.
- Allow `pathOr`'s `defaultValue` argument to be of any type. This broadens the behavior or `pathOr` a bit, but seems appropriate.
- Enable `strictNullCheck`, which no longer triggers compiler errors.