### PR TITLE
chore: added uniqBy to default library exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,3 +53,4 @@ export * from './times';
 export * from './toPairs';
 export * from './type';
 export * from './uniq';
+export * from './uniqBy';


### PR DESCRIPTION
Just a minor thing -> saw that **uniqBy** was missing from the default exports and must be referenced directly from its inner path.