### PR TITLE
Add `zip` utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,4 @@ export * from './toPairs';
 export * from './type';
 export * from './uniq';
 export * from './uniqBy';
+export * from './zip';

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,0 +1,30 @@
+import { zip } from './zip';
+
+const first = [1, 2, 3];
+const last = ['a', 'b', 'c'];
+const shorterFirst = [1, 2];
+const shorterLast = ['a', 'b']
+
+describe('data first', () => {
+  test('should zip', () => {
+    expect(zip(first, last)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
+  })
+  test('should truncate to shorter last', () => {
+    expect(zip(first, shorterLast)).toEqual([[1, 'a'], [2, 'b']]);
+  })
+  test('should truncate to shorter first', () => {
+    expect(zip(shorterFirst, last)).toEqual([[1, 'a'], [2, 'b']])
+  })
+})
+
+describe('data last', () => {
+  test('should zip', () => {
+    expect(zip(last)(first)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
+  })
+  test('should truncate to shorter last', () => {
+    expect(zip(shorterLast)(first)).toEqual([[1, 'a'], [2, 'b']]);
+  })
+  test('should truncate to shorter first', () => {
+    expect(zip(last)(shorterFirst)).toEqual([[1, 'a'], [2, 'b']])
+  })
+})

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,30 +1,103 @@
 import { zip } from './zip';
+import { AssertEqual } from './_types';
 
 const first = [1, 2, 3];
 const second = ['a', 'b', 'c'];
 const shorterFirst = [1, 2];
-const shorterSecond = ['a', 'b']
+const shorterSecond = ['a', 'b'];
 
 describe('data first', () => {
   test('should zip', () => {
-    expect(zip(first, second)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
-  })
+    expect(zip(first, second)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ]);
+  });
   test('should truncate to shorter second', () => {
-    expect(zip(first, shorterSecond)).toEqual([[1, 'a'], [2, 'b']]);
-  })
+    expect(zip(first, shorterSecond)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+  });
   test('should truncate to shorter first', () => {
-    expect(zip(shorterFirst, second)).toEqual([[1, 'a'], [2, 'b']])
-  })
-})
+    expect(zip(shorterFirst, second)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+  });
+});
+
+describe('data first typings', () => {
+  test('arrays', () => {
+    const actual = zip(first, second);
+    const result: AssertEqual<typeof actual, [number, string][]> = true;
+    expect(result).toBe(true);
+  });
+  test('tuples', () => {
+    const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
+    const result: AssertEqual<
+      typeof actual,
+      [1 | 2 | 3, 'a' | 'b' | 'c'][]
+    > = true;
+    expect(result).toBe(true);
+  });
+  test('variadic tuples', () => {
+    const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
+    const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
+    const actual = zip(firstVariadic, secondVariadic);
+    const result: AssertEqual<
+      typeof actual,
+      [string | number, string | number][]
+    > = true;
+    expect(result).toBe(true);
+  });
+});
 
 describe('data second', () => {
   test('should zip', () => {
-    expect(zip(second)(first)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
-  })
+    expect(zip(second)(first)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ]);
+  });
   test('should truncate to shorter second', () => {
-    expect(zip(shorterSecond)(first)).toEqual([[1, 'a'], [2, 'b']]);
-  })
+    expect(zip(shorterSecond)(first)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+  });
   test('should truncate to shorter first', () => {
-    expect(zip(second)(shorterFirst)).toEqual([[1, 'a'], [2, 'b']])
-  })
-})
+    expect(zip(second)(shorterFirst)).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+    ]);
+  });
+});
+
+describe('data first typings', () => {
+  test('arrays', () => {
+    const actual = zip(second)(first);
+    const result: AssertEqual<typeof actual, [number, string][]> = true;
+    expect(result).toBe(true);
+  });
+  test('tuples', () => {
+    const actual = zip(second as ['a', 'b', 'c'])(first as [1, 2, 3]);
+    const result: AssertEqual<
+      typeof actual,
+      [1 | 2 | 3, 'a' | 'b' | 'c'][]
+    > = true;
+    expect(result).toBe(true);
+  });
+  test('variadic tuples', () => {
+    const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
+    const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
+    const actual = zip(secondVariadic)(firstVariadic);
+    const result: AssertEqual<
+      typeof actual,
+      [string | number, string | number][]
+    > = true;
+    expect(result).toBe(true);
+  });
+});

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -76,7 +76,7 @@ describe('data second', () => {
   });
 });
 
