### PR TITLE
Added support for type guards in filter function

### DIFF
--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -2,10 +2,26 @@ import { pipe } from './pipe';
 import { filter } from './filter';
 import { createCounter } from './_counter';
 
+function assertType<T>(data: T): T {
+  return data
+}
+
+function isNumber<T>(data: T): data is Extract<T, number> {
+  return typeof data === 'number'
+} // TODO Refactor to remeda function
+
 describe('data_first', () => {
+
   it('filter', () => {
     const result = filter([1, 2, 3] as const, x => x % 2 === 1);
+    assertType<(1 | 2 | 3)[]>(result) // Type test
     expect(result).toEqual([1, 3]);
+  });
+
+  it('data_first with typescript guard', () => {
+    const result = filter([1, 2, 3, 'abc', true] as const, isNumber);
+    assertType<(1 | 2 | 3)[]>(result) // Type test
+    expect(result).toEqual([1, 2, 3]);
   });
 
   it('filter.indexed', () => {
@@ -13,7 +29,17 @@ describe('data_first', () => {
       [1, 2, 3] as const,
       (x, i) => x % 2 === 1 && i !== 1
     );
+    assertType<(1 | 2 | 3)[]>(result) // Type test
     expect(result).toEqual([1, 3]);
+  });
+
+  it('filter.indexed with typescript guard', () => {
+    const result = filter.indexed(
+      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[] 
+      isNumber
+    );
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    expect(result).toEqual([1, 2, 3]);
   });
 });
 
@@ -26,7 +52,43 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 3]);
+  });
+
+  it('filter', () => {
+    const counter = createCounter();
+    const result = pipe(
+      [1, 2, 3] as const,
+      filter(x => x % 2 === 1),
+      counter.fn()
+    );
+    expect(counter.count).toHaveBeenCalledTimes(2);
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    expect(result).toEqual([1, 3]);
+  });
+
+  it('filter with typescript guard', () => {
+    const counter = createCounter();
+    const result = pipe(
+      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[] 
+      filter(isNumber),
+      counter.fn()
+    );
+    expect(counter.count).toHaveBeenCalledTimes(3);
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    expect(result).toEqual([1, 2, 3]);
+  });
+  it('filter.indexed with typescript guard', () => {
+    const counter = createCounter();
+    const result = pipe(
+      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[]
+      filter.indexed(isNumber),
+      counter.fn()
+    );
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    expect(counter.count).toHaveBeenCalledTimes(3);
+    expect(result).toEqual([1, 2, 3]);
   });
   it('filter.indexed', () => {
     const counter = createCounter();
@@ -35,6 +97,7 @@ describe('data_last', () => {
       filter.indexed((x, i) => x % 2 === 1 && i !== 1),
       counter.fn()
     );
+    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -18,6 +18,7 @@ import { _toLazyIndexed } from './_toLazyIndexed';
  * @pipeable
  * @category Array
  */
+export function filter<T, S extends T>(array: readonly T[], fn: (value: T) => value is S): S[];
 export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
 
 /**
@@ -34,6 +35,7 @@ export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
  * @pipeable
  * @category Array
  */
+export function filter<T, S extends T>(fn: (input: T) => input is S): (array: readonly T[]) => S[];
 export function filter<T>(fn: Pred<T, boolean>): (array: readonly T[]) => T[];
 
 export function filter() {
@@ -71,13 +73,24 @@ const _lazy = (indexed: boolean) => <T>(
 };
 
 export namespace filter {
-  export function indexed<T, K>(
+  // I don't understand why you need additional generic?
+  export function indexed<T, S extends T>(
+    array: readonly T[],
+    fn: (input: T, index: number, array: T[]) => input is S
+  ): S[];
+  export function indexed<T>(
     array: readonly T[],
     fn: PredIndexed<T, boolean>
-  ): K[];
-  export function indexed<T, K>(
+  ): T[];
+  /**
+   * @data_last
+   */
+  export function indexed<T, S extends T>(
+    fn: (input: T, index: number, array: T[]) => input is S
+  ): (array: readonly T[]) => S[];
+  export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => K[];
+  ): (array: readonly T[]) => T[];
   export function indexed() {
     return purry(_filter(true), arguments, filter.lazyIndexed);
   }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -73,7 +73,6 @@ const _lazy = (indexed: boolean) => <T>(
 };
 
 export namespace filter {
-  // I don't understand why you need additional generic?
   export function indexed<T, S extends T>(
     array: readonly T[],
     fn: (input: T, index: number, array: T[]) => input is S


### PR DESCRIPTION
Currently, the filter function and other functions like reject do not support type guards.
I added some simple overloads to support this feature.

```typescript
// Guard format that I use
function isNumber<T>(data: T): data is Extract<T, number> {
  return typeof data === 'number'
}
```

Before
```typescript
const result = filter([1, 2, 3, 'abc', true] as const, isNumber); value is [1,2,3] incorect type 1 | 2 | 3 | 'abc' | true
`

After
```typescript
const result = filter([1, 2, 3, 'abc', true] as const, isNumber); value is [1,2,3] type 1 | 2 | 3
```

This pull request will add this feature only for filter and filter.indexed functions.

In next pull request, I will add this support for reject and other functions that can accept type guards

P.S Please test not only functionality but also types.
NOTE: broken type is equal to broken function :) 
It's really simple to write tests for typescript. Just create function assertType

```typescript
function assertType<T>(data: T) { return data } // Simple test function

// And test your type output like asserType<YOUR FINAL TYPE>(resultTrasformation) 
```
You can see it in my pull request.
