### PR TITLE
Feature/reverse for tuples

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ts-jest": "^22.4.5",
     "ts-node": "^8.4.1",
     "typedoc": "^0.11.1",
-    "typescript": "^3.8.3"
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "test": "jest --coverage && yarn run compile",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/jest": "^22.2.3",
     "jest": "^22.4.3",
     "marked": "^0.4.0",
-    "prettier": "^2.0.1",
+    "prettier": "^2.1.2",
     "ts-jest": "^22.4.5",
     "ts-node": "^8.4.1",
     "typedoc": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
-    "test": "jest --coverage",
+    "test": "jest --coverage && yarn run compile",
+    "compile": "tsc -p ./tsconfig.json --noEmit",
     "prettier": "prettier 'src/**/*.ts' --write",
     "docs:install": "cd docs && yarn",
     "docs:fix": "rm -rf node_modules/typedoc/node_modules/typescript",

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -11,3 +11,9 @@ export type Key = string | number | symbol;
 
 /** Mapped type to remove optional, null, and undefined from all props */
 export type NonNull<T> = { [K in keyof T]-?: Exclude<T[K], null | undefined> };
+
+export type AssertEqual<Type, Expected> = Type extends Expected
+  ? Expected extends Type
+    ? true
+    : never
+  : never;

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -55,7 +55,7 @@ function _clone(value: any, refFrom: any[], refTo: any[], deep: boolean) {
  * @example R.clone({foo: 'bar'}) // {foo: 'bar'}
  */
 export function clone<T extends any>(value: T): T {
-  return value != null && typeof value.clone === 'function'
-    ? value.clone()
+  return value != null && typeof (value as any).clone === 'function'
+    ? (value as any).clone()
     : _clone(value, [], [], true);
 }

--- a/src/dropLast.ts
+++ b/src/dropLast.ts
@@ -33,7 +33,7 @@ export function dropLast() {
 function _dropLast<T>(array: T[], n: number) {
   const copy = [...array];
   if (n !== 0) {
-    copy.splice(-n)
+    copy.splice(-n);
   }
   return copy;
 }

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -3,24 +3,23 @@ import { filter } from './filter';
 import { createCounter } from './_counter';
 
 function assertType<T>(data: T): T {
-  return data
+  return data;
 }
 
 function isNumber<T>(data: T): data is Extract<T, number> {
-  return typeof data === 'number'
+  return typeof data === 'number';
 } // TODO Refactor to remeda function
 
 describe('data_first', () => {
-
   it('filter', () => {
     const result = filter([1, 2, 3] as const, x => x % 2 === 1);
-    assertType<(1 | 2 | 3)[]>(result) // Type test
+    assertType<(1 | 2 | 3)[]>(result); // Type test
     expect(result).toEqual([1, 3]);
   });
 
   it('data_first with typescript guard', () => {
     const result = filter([1, 2, 3, 'abc', true] as const, isNumber);
-    assertType<(1 | 2 | 3)[]>(result) // Type test
+    assertType<(1 | 2 | 3)[]>(result); // Type test
     expect(result).toEqual([1, 2, 3]);
   });
 
@@ -29,16 +28,16 @@ describe('data_first', () => {
       [1, 2, 3] as const,
       (x, i) => x % 2 === 1 && i !== 1
     );
-    assertType<(1 | 2 | 3)[]>(result) // Type test
+    assertType<(1 | 2 | 3)[]>(result); // Type test
     expect(result).toEqual([1, 3]);
   });
 
   it('filter.indexed with typescript guard', () => {
     const result = filter.indexed(
-      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[] 
+      [1, 2, 3, false, 'text'] as const, // Type (1 | 2 | 3 | false | "text")[]
       isNumber
     );
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 2, 3]);
   });
 });
@@ -52,7 +51,7 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 3]);
   });
 
