### PR TITLE
Added multi keys group support to groupBy function

### DIFF
--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -16,13 +16,66 @@ const expected = {
   2: [{ a: 2, b: 1 }],
 };
 
+const employees = [
+  {
+    name: 'John',
+    skills: ["Printing", 'Painting', 'Writing']
+  },
+  {
+    name: 'Britney',
+    skills: ["Printing", 'Managing', 'Acting']
+  }
+]
+const expectedEmployees = {
+  "Printing": [
+    {
+      name: 'John',
+      skills: ["Printing", 'Painting', 'Writing']
+    },
+    {
+      name: 'Britney',
+      skills: ["Printing", 'Managing', 'Acting']
+    }
+  ],
+  "Painting": [
+    {
+      name: 'John',
+      skills: ["Printing", 'Painting', 'Writing'] 
+    }
+  ],
+  "Managing": [
+    {
+      name: 'Britney',
+      skills: ["Printing", 'Managing', 'Acting']
+    }
+  ],
+  "Acting": [
+    {
+      name: 'Britney',
+      skills: ["Printing", 'Managing', 'Acting']
+    }
+  ],
+  "Writing": [
+    {
+      name: 'John',
+      skills: ["Printing", 'Painting', 'Writing']
+    },
+  ]
+}
+
 describe('data first', () => {
   test('groupBy', () => {
     expect(groupBy(array, x => x.a)).toEqual(expected);
   });
+  test('groupBy multi keys', () => {
+    expect(groupBy(employees, (x) => x.skills)).toEqual(expectedEmployees)
+  })
   test('groupBy.indexed', () => {
     expect(groupBy.indexed(array, x => x.a)).toEqual(expected);
   });
+  test('groupBy.indexed multi keys', () => {
+    expect(groupBy.indexed(employees, x => x.skills)).toEqual(expectedEmployees);
+  })
 });
 
 describe('data last', () => {
@@ -34,6 +87,14 @@ describe('data last', () => {
       )
     ).toEqual(expected);
   });
+  test('groupBy multi keys', () => {
+    expect(
+      pipe(
+        employees,
+        groupBy(x => x.skills)
+      )
+    ).toEqual(expectedEmployees);
+  });
   test('groupBy.indexed', () => {
     expect(
       pipe(
@@ -41,5 +102,14 @@ describe('data last', () => {
         groupBy.indexed(x => x.a)
       )
     ).toEqual(expected);
+  });
+
+  test('groupBy.indexed multi keys', () => {
+    expect(
+      pipe(
+        employees,
+        groupBy.indexed(x => x.skills)
+      )
+    ).toEqual(expectedEmployees);
   });
 });


### PR DESCRIPTION
Currently, the groupBy function lacks some additional functionality. Actually this feature is not supported by ramada and loadash but it is very useful.

There is a lot of use cases where you want to group data with an arbitrary list of values. 

Let's take an example. 
Objective 1: Extract active chatRoomsIds from the user list.
Objective 2: Users can join multiple rooms. And we want to know other users that joined the same room

```typescript
interface User { 
  name: string,
  joinedChatRooms: string[]
}

const users: User[] = [...]
R.groupBy(users, (user) => user.joinedChatRooms)
```

The provided example is solving a common problem where you need to extract statistics from the list of data. In most cases to solve this problem, you have to implement custom groupBy function
An additional example where such a feature is useful

Find out how much particular attribute have products
```typescript
interface Product {
  id: string,
  attr: Record<string, string>
}
const products: Product[] = [...]

R.pipe(
     products,
     R.groupBy((product) => Object.keys(product.attr)),
     R.toPairs(),
     R.map(([attr, productList])=> [attr, productList.lenght]),
     R.sortBy(([,count])=>count)
)
// An display it in sidebar
```
