### PR TITLE
Add zipWith utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,4 @@ export * from './toPairs';
 export * from './type';
 export * from './uniq';
 export * from './uniqBy';
+export * from './zipWith';

--- a/src/zipWith.test.ts
+++ b/src/zipWith.test.ts
@@ -1,44 +1,69 @@
 import { zipWith } from './zipWith';
+import { AssertEqual } from './_types';
 
-const pred = (a: string, b: string) => a + b
+const pred = (a: string, b: string) => a + b;
 
 const first = ['1', '2', '3'];
 const second = ['a', 'b', 'c'];
 const shorterFirst = ['1', '2'];
-const shorterSecond = ['a', 'b']
+const shorterSecond = ['a', 'b'];
 
 describe('data first', () => {
   test('should zip with predicate', () => {
     expect(zipWith(first, second, pred)).toEqual(['1a', '2b', '3c']);
-  })
+  });
   test('should truncate to shorter second', () => {
     expect(zipWith(first, shorterSecond, pred)).toEqual(['1a', '2b']);
-  })
+  });
   test('should truncate to shorter first', () => {
-    expect(zipWith(shorterFirst, second, pred)).toEqual(['1a', '2b'])
-  })
-})
+    expect(zipWith(shorterFirst, second, pred)).toEqual(['1a', '2b']);
+  });
+});
+
+describe('data first typings', () => {
+  test('infers typing from predicate', () => {
+    const actual = zipWith(first, second, pred);
+    const result: AssertEqual<typeof actual, string[]> = true;
+    expect(result).toBe(true);
+  });
+});
 
 describe('data second', () => {
   test('should zip with predicate', () => {
     expect(zipWith(pred)(first, second)).toEqual(['1a', '2b', '3c']);
-  })
+  });
   test('should truncate to shorter second', () => {
     expect(zipWith(pred)(first, shorterSecond)).toEqual(['1a', '2b']);
-  })
+  });
   test('should truncate to shorter first', () => {
-    expect(zipWith(pred)(shorterFirst, second)).toEqual(['1a', '2b'])
-  })
-})
+    expect(zipWith(pred)(shorterFirst, second)).toEqual(['1a', '2b']);
+  });
+});
+
+describe('data second typings', () => {
+  test('infers typing from predicate', () => {
+    const actual = zipWith(pred)(first, second);
+    const result: AssertEqual<typeof actual, string[]> = true;
+    expect(result).toBe(true);
+  });
+});
 
 describe('data second with initial arg', () => {
   test('should zip with predicate', () => {
     expect(zipWith(pred, second)(first)).toEqual(['1a', '2b', '3c']);
-  })
+  });
   test('should truncate to shorter second', () => {
     expect(zipWith(pred, shorterSecond)(first)).toEqual(['1a', '2b']);
-  })
+  });
   test('should truncate to shorter first', () => {
-    expect(zipWith(pred, second)(shorterFirst)).toEqual(['1a', '2b'])
-  })
-})
+    expect(zipWith(pred, second)(shorterFirst)).toEqual(['1a', '2b']);
+  });
+});
+
+describe('data second with initial arg typings', () => {
+  test('infers typing from predicate', () => {
+    const actual = zipWith(pred, second)(first);
+    const result: AssertEqual<typeof actual, string[]> = true;
+    expect(result).toBe(true);
+  });
+});