@@ -64,29 +63,29 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 3]);
   });
 
   it('filter with typescript guard', () => {
     const counter = createCounter();
     const result = pipe(
-      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[] 
+      [1, 2, 3, false, 'text'] as const, // Type (1 | 2 | 3 | false | "text")[]
       filter(isNumber),
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(3);
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 2, 3]);
   });
   it('filter.indexed with typescript guard', () => {
     const counter = createCounter();
     const result = pipe(
-      [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[]
+      [1, 2, 3, false, 'text'] as const, // Type (1 | 2 | 3 | false | "text")[]
       filter.indexed(isNumber),
       counter.fn()
     );
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([1, 2, 3]);
   });
@@ -97,7 +96,7 @@ describe('data_last', () => {
       filter.indexed((x, i) => x % 2 === 1 && i !== 1),
       counter.fn()
     );
-    assertType<(1 | 2 | 3)[]>(result) // Type test (1 | 2 | 3)[]
+    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -18,7 +18,10 @@ import { _toLazyIndexed } from './_toLazyIndexed';
  * @pipeable
  * @category Array
  */
-export function filter<T, S extends T>(array: readonly T[], fn: (value: T) => value is S): S[];
+export function filter<T, S extends T>(
+  array: readonly T[],
+  fn: (value: T) => value is S
+): S[];
 export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
 
 /**
@@ -35,7 +38,9 @@ export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
  * @pipeable
  * @category Array
  */
-export function filter<T, S extends T>(fn: (input: T) => input is S): (array: readonly T[]) => S[];
+export function filter<T, S extends T>(
+  fn: (input: T) => input is S
+): (array: readonly T[]) => S[];
 export function filter<T>(fn: Pred<T, boolean>): (array: readonly T[]) => T[];
 
 export function filter() {

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -14,8 +14,18 @@ describe('data first', () => {
       expect(result).toEqual(true);
     });
     test('tuples', () => {
-      const actual = reverse([1, 2, 3] as const);
-      const result: AssertEqual<typeof actual, [3, 2, 1]> = true;
+      const actual = reverse([1, 2, [true], 'a'] as const);
+      const result: AssertEqual<
+        typeof actual,
+        ['a', readonly [true], 2, 1]
+      > = true;
+      expect(result).toEqual(true);
+    });
+
+    test('variadic tuples', () => {
+      const input: [number, ...Array<string>] = [1, 'two', 'three'];
+      const actual = reverse(input);
+      const result: AssertEqual<typeof actual, (string | number)[]> = true;
       expect(result).toEqual(true);
     });
   });
@@ -33,8 +43,18 @@ describe('data last', () => {
       expect(result).toEqual(true);
     });
     test('tuples', () => {
-      const actual = pipe([1, 2, 3] as const, reverse());
-      const result: AssertEqual<typeof actual, [3, 2, 1]> = true;
+      const actual = pipe([1, 2, [true], 'a'] as const, reverse());
+      const result: AssertEqual<
+        typeof actual,
+        ['a', readonly [true], 2, 1]
+      > = true;
+      expect(result).toEqual(true);
+    });
+
+    test('variadic tuples', () => {
+      const input: [number, ...Array<string>] = [1, 'two', 'three'];
+      const actual = pipe(input, reverse());
+      const result: AssertEqual<typeof actual, (string | number)[]> = true;
       expect(result).toEqual(true);
     });
   });

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -1,3 +1,4 @@
+import { AssertEqual } from './_types';
 import { reverse } from './reverse';
 import { pipe } from './pipe';
 
@@ -6,11 +7,35 @@ describe('data first', () => {
     const actual = reverse([1, 2, 3]);
     expect(actual).toEqual([3, 2, 1]);
   });
+  describe('reverse typings', () => {
+    test('arrays', () => {
+      const actual = reverse([1, 2, 3]);
+      const result: AssertEqual<typeof actual, number[]> = true;
+      expect(result).toEqual(true);
+    });
+    test('tuples', () => {
+      const actual = reverse([1, 2, 3] as const);
+      const result: AssertEqual<typeof actual, [3, 2, 1]> = true;
+      expect(result).toEqual(true);
+    });
+  });
 });
 
 describe('data last', () => {
   test('reverse', () => {
     const actual = pipe([1, 2, 3], reverse());
     expect(actual).toEqual([3, 2, 1]);
+  });
+  describe('reverse typings', () => {
+    test('arrays', () => {
+      const actual = pipe([1, 2, 3], reverse());
+      const result: AssertEqual<typeof actual, number[]> = true;
+      expect(result).toEqual(true);
+    });
+    test('tuples', () => {
+      const actual = pipe([1, 2, 3] as const, reverse());
+      const result: AssertEqual<typeof actual, [3, 2, 1]> = true;
+      expect(result).toEqual(true);
+    });
   });
 });

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,11 +1,18 @@
 import { purry } from './purry';
 
 // prettier-ignore
