### PR TITLE
Add typed clone()

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -54,7 +54,7 @@ function _clone(value: any, refFrom: any[], refTo: any[], deep: boolean) {
  * @signature R.clone(value)
  * @example R.clone({foo: 'bar'}) // {foo: 'bar'}
  */
-export function clone(value: any) {
+export function clone<T extends any>(value: T): T {
   return value != null && typeof value.clone === 'function'
     ? value.clone()
     : _clone(value, [], [], true);


### PR DESCRIPTION
Closes https://github.com/remeda/remeda/issues/26

The current version of the clone() function converts the provided
argument to type 'any'. These changes make the cloned version keep the
type of the provided argument