### PR TITLE
Add fromPairs utility

### DIFF
--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,4 +1,5 @@
 import { fromPairs } from './fromPairs';
+import { AssertEqual } from './_types';
 
 const tuples: [string, number][] = [
   ['a', 1],
@@ -22,5 +23,24 @@ describe('fromPairs', () => {
       b: 2,
       c: 3,
     });
+  });
+});
+
+describe('typings', () => {
+  test('arrays', () => {
+    const actual = fromPairs(tuples);
+    const result: AssertEqual<typeof actual, Record<string, number>> = true;
+    expect(result).toBe(true);
+  });
+  test('arrays with mixed type value', () => {
+    const actual = fromPairs<string | number>([
+      ['a', 2],
+      ['b', 'c'],
+    ]);
+    const result: AssertEqual<
+      typeof actual,
+      Record<string, string | number>
+    > = true;
+    expect(result).toBe(true);
   });
 });

--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,0 +1,22 @@
+import { fromPairs } from './fromPairs';
+
+const tuples: [string, number][] = [['a', 1], ['b', 2], ['c', 3]]
+
+describe('fromPairs', () => {
+  test('generates object from pairs', () => {
+    expect(fromPairs(tuples)).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    })
+  })
+
+  test('ignores non-tuples', () => {
+    const badInput = [...tuples, undefined, [], [2]];
+    expect(fromPairs(badInput as any)).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    })
+  })
+})

--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,6 +1,10 @@
 import { fromPairs } from './fromPairs';
 
-const tuples: [string, number][] = [['a', 1], ['b', 2], ['c', 3]]
+const tuples: [string, number][] = [
+  ['a', 1],
+  ['b', 2],
+  ['c', 3],
+];
 
 describe('fromPairs', () => {
   test('generates object from pairs', () => {
@@ -8,8 +12,8 @@ describe('fromPairs', () => {
       a: 1,
       b: 2,
       c: 3,
-    })
-  })
+    });
+  });
 
   test('ignores non-tuples', () => {
     const badInput = [...tuples, undefined, [], [2]];
@@ -17,6 +21,6 @@ describe('fromPairs', () => {
       a: 1,
       b: 2,
       c: 3,
-    })
-  })
-})
+    });
+  });
+});

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -1,6 +1,7 @@
 /**
  * Creates a new object from an array of tuples by pairing up first and second elements as {[key]: value}.
  * If a tuple is not supplied for any element in the array, the element will be ignored
+ * If duplicate keys exist, the tuple with the greatest index in the input array will be preferred.
  * @param tuples the list of input tuples
  * @signature
  *   R.fromPairs(tuples)

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -1,0 +1,19 @@
+/**
+ * Creates a new object from an array of tuples by pairing up first and second elements as {[key]: value}.
+ * If a tuple is not supplied for any element in the array, the element will be ignored
+ * @param tuples the list of input tuples
+ * @signature
+ *   R.fromPairs(tuples)
+ * @example
+ *   R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'}
+ * @category Object
+ */
+export function fromPairs<K extends string | number | symbol, V>(tuples: Array<[K, V]>): Record<K, V>
+
+
+export function fromPairs(tuples: Array<[string | number | symbol, unknown]>) {
+  return tuples.reduce((acc, curr) => curr && curr.length === 2 ? ({
+      ...acc,
+      [curr[0]]: curr[1]
+  }) : acc, {})
+}

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -9,12 +9,14 @@
  *   R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'}
  * @category Object
  */
-export function fromPairs<K extends string | number | symbol, V>(tuples: Array<[K, V]>): Record<K, V>
+export function fromPairs<K extends string | number, V>(tuples: Array<[K, V]>): Record<K, V>
 
 
-export function fromPairs(tuples: Array<[string | number | symbol, unknown]>) {
-  return tuples.reduce((acc, curr) => curr && curr.length === 2 ? ({
-      ...acc,
-      [curr[0]]: curr[1]
-  }) : acc, {})
+export function fromPairs(tuples: Array<[string | number, unknown]>) {
+  return tuples.reduce<Record<string | number, unknown>>((acc, curr) => {
+    if (curr && curr.length === 2) {
+      acc[curr[0]] = curr[1];
+    }
+    return acc;
+  }, {})
 }

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -9,11 +9,10 @@
  *   R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'}
  * @category Object
  */
-export function fromPairs<K extends string | number, V>(
-  tuples: Array<[K, V]>
-): Record<K, V>;
+export function fromPairs<V>(tuples: ReadonlyArray<[number, V]>): Record<number, V>;
+export function fromPairs<V>(tuples: ReadonlyArray<[string, V]>): Record<string, V>;
 
-export function fromPairs(tuples: Array<[string | number, unknown]>) {
+export function fromPairs(tuples: ReadonlyArray<[string | number, unknown]>) {
   return tuples.reduce<Record<string | number, unknown>>((acc, curr) => {
     if (curr && curr.length === 2) {
       acc[curr[0]] = curr[1];

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -9,8 +9,9 @@
  *   R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'}
  * @category Object
  */
-export function fromPairs<K extends string | number, V>(tuples: Array<[K, V]>): Record<K, V>
-
+export function fromPairs<K extends string | number, V>(
+  tuples: Array<[K, V]>
+): Record<K, V>;
 
 export function fromPairs(tuples: Array<[string | number, unknown]>) {
   return tuples.reduce<Record<string | number, unknown>>((acc, curr) => {
@@ -18,5 +19,5 @@ export function fromPairs(tuples: Array<[string | number, unknown]>) {
       acc[curr[0]] = curr[1];
     }
     return acc;
-  }, {})
+  }, {});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export * from './flatten';
 export * from './flattenDeep';
 export * from './forEach';
 export * from './forEachObj';
+export * from './fromPairs';
 export * from './groupBy';
 export * from './identity';
 export * from './indexBy';


### PR DESCRIPTION
Per #72 adds `fromPairs` utility

```
R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'}
```