### PR TITLE
 be more elaborate in the lazy evaluation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Lazy evaluation is not supported in Ramda and only partially supported in lodash
 const arr = [1, 2, 2, 3, 3, 4, 5, 6];
 
 const result = R.pipe(
-  arr,
+  arr,                    // only four iterations instead of eight (array.length)
   R.map(x => {
     console.log('iterate', x);
     return x;


### PR DESCRIPTION
be more elaborate in the lazy evaluation example, avoid confusion