-describe('data first typings', () => {
+describe('data second typings', () => {
   test('arrays', () => {
     const actual = zip(second)(first);
     const result: AssertEqual<typeof actual, [number, string][]> = true;

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,30 +1,30 @@
 import { zip } from './zip';
 
 const first = [1, 2, 3];
-const last = ['a', 'b', 'c'];
+const second = ['a', 'b', 'c'];
 const shorterFirst = [1, 2];
-const shorterLast = ['a', 'b']
+const shorterSecond = ['a', 'b']
 
 describe('data first', () => {
   test('should zip', () => {
-    expect(zip(first, last)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
+    expect(zip(first, second)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
   })
-  test('should truncate to shorter last', () => {
-    expect(zip(first, shorterLast)).toEqual([[1, 'a'], [2, 'b']]);
+  test('should truncate to shorter second', () => {
+    expect(zip(first, shorterSecond)).toEqual([[1, 'a'], [2, 'b']]);
   })
   test('should truncate to shorter first', () => {
-    expect(zip(shorterFirst, last)).toEqual([[1, 'a'], [2, 'b']])
+    expect(zip(shorterFirst, second)).toEqual([[1, 'a'], [2, 'b']])
   })
 })
 
-describe('data last', () => {
+describe('data second', () => {
   test('should zip', () => {
-    expect(zip(last)(first)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
+    expect(zip(second)(first)).toEqual([[1, 'a'], [2, 'b'], [3, 'c']]);
   })
-  test('should truncate to shorter last', () => {
-    expect(zip(shorterLast)(first)).toEqual([[1, 'a'], [2, 'b']]);
+  test('should truncate to shorter second', () => {
+    expect(zip(shorterSecond)(first)).toEqual([[1, 'a'], [2, 'b']]);
   })
   test('should truncate to shorter first', () => {
-    expect(zip(last)(shorterFirst)).toEqual([[1, 'a'], [2, 'b']])
+    expect(zip(second)(shorterFirst)).toEqual([[1, 'a'], [2, 'b']])
   })
 })

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -12,7 +12,7 @@ import { purry } from './purry'
  * @data_first
  * @category Array
  */
-export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F, second: S): Array<[F, S]>
+export function zip<F extends unknown, S extends unknown>(first: Array<F>, second: Array<S>): Array<[F, S]>
 
 /**
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
@@ -25,7 +25,7 @@ export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F
  * @data_last
  * @category Array
  */
-export function zip<F extends Array<unknown>, S extends Array<unknown>>(second: S): (first: F) => Array<[F, S]>
+export function zip<F extends unknown, S extends unknown>(second: Array<S>): (first: Array<F>) => Array<[F, S]>
 
 export function zip() {
   return purry(_zip, arguments)

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -8,7 +8,7 @@ import { purry } from './purry'
  * @signature
  *   R.zip(first, second)
  * @example
- *   R.zip([1, 2], ['c', 'd']) // => [[1, 'c'], [2, 'd']
+ *   R.zip([1, 2], ['a', 'b']) // => [1, 'a'], [2, 'b']
  * @data_first
  * @category Array
  */
@@ -21,11 +21,11 @@ export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F
  * @signature
  *   R.zip(second)(first)
  * @example
- *   R.zip(['c', 'd'])([1, 2]) // => [[1, 'c'], [2, 'd']
+ *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']
  * @data_last
  * @category Array
  */
-export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F): (second: S) => Array<[F, S]>
+export function zip<F extends Array<unknown>, S extends Array<unknown>>(second: S): (first: F) => Array<[F, S]>
 
 export function zip() {
   return purry(_zip, arguments)

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,4 +1,4 @@
-import { purry } from './purry'
+import { purry } from './purry';
 
 /**
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
@@ -12,7 +12,10 @@ import { purry } from './purry'
  * @data_first
  * @category Array
  */
-export function zip<F extends unknown, S extends unknown>(first: Array<F>, second: Array<S>): Array<[F, S]>
+export function zip<F extends unknown, S extends unknown>(
+  first: ReadonlyArray<F>,
+  second: ReadonlyArray<S>
+): Array<[F, S]>;
 
 /**
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
@@ -25,14 +28,17 @@ export function zip<F extends unknown, S extends unknown>(first: Array<F>, secon
  * @data_last
  * @category Array
  */
-export function zip<F extends unknown, S extends unknown>(second: Array<S>): (first: Array<F>) => Array<[F, S]>
+export function zip<S extends unknown>(
+  second: ReadonlyArray<S>
+): <F extends unknown>(first: ReadonlyArray<F>) => Array<[F, S]>;
 
 export function zip() {
-  return purry(_zip, arguments)
+  return purry(_zip, arguments);
 }
 
 function _zip(first: Array<unknown>, second: Array<unknown>) {
-  const resultLength = first.length > second.length ? second.length : first.length;
+  const resultLength =
+    first.length > second.length ? second.length : first.length;
   const result = [];
   for (let i = 0; i < resultLength; i++) {
     result.push([first[i], second[i]]);

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,0 +1,42 @@
+import { purry } from './purry'
+
+/**
+ * Creates a new list from two supplied lists by pairing up equally-positioned items.
+ * The length of the returned list will match the shortest of the two inputs.
+ * @param first the first input list
+ * @param second the second input list
+ * @signature
+ *   R.zip(first, second)
+ * @example
+ *   R.zip([1, 2], ['c', 'd']) // => [[1, 'c'], [2, 'd']
+ * @data_first
+ * @category Array
+ */
+export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F, second: S): Array<[F, S]>
+
+/**
+ * Creates a new list from two supplied lists by pairing up equally-positioned items.
+ * The length of the returned list will match the shortest of the two inputs.
+ * @param second the second input list
+ * @signature
+ *   R.zip(second)(first)
+ * @example
+ *   R.zip(['c', 'd'])([1, 2]) // => [[1, 'c'], [2, 'd']
+ * @data_last
+ * @category Array
+ */
+export function zip<F extends Array<unknown>, S extends Array<unknown>>(first: F): (second: S) => Array<[F, S]>
+
+export function zip() {
+  return purry(_zip, arguments)
+}
+
+function _zip(first: Array<unknown>, second: Array<unknown>) {
+  const resultLength = first.length > second.length ? second.length : first.length;
+  const result = [];
+  for (let i = 0; i < resultLength; i++) {
+    result.push([first[i], second[i]]);
+  }
+
+  return result;
+}


### PR DESCRIPTION
Per remeda/remeda#72, adds the `zip` utility:

*Data first*
```
R.zip([1, 2], ['c', 'd']) // => [[1, 'c'], [2, 'd']
```
*Data last*
```
R.zip(['c', 'd'])([1, 2]) // => [[1, 'c'], [2, 'd']
```