### PR TITLE
add mapValues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './intersection';
 export * from './last';
 export * from './map';
 export * from './mapKeys';
+export * from './mapValues';
 export * from './merge';
 export * from './mergeAll';
 export * from './noop';

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -1,0 +1,36 @@
+import { mapValues } from './mapValues';
+import { pipe } from './pipe';
+
+describe('data first', () => {
+  test('mapValues', () => {
+    expect(
+      mapValues(
+        {
+          a: 1,
+          b: 2,
+        },
+        (value, key) => value + key
+      )
+    ).toEqual({
+      a: '1a',
+      b: '2b',
+    });
+  });
+});
+
+describe('data last', () => {
+  test('mapValues', () => {
+    expect(
+      pipe(
+        {
+          a: 1,
+          b: 2,
+        },
+        mapValues((value, key) => value + key)
+      )
+    ).toEqual({
+      a: '1a',
+      b: '2b',
+    });
+  });
+});

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -1,0 +1,43 @@
+/**
+ * Maps values of `object` and keeps the same keys.
+ * @param object the object to map
+ * @param fn the mapping function
+ * @signature
+ *    R.mapValues(object, fn)
+ * @example
+ *    R.mapValues({a: 1, b: 2}, (value, key) => value + key) // => { a: 1a, b: 2b }
+ * @data_first
+ * @category Object
+ */
+export function mapValues<T extends object, S>(
+  object: T,
+  fn: (value: T[keyof T], key: keyof T) => S
+): Record<keyof T, S>;
+
+/**
+ * Maps values of `object` and keeps the same keys.
+ * @param fn the mapping function
+ * @signature
+ *    R.mapKeys(fn)(object)
+ * @example
+ *    R.pipe({a: 1, b: 2}, R.mapValues((value, key) => value + key)) // => { a: 1a, b: 2b }
+ * @data_last
+ * @category Object
+ */
+export function mapValues<T extends object, S>(
+  fn: (key: keyof T, value: T[keyof T]) => S
+): (object: T) => Record<keyof T, S>;
+
+export function mapValues(arg1: any, arg2?: any): any {
+  if (arguments.length === 1) {
+    return (data: any) => _mapValues(data, arg1);
+  }
+  return _mapValues(arg1, arg2);
+}
+
+function _mapValues(obj: any, fn: (key: string, value: any) => any) {
+  return Object.keys(obj).reduce((acc, key) => {
+    acc[key] = fn(obj[key], key);
+    return acc;
+  }, {} as any);
+}

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -5,7 +5,7 @@
  * @signature
  *    R.mapValues(object, fn)
  * @example
- *    R.mapValues({a: 1, b: 2}, (value, key) => value + key) // => { a: 1a, b: 2b }
+ *    R.mapValues({a: 1, b: 2}, (value, key) => value + key) // => {a: '1a', b: '2b'}
  * @data_first
  * @category Object
  */
@@ -20,7 +20,7 @@ export function mapValues<T extends object, S>(
  * @signature
  *    R.mapKeys(fn)(object)
  * @example
- *    R.pipe({a: 1, b: 2}, R.mapValues((value, key) => value + key)) // => { a: 1a, b: 2b }
+ *    R.pipe({a: 1, b: 2}, R.mapValues((value, key) => value + key)) // => {a: '1a', b: '2b'}
  * @data_last
  * @category Object
  */


### PR DESCRIPTION
closes #77 

similar to the mapKeys function, but the keys stay the same and the value of the object is mapped instead

I opted for inverting the parameters compared to `mapKeys`, because most of the time, you won't need the `key`, but only the `value`, so having it as a first parameter seems better. This is also how [mapValues from lodash](https://lodash.com/docs/4.17.15#mapValues) works.