### PR TITLE
Add "tap" function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export * from './splitAt';
 export * from './splitWhen';
 export * from './take';
 export * from './takeWhile';
+export * from './tap';
 export * from './times';
 export * from './toPairs';
 export * from './type';

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -1,9 +1,11 @@
 import { tap } from './tap';
 import { pipe } from './pipe';
+import { take } from './take';
+
+const mockFn = jest.fn(() => void 0);
 
 describe('data_first', () => {
   it('tap', () => {
-    const mockFn = jest.fn(() => void 0);
     expect(tap(1, mockFn)).toBe(1);
     expect(mockFn).toBeCalledWith(1);
   });
@@ -11,8 +13,15 @@ describe('data_first', () => {
 
 describe('data_last', () => {
   it('tap', () => {
-    const mockFn = jest.fn(() => void 0);
     expect(pipe(1, tap(mockFn))).toBe(1);
     expect(mockFn).toBeCalledWith(1);
+  });
+
+  it('tap lazily', () => {
+    expect(pipe([1, 2, 3, 4, 5], tap(mockFn), take(3))).toEqual([1, 2, 3]);
+    expect(mockFn).toBeCalledWith(1);
+    expect(mockFn).toBeCalledWith(2);
+    expect(mockFn).toBeCalledWith(3);
+    expect(mockFn).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -1,0 +1,18 @@
+import { tap } from './tap';
+import { pipe } from './pipe';
+
+describe('data_first', () => {
+  it('tap', () => {
+    const mockFn = jest.fn(() => void 0);
+    expect(tap(1, mockFn)).toBe(1);
+    expect(mockFn).toBeCalledWith(1);
+  });
+});
+
+describe('data_last', () => {
+  it('tap', () => {
+    const mockFn = jest.fn(() => void 0);
+    expect(pipe(1, tap(mockFn))).toBe(1);
+    expect(mockFn).toBeCalledWith(1);
+  });
+});

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,4 +1,5 @@
 import { purry } from './purry';
+import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 /**
  * Runs the given function with the supplied object, then returns the object.
@@ -24,10 +25,23 @@ export function tap<T>(x: T, fn: (x: T) => void): T;
 export function tap<T>(fn: (x: T) => void): (x: T) => T;
 
 export function tap() {
-  return purry(_tap, arguments);
+  return purry(_tap, arguments, tap.lazy);
 }
 
-export function _tap<T>(x: T, fn: (x: T) => void): T {
+export function _tap<T>(x: any, fn: (x: T) => void) {
   fn(x);
   return x;
+}
+
+export namespace tap {
+  export function lazy(fn: (value: any) => any) {
+    return (value: any): LazyResult<any> => {
+      fn(value);
+      return {
+        done: false,
+        hasNext: true,
+        next: value,
+      };
+    };
+  }
 }

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,0 +1,33 @@
+import { purry } from './purry';
+
+/**
+ * Runs the given function with the supplied object, then returns the object.
+ * @param value
+ * @param fn the transducer
+ * @signature
+ *    R.tap(value, fn)
+ * @example
+ *    R.tap(1, x => console.log(`value is ${x}`)) // => 1, and logs "value is 1"
+ * @data_first
+ */
+export function tap<T>(x: T, fn: (x: T) => void): T;
+
+/**
+ * Runs the given function with the supplied object, then returns the object.
+ * @param fn the transducer
+ * @signature
+ *    R.tap(fn)(value)
+ * @example
+ *    R.pipe(1, R.tap(x => console.log(`value is ${x}`))) // => 1, and logs "value is 1"
+ * @data_last
+ */
+export function tap<T>(fn: (x: T) => void): (x: T) => T;
+
+export function tap() {
+  return purry(_tap, arguments);
+}
+
+export function _tap<T>(x: T, fn: (x: T) => void): T {
+  fn(x);
+  return x;
+}


### PR DESCRIPTION
Hi, thank you for the great library. I'm a fan of Remeda.

I would like to include `tap`, which is an utility function acting as a transducer.

Useful for:

- Add logging of current operation.

```ts
R.pipe(
  [1, 2, 3],
  R.filter(item => item > 1),
  R.tap(array => console.log(array)), // => logs "[2, 3]"
  R.map(item => item * 2),
  //...
)
```

- Run exception in operation.

```ts
function validateInvalidValue(array: any[]) {
  if (array.includes('invalid')) {
    throw new Error('Invalid value contained')
  }
}

R.pipe(
  [1, 2, 3, "invalid"],
  R.tap(validateInvalidValue), // throws "Invalid value contained"
  //...
)
```



Inspired by: https://ramdajs.com/docs/#tap