-type ReverseTuple<T extends readonly unknown[], R extends readonly unknown[] = []> = ReturnType<
-  T extends readonly [infer F, ...infer L] ? () => ReverseTuple<L, [F, ...R]> : () => R
+type Reverse<
+  T extends readonly unknown[],
+  R extends readonly unknown[] = []
+> = ReturnType<
+  T extends IsNoTuple<T>
+    ? () => [...T, ...R]
+    : T extends readonly [infer F, ...infer L]
+    ? () => Reverse<L, [F, ...R]>
+    : () => R
 >;
 
-type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
+type IsNoTuple<T> = T extends readonly [unknown, ...unknown[]] ? never : T;
 
 /**
  * Reverses array.
@@ -17,9 +24,7 @@ type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
  * @data_first
  * @category Array
  */
-export function reverse<T extends readonly unknown[]>(
-  array: T
-): T extends IsTuple<T> ? ReverseTuple<T> : T;
+export function reverse<T extends readonly unknown[]>(array: T): Reverse<T>;
 
 /**
  * Reverses array.
@@ -33,7 +38,7 @@ export function reverse<T extends readonly unknown[]>(
  */
 export function reverse<T extends readonly unknown[]>(): (
   array: T
-) => T extends IsTuple<T> ? ReverseTuple<T> : T;
+) => Reverse<T>;
 
 export function reverse() {
   return purry(_reverse, arguments);

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,24 +1,9 @@
 import { purry } from './purry';
 
-type Prepend<Tuple extends readonly unknown[], Added> = ((
-  _: Added,
-  ..._1: Tuple
-) => unknown) extends (..._: infer Result) => unknown
-  ? Result
-  : never;
-
-type Reverse<
-  Tuple extends readonly unknown[],
-  Prefix extends readonly unknown[] = []
-> = {
-  0: Prefix;
-  1: ((..._: Tuple) => unknown) extends (
-    _: infer First,
-    ..._1: infer Next
-  ) => unknown
-    ? Reverse<Next, Prepend<Prefix, First>>
-    : never;
-}[Tuple extends readonly [unknown, ...unknown[]] ? 1 : 0];
+// prettier-ignore
+type ReverseTuple<T extends readonly unknown[], R extends readonly unknown[] = []> = ReturnType<
+  T extends readonly [infer F, ...infer L] ? () => ReverseTuple<L, [F, ...R]> : () => R
+>;
 
 type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
 
@@ -34,7 +19,7 @@ type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
  */
 export function reverse<T extends readonly unknown[]>(
   array: T
-): T extends IsTuple<T> ? Reverse<T> : T;
+): T extends IsTuple<T> ? ReverseTuple<T> : T;
 
 /**
  * Reverses array.
@@ -48,7 +33,7 @@ export function reverse<T extends readonly unknown[]>(
  */
 export function reverse<T extends readonly unknown[]>(): (
   array: T
-) => T extends IsTuple<T> ? Reverse<T> : T;
+) => T extends IsTuple<T> ? ReverseTuple<T> : T;
 
 export function reverse() {
   return purry(_reverse, arguments);

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,13 +1,13 @@
 import { purry } from './purry';
 
-export type Prepend<Tuple extends readonly any[], Added> = ((
+type Prepend<Tuple extends readonly any[], Added> = ((
   _: Added,
   ..._1: Tuple
 ) => any) extends (..._: infer Result) => any
   ? Result
   : never;
 
-export type Reverse<
+type Reverse<
   Tuple extends readonly any[],
   Prefix extends readonly any[] = []
 > = {

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,7 +1,7 @@
 import { purry } from './purry';
 
-export type Prepend<Tuple extends readonly any[], Addend> = ((
-  _: Addend,
+export type Prepend<Tuple extends readonly any[], Added> = ((
+  _: Added,
   ..._1: Tuple
 ) => any) extends (..._: infer Result) => any
   ? Result

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,23 +1,26 @@
 import { purry } from './purry';
 
-type Prepend<Tuple extends readonly any[], Added> = ((
+type Prepend<Tuple extends readonly unknown[], Added> = ((
   _: Added,
   ..._1: Tuple
-) => any) extends (..._: infer Result) => any
+) => unknown) extends (..._: infer Result) => unknown
   ? Result
   : never;
 
 type Reverse<
-  Tuple extends readonly any[],
-  Prefix extends readonly any[] = []
+  Tuple extends readonly unknown[],
+  Prefix extends readonly unknown[] = []
 > = {
   0: Prefix;
-  1: ((..._: Tuple) => any) extends (_: infer First, ..._1: infer Next) => any
+  1: ((..._: Tuple) => unknown) extends (
+    _: infer First,
+    ..._1: infer Next
+  ) => unknown
     ? Reverse<Next, Prepend<Prefix, First>>
     : never;
-}[Tuple extends readonly [any, ...any[]] ? 1 : 0];
+}[Tuple extends readonly [unknown, ...unknown[]] ? 1 : 0];
 
-type IsTuple<T> = T extends readonly [any, ...any[]] ? T : never;
+type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
 
 /**
  * Reverses array.
@@ -29,7 +32,7 @@ type IsTuple<T> = T extends readonly [any, ...any[]] ? T : never;
  * @data_first
  * @category Array
  */
-export function reverse<T extends readonly any[]>(
+export function reverse<T extends readonly unknown[]>(
   array: T
 ): T extends IsTuple<T> ? Reverse<T> : T;
 
@@ -43,7 +46,7 @@ export function reverse<T extends readonly any[]>(
  * @data_last
  * @category Array
  */
-export function reverse<T extends readonly any[]>(): (
+export function reverse<T extends readonly unknown[]>(): (
   array: T
 ) => T extends IsTuple<T> ? Reverse<T> : T;
 

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,6 +1,5 @@
 import { purry } from './purry';
 
-// prettier-ignore
 type Reverse<
   T extends readonly unknown[],
   R extends readonly unknown[] = []

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,5 +1,24 @@
 import { purry } from './purry';
 
+export type Prepend<Tuple extends readonly any[], Addend> = ((
+  _: Addend,
+  ..._1: Tuple
+) => any) extends (..._: infer Result) => any
+  ? Result
+  : never;
+
+export type Reverse<
+  Tuple extends readonly any[],
+  Prefix extends readonly any[] = []
+> = {
+  0: Prefix;
+  1: ((..._: Tuple) => any) extends (_: infer First, ..._1: infer Next) => any
+    ? Reverse<Next, Prepend<Prefix, First>>
+    : never;
+}[Tuple extends readonly [any, ...any[]] ? 1 : 0];
+
+type IsTuple<T> = T extends readonly [any, ...any[]] ? T : never;
+
 /**
  * Reverses array.
  * @param array the array
@@ -10,7 +29,9 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function reverse<T>(array: readonly T[]): Array<T>;
+export function reverse<T extends readonly any[]>(
+  array: T
+): T extends IsTuple<T> ? Reverse<T> : T;
 
 /**
  * Reverses array.
@@ -22,7 +43,9 @@ export function reverse<T>(array: readonly T[]): Array<T>;
  * @data_last
  * @category Array
  */
-export function reverse<T>(): (array: readonly T[]) => Array<T>;
+export function reverse<T extends readonly any[]>(): (
+  array: T
+) => T extends IsTuple<T> ? Reverse<T> : T;
 
 export function reverse() {
   return purry(_reverse, arguments);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,10 +2522,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
-  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 pretty-format@^22.4.3:
   version "22.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,10 +3214,10 @@ typescript@2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uglify-js@^3.1.4:
   version "3.10.3"


### PR DESCRIPTION
currently, calling `reverse` an on a tuple, e.g. `[string, number, boolean]` will return `[string | number | boolean][]` - which means any position can have any of those three types. But actually, because we have a fixed length, we can know which item will have which type.

so with this PR, `[string, number, boolean]` will be reversed to `[boolean, number, string]`, which I think is nice. The usages for arrays remain intact, so a `number[]` will still be reversed to `number[]`.

I also added compile time tests, which will make sure that the functions return the correct type depending on the input. The `AssertEqual` util will yield a compile time error, so I enforced that check with a `compile` script that is called during the test phase. Note that the actual `expect` is only there to make sure that we have a usage of `const result` 🤷 .