### PR TITLE
[remeda/remeda#107] Restore support for inherited properties with pick

### DIFF
--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -11,6 +11,14 @@ describe('data first', () => {
     expect(pick(undefined as any, ['foo'])).toEqual({});
     expect(pick(null as any, ['foo'])).toEqual({});
   });
+  test('support inherited properties', () => {
+    class BaseClass {
+      testProp() {return 'abc'};
+    }
+    class TestClass extends BaseClass { }
+    const testClass = new TestClass();
+    expect(pick(testClass, ['testProp'])).toEqual({ testProp: expect.any(Function) })
+  });
 });
 
 describe('data last', () => {

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -37,7 +37,7 @@ function _pick(object: any, names: string[]) {
     return {};
   }
   return names.reduce((acc, name) => {
-    if (object.hasOwnProperty(name)) {
+    if (name in object) {
       acc[name] = object[name];
     }
     return acc;


### PR DESCRIPTION
Previous change used `hasOwnProperty`, which does not support inherited properties.  Using `in` per suggestion in #107 fixes this problem.