### PR TITLE
Improve performance of difference by creating the "other" set once for each lazy

### DIFF
--- a/src/difference.ts
+++ b/src/difference.ts
@@ -46,8 +46,8 @@ function _difference<T>(array: T[], other: T[]) {
 
 export namespace difference {
   export function lazy<T>(other: T[]) {
+    const set = new Set(other);
     return (value: T): LazyResult<T> => {
-      const set = new Set(other);
       if (!set.has(value)) {
         return {
           done: false,


### PR DESCRIPTION
Currently the difference function creates a new set with the entire other list for every item in the primary list. This is quite slow when you have large lists, something I noticed while debugging perf on a node backend we use remeda on. 

I've got a sample runkit that shows the problem in a bit of a basic way: https://runkit.com/ritwik/remeda-difference-perf

This can be improved by creating the set once per call to difference.lazy, rather than on each call of the returned function. It should have the same effect since other shouldn't be modified between those calls (unless I'm misunderstanding something).

Let me know if I should be doing anything else for this PR - I've run the tests locally and they pass, and I assume CI will catch anything else? Or if you prefer, I can create a separate issue first but this seemed small enough to just open a PR.

And as a side note, thanks for this library, it's great! :) 