### PR TITLE
Bugfix: Search docs by lower case function names

### DIFF
--- a/docs/src/Menu.tsx
+++ b/docs/src/Menu.tsx
@@ -33,7 +33,7 @@ export class Menu extends React.PureComponent<
         </div>
         <div className="fn-scroll">
           {items
-            .filter(item => item.name.indexOf(searchTermLowered) !== -1)
+            .filter(item => item.name.toLowerCase().indexOf(searchTermLowered) !== -1)
             .map(item => (
               <a href={'#' + item.name} key={item.name} className="menu-link">
                 <span>{item.name}</span>


### PR DESCRIPTION
I wondered why searching the docs for `map` doesn't show `flatMap` in the results. I believe this fixes the issue.

Fair warning, I haven't actually run the code, the change is so simple I assumed it was safe to submit a PR without in depth testing.

Thanks for remeda, it's awesome to have a typescript first utility library that's tree shaking friendly. ❤️ ❤️ ❤️ 