### PR TITLE
Narrow typings for compact()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remeda",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A utility library for JavaScript and Typescript.",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/src/compact.test.ts
+++ b/src/compact.test.ts
@@ -5,7 +5,8 @@ import { compact } from './compact';
 
 test('filter correctly', () => {
   const items = [false, null, 0, '', undefined, NaN, true, 1, 'a'] as const;
-  expect(compact(items)).toEqual([true, 1, 'a']);
+  const results: (boolean | number | 'a')[] = compact(items);
+  expect(results).toEqual([true, 1, 'a']);
 });
 
 // test('lazy', () => {

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -1,4 +1,4 @@
-function notNil<T>(value: T | null | undefined | false | '' | 0): value is T {
+function isTruthy<T>(value: T | null | undefined | false | '' | 0): value is T {
   return !!value;
 }
 
@@ -16,5 +16,5 @@ export function compact<T>(
   items: readonly (T | null | undefined | false | '' | 0)[]
 ): T[] {
   // TODO: Make lazy version
-  return items.filter(notNil);
+  return items.filter(isTruthy);
 }

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -1,3 +1,7 @@
+function notNil<T>(value: T | null | undefined | false | '' | 0): value is T {
+  return !!value;
+}
+
 /**
  * Filter out all falsey values. The values `false`, `null`, `0`, `""`, `undefined`, and `NaN` are falsey.
  * @param items the array to compact
@@ -8,7 +12,9 @@
  * @category Array
  * @pipeable
  */
-export function compact<T>(items: readonly T[]) {
+export function compact<T>(
+  items: readonly (T | null | undefined | false | '' | 0)[]
+): T[] {
   // TODO: Make lazy version
-  return items.filter(x => !!x);
+  return items.filter(notNil);
 }


### PR DESCRIPTION
I noticed that calling `compact()` didn't actually remove falsy values according to the typings, which is one of the main reasons I use that function in lodash. IE: `_compact((string|undefined)[])` should result in `string[]`. This doesn't change any functionality, just the typings.

Also, I noticed that for `R.uniq`, two typings are provided for the function, `items => items` and `() => items => items`, while compact() just has this single definition. This lead to some confusion in R.pipe, as I had to call `R.uniq()`, but just use `R.compact` without calling it. I feel like we should standardize on one of these, maybe the `R.uniq()` style?