--- a/src/zipWith.test.ts
+++ b/src/zipWith.test.ts
@@ -1,0 +1,44 @@
+import { zipWith } from './zipWith';
+
+const pred = (a: string, b: string) => a + b
+
+const first = ['1', '2', '3'];
+const second = ['a', 'b', 'c'];
+const shorterFirst = ['1', '2'];
+const shorterSecond = ['a', 'b']
+
+describe('data first', () => {
+  test('should zip with predicate', () => {
+    expect(zipWith(first, second, pred)).toEqual(['1a', '2b', '3c']);
+  })
+  test('should truncate to shorter second', () => {
+    expect(zipWith(first, shorterSecond, pred)).toEqual(['1a', '2b']);
+  })
+  test('should truncate to shorter first', () => {
+    expect(zipWith(shorterFirst, second, pred)).toEqual(['1a', '2b'])
+  })
+})
+
+describe('data second', () => {
+  test('should zip with predicate', () => {
+    expect(zipWith(pred)(first, second)).toEqual(['1a', '2b', '3c']);
+  })
+  test('should truncate to shorter second', () => {
+    expect(zipWith(pred)(first, shorterSecond)).toEqual(['1a', '2b']);
+  })
+  test('should truncate to shorter first', () => {
+    expect(zipWith(pred)(shorterFirst, second)).toEqual(['1a', '2b'])
+  })
+})
+
+describe('data second with initial arg', () => {
+  test('should zip with predicate', () => {
+    expect(zipWith(pred, second)(first)).toEqual(['1a', '2b', '3c']);
+  })
+  test('should truncate to shorter second', () => {
+    expect(zipWith(pred, shorterSecond)(first)).toEqual(['1a', '2b']);
+  })
+  test('should truncate to shorter first', () => {
+    expect(zipWith(pred, second)(shorterFirst)).toEqual(['1a', '2b'])
+  })
+})

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -1,0 +1,70 @@
+/**
+ * Creates a new list from two supplied lists by calling the supplied function
+ * with the same-positioned element from each list.
+ * @param first the first input list
+ * @param second the second input list
+ * @param fn the function applied to each position of the list
+ * @signature
+ *   R.zipWith(first, second, fn)
+ * @example
+ *   R.zipWith(['1', '2', '3'], ['a', 'b', 'c'], (a, b) => a + b) // => ['1a', '2b', '3c']
+ * @data_first
+ * @category Array
+ */
+export function zipWith<F, S, P, R>(first: Array<F>, second: Array<S>, fn: (f: F, s: S) => R ): Array<R>;
+
+/**
+ * Creates a new list from two supplied lists by calling the supplied function
+ * with the same-positioned element from each list.
+ * @param fn the function applied to each position of the list
+ * @signature
+ *   R.zipWith(fn)(first, second)
+ * @example
+ *   R.zipWith((a, b) => a + b)(['1', '2', '3'], ['a', 'b', 'c']) // => ['1a', '2b', '3c']
+ * @data_last
+ * @category Array
+ */
+export function zipWith<F, S, P, R>(fn: (f: F, s: S) => R): (first: Array<F>, second: Array<S>) => Array<R>;
+
+/**
+ * Creates a new list from two supplied lists by calling the supplied function
+ * with the same-positioned element from each list.
+ * @param fn the function applied to each position of the list
+ * @param second the second input list
+ * @signature
+ *   R.zipWith(fn)(first, second)
+ * @example
+ *   R.zipWith((a, b) => a + b, ['a', 'b', 'c'])(['1', '2', '3']) // => ['1a', '2b', '3c']
+ * @data_last
+ * @category Array
+ */
+export function zipWith<F, S, P, R>(fn: (f: F, s: S) => R, second: Array<S>): (first: Array<F>) => Array<R>;
+
+export function zipWith() {
+  const args = Array.from(arguments);
+  if (typeof args[0] === 'function' && args.length === 1) {
+    return function (f: any, s: any) {
+      return _zipWith(f, s, args[0]);
+    }
+  }
+
+  if (typeof args[0] === 'function' && args.length === 2) {
+    return function(f: any) {
+      return _zipWith(f, args[1], args[0])
+    }
+  }
+
+  if (args.length === 3) {
+    return _zipWith(args[0], args[1], args[2]);
+  }
+}
+
+function _zipWith<F, S, R>(first: Array<F>, second: Array<S>, fn: (f: F, s: S) => R) {
+  const resultLength = first.length > second.length ? second.length : first.length;
+  const result = [];
+  for (let i = 0; i < resultLength; i++) {
+    result.push(fn(first[i], second[i]));
+  }
+
+  return result;
+}

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -11,7 +11,11 @@
  * @data_first
  * @category Array
  */
-export function zipWith<F, S, P, R>(first: Array<F>, second: Array<S>, fn: (f: F, s: S) => R ): Array<R>;
+export function zipWith<F, S, R>(
+  first: Array<F>,
+  second: Array<S>,
+  fn: (f: F, s: S) => R
+): Array<R>;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -24,7 +28,9 @@ export function zipWith<F, S, P, R>(first: Array<F>, second: Array<S>, fn: (f: F
  * @data_last
  * @category Array
  */
-export function zipWith<F, S, P, R>(fn: (f: F, s: S) => R): (first: Array<F>, second: Array<S>) => Array<R>;
+export function zipWith<F, S, R>(
+  fn: (f: F, s: S) => R
+): (first: Array<F>, second: Array<S>) => Array<R>;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -38,20 +44,23 @@ export function zipWith<F, S, P, R>(fn: (f: F, s: S) => R): (first: Array<F>, se
  * @data_last
  * @category Array
  */
-export function zipWith<F, S, P, R>(fn: (f: F, s: S) => R, second: Array<S>): (first: Array<F>) => Array<R>;
+export function zipWith<F, S, R>(
+  fn: (f: F, s: S) => R,
+  second: Array<S>
+): (first: Array<F>) => Array<R>;
 
 export function zipWith() {
   const args = Array.from(arguments);
   if (typeof args[0] === 'function' && args.length === 1) {
     return function (f: any, s: any) {
       return _zipWith(f, s, args[0]);
-    }
+    };
   }
 
   if (typeof args[0] === 'function' && args.length === 2) {
-    return function(f: any) {
-      return _zipWith(f, args[1], args[0])
-    }
+    return function (f: any) {
+      return _zipWith(f, args[1], args[0]);
+    };
   }
 
   if (args.length === 3) {
@@ -59,8 +68,13 @@ export function zipWith() {
   }
 }
 
-function _zipWith<F, S, R>(first: Array<F>, second: Array<S>, fn: (f: F, s: S) => R) {
-  const resultLength = first.length > second.length ? second.length : first.length;
+function _zipWith<F, S, R>(
+  first: Array<F>,
+  second: Array<S>,
+  fn: (f: F, s: S) => R
+) {
+  const resultLength =
+    first.length > second.length ? second.length : first.length;
   const result = [];
   for (let i = 0; i < resultLength; i++) {
     result.push(fn(first[i], second[i]));


### PR DESCRIPTION
Per #72 adds `zipWith` utility

*Data first*
```
R.zipWith(['1', '2', '3'], ['a', 'b', 'c'], (a, b) => a + b) // => ['1a', '2b', '3c']
```

*Data last*
```
R.zipWith((a, b) => a + b)(['1', '2', '3'], ['a', 'b', 'c']) // => ['1a', '2b', '3c']
```

*Data last with initial arg*
```
R.zipWith((a, b) => a + b, ['a', 'b', 'c'])(['1', '2', '3']) // => ['1a', '2b', '3c']
```