### PR TITLE
Adds support for multiple sort by projections as well as directions

### DIFF
--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -25,7 +25,7 @@ describe('data first', () => {
     ).toEqual([1, 1, 2, 3]);
   });
   test('sort objects descending correctly', () => {
-    expect(sortBy(objects, x => x.weight, 'desc').map(x => x.weight)).toEqual([
+    expect(sortBy(objects, [x => x.weight, 'desc']).map(x => x.weight)).toEqual([
       3, 2, 1, 1,
     ]);
   });
@@ -41,20 +41,19 @@ describe('data last', () => {
     ).toEqual(sorted);
   });
   test('sort objects correctly', () => {
-    expect(
-      sortBy<{ weight: number; color: string }>(
+    const sortFn = sortBy<{ weight: number; color: string }>(
         x => x.weight,
         x => x.color
-      )(objects).map(x => x.color)
+    );
+    expect(
+      sortFn(objects).map(x => x.color)
     ).toEqual(['green', 'purple', 'red', 'blue']);
   });
   test('sort objects correctly by weight asc then color desc', () => {
     expect(
       sortBy<{ weight: number; color: string }>(
-        x => x.weight,
-        'asc',
-        x => x.color,
-        'desc'
+        [x => x.weight, 'asc'],
+        [x => x.color, 'desc']
       )(objects).map(x => x.color)
     ).toEqual(['purple', 'green', 'red', 'blue']);
   });

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -5,15 +5,21 @@ const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
 const sorted = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }];
 
 const objects = [
-  { color: 'red', weight: 2 },
-  { color: 'blue', weight: 3 },
-  { color: 'green', weight: 1 },
-  { color: 'purple', weight: 1 },
+  { id: 1, color: 'red', weight: 2, active: true, date: new Date(2021, 1, 1) },
+  { id: 2, color: 'blue', weight: 3, active: false, date: new Date(2021, 1, 2) },
+  { id: 3, color: 'green', weight: 1, active: false, date: new Date(2021, 1, 3) },
+  { id: 4, color: 'purple', weight: 1, active: true, date: new Date(2021, 1, 4) },
 ];
 
 describe('data first', () => {
   test('sort correctly', () => {
     expect(sortBy(items, x => x.a)).toEqual(sorted);
+  });
+  test('sort booleans correctly', () => {
+    expect(sortBy(objects, [x => x.active, 'desc']).map(x => x.active)).toEqual([true, true, false, false]);
+  });
+  test('sort dates correctly', () => {
+    expect(sortBy(objects, [x => x.date, 'desc']).map(x => x.id)).toEqual([4, 3, 2, 1]);
   });
   test('sort objects correctly', () => {
     expect(
@@ -22,6 +28,15 @@ describe('data first', () => {
         x => x.weight,
         x => x.color
       ).map(x => x.weight)
+    ).toEqual([1, 1, 2, 3]);
+  });
+  test('sort objects correctly mixing sort pair and sort projection', () => {
+    expect(
+        sortBy(
+            objects,
+            x => x.weight,
+            [x => x.color, 'asc']
+        ).map(x => x.weight)
     ).toEqual([1, 1, 2, 3]);
   });
   test('sort objects descending correctly', () => {

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -4,9 +4,30 @@ import { pipe } from './pipe';
 const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
 const sorted = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }];
 
+const objects = [
+  { color: 'red', weight: 2 },
+  { color: 'blue', weight: 3 },
+  { color: 'green', weight: 1 },
+  { color: 'purple', weight: 1 },
+];
+
 describe('data first', () => {
   test('sort correctly', () => {
     expect(sortBy(items, x => x.a)).toEqual(sorted);
+  });
+  test('sort objects correctly', () => {
+    expect(
+      sortBy(
+        objects,
+        x => x.weight,
+        x => x.color
+      ).map(x => x.weight)
+    ).toEqual([1, 1, 2, 3]);
+  });
+  test('sort objects descending correctly', () => {
+    expect(sortBy(objects, x => x.weight, 'desc').map(x => x.weight)).toEqual([
+      3, 2, 1, 1,
+    ]);
   });
 });
 
@@ -18,5 +39,23 @@ describe('data last', () => {
         sortBy(x => x.a)
       )
     ).toEqual(sorted);
+  });
+  test('sort objects correctly', () => {
+    expect(
+      sortBy<{ weight: number; color: string }>(
+        x => x.weight,
+        x => x.color
+      )(objects).map(x => x.color)
+    ).toEqual(['green', 'purple', 'red', 'blue']);
+  });
+  test('sort objects correctly by weight asc then color desc', () => {
+    expect(
+      sortBy<{ weight: number; color: string }>(
+        x => x.weight,
+        'asc',
+        x => x.color,
+        'desc'
+      )(objects).map(x => x.color)
+    ).toEqual(['purple', 'green', 'red', 'blue']);
   });
 });

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -1,29 +1,57 @@
 import { purry } from './purry';
 
+type Direction = 'asc' | 'desc';
+type SortProjection<T> = (x: T) => Sortable;
+type SortablePrimitive = number | string;
+type Sortable = SortablePrimitive | { valueOf(): SortablePrimitive };
+
 /**
- * Sorts the list according to the supplied function in ascending order.
+ * Sorts the list according to the supplied functions and directions.
  * Sorting is based on a native `sort` function. It's not guaranteed to be stable.
+ *
+ * Directions are applied to functions in order and default to ascending if not specified.
  * @param array the array to sort
- * @param fn the mapping function
+ * @param fnDirs a list of mapping functions and directions
  * @signature
- *    R.sortBy(array, fn)
+ *    R.sortBy(array, ...fnDirs)
  * @example
  *    R.sortBy(
  *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
  *      x => x.a
  *    )
  *    // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]
+ *
+ *    R.sortBy(
+ *     const objects = [
+ *       {color: 'red', weight: 2},
+ *       {color: 'blue', weight: 3},
+ *       {color: 'green', weight: 1},
+ *       {color: 'purple', weight: 1},
+ *     ];
+ *      x => x.weight, 'asc', x.color, 'desc'
+ *    )
+ *    // =>
+ *    //   {color: 'purple', weight: 1},
+ *    //   {color: 'green', weight: 1},
+ *    //   {color: 'red', weight: 2},
+ *    //   {color: 'blue', weight: 3},
  * @data_first
  * @category Array
  */
-export function sortBy<T>(array: readonly T[], fn: (item: T) => any): T[];
+export function sortBy<T>(
+  array: readonly T[],
+  ...fnDirs: (SortProjection<T> | Direction)[]
+): T[];
 
 /**
- * Sorts the list according to the supplied function in ascending order.
+ * Sorts the list according to the supplied functions and directions.
  * Sorting is based on a native `sort` function. It's not guaranteed to be stable.
- * @param fn the mapping function
+ *
+ * Directions are applied to functions in order and default to ascending if not specified.
+ * @param fnDir first mapping function or direction
+ * @param fnDirs additional mapping function
  * @signature
- *    R.sortBy(fn)(array)
+ *    R.sortBy(...fnDirs)(array)
  * @example
  *    R.pipe(
  *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
@@ -32,17 +60,51 @@ export function sortBy<T>(array: readonly T[], fn: (item: T) => any): T[];
  * @data_last
  * @category Array
  */
-export function sortBy<T>(fn: (item: T) => any): (array: readonly T[]) => T[];
+export function sortBy<T>(
+  fnDir: SortProjection<T> | Direction,
+  ...fnDirs: (SortProjection<T> | Direction)[]
+): (array: readonly T[]) => T[];
 
 export function sortBy() {
-  return purry(_sortBy, arguments);
+  if (Array.isArray(arguments[0])) {
+    return purry(_sortBy, [arguments[0], Array.from(arguments).slice(1)]);
+  }
+  return purry(_sortBy, [Array.from(arguments)]);
 }
 
-function _sortBy<T>(array: T[], fn: (item: T) => any): T[] {
+function _sortBy<T>(
+  array: T[],
+  fnDirs: (SortProjection<T> | Direction)[]
+): T[] {
+  let _fns: SortProjection<T>[] = fnDirs.filter(
+    x => x instanceof Function
+  ) as SortProjection<T>[];
+  const _directions: Direction[] = fnDirs.filter(
+    x => !(x instanceof Function)
+  ) as Direction[];
+  const sort = (
+    a: T,
+    b: T,
+    fn: SortProjection<T>,
+    fns: SortProjection<T>[],
+    direction: Direction,
+    directions: Direction[]
+  ): number => {
+    const dir: (x: Sortable, y: Sortable) => boolean =
+      direction !== 'desc' ? (x, y) => x > y : (x, y) => x < y;
+    if (!fn) {
+      return 0;
+    }
+    if (dir(fn(a), fn(b))) {
+      return 1;
+    }
+    if (dir(fn(b), fn(a))) {
+      return -1;
+    }
+    return sort(a, b, fns[0], fns.slice(1), directions[0], directions.slice(1));
+  };
   const copied = [...array];
-  return copied.sort((a, b) => {
-    const aa = fn(a);
-    const bb = fn(b);
-    return aa < bb ? -1 : aa > bb ? 1 : 0;
-  });
+  return copied.sort((a: T, b: T) =>
+    sort(a, b, _fns[0], _fns.slice(1), _directions[0], _directions.slice(1))
+  );
 }

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -22,12 +22,12 @@ type Sortable = SortablePrimitive | { valueOf(): SortablePrimitive };
  *    // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]
  *
  *    R.sortBy(
- *     const objects = [
+ *     [
  *       {color: 'red', weight: 2},
  *       {color: 'blue', weight: 3},
  *       {color: 'green', weight: 1},
  *       {color: 'purple', weight: 1},
- *     ];
+ *     ],
  *      x => x.weight, 'asc', x.color, 'desc'
  *    )
  *    // =>

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -1,9 +1,9 @@
 import { purry } from './purry';
 
 type Direction = 'asc' | 'desc';
-type SortProjection<T> = (x: T) => Sortable;
-type SortablePrimitive = number | string;
-type Sortable = SortablePrimitive | { valueOf(): SortablePrimitive };
+type SortProjection<T> = (x: T) => Comparable;
+type ComparablePrimitive = number | string | boolean;
+type Comparable = ComparablePrimitive | { valueOf(): ComparablePrimitive };
 type SortPair<T> = [SortProjection<T>, Direction];
 type SortRule<T> = SortProjection<T> | SortPair<T>;
 
@@ -72,14 +72,12 @@ export function sortBy<T>(
     ...sorts: SortRule<T>[]
 ): any {
   if (!isSortRule(arrayOrSort)) {
-    const array: readonly T[] = arrayOrSort as unknown as readonly T[];
-    return purry(_sortBy, [array, sorts]) as T[];
+    return purry(_sortBy, [arrayOrSort, sorts]) as T[];
   }
-  const sort = arrayOrSort as SortRule<T>;
-  return purry(_sortBy, [[sort, ...sorts]]) as (arr: readonly T[]) => T[];
+  return purry(_sortBy, [[arrayOrSort, ...sorts]]) as (arr: readonly T[]) => T[];
 }
 
-function isSortRule<T> (x: readonly T[] | SortRule<T>): boolean {
+function isSortRule<T> (x: readonly T[] | SortRule<T>): x is SortRule<T> {
   if (typeof(x) == 'function') return true; // must be a SortProjection
   if (x.length != 2) return false; // cannot be a SortRule
   return (typeof x[0] == 'function' && (x[1] === 'asc' || x[1] === 'desc'));
@@ -103,7 +101,7 @@ function _sortBy<T>(
       direction = 'asc';
       fn = sortRule as SortProjection<T>;
     }
-    const dir: (x: Sortable, y: Sortable) => boolean =
+    const dir: (x: Comparable, y: Comparable) => boolean =
       direction !== 'desc' ? (x, y) => x > y : (x, y) => x < y;
     if (!fn) {
       return 0;


### PR DESCRIPTION
Thank your for this wonderful library!

I often need to be able to specify multiple fields to project a sort on, in addition to parameters. I would like to add this behavior to remeda.

Can be used like:

```ts
const objects = [
  { color: 'red', weight: 2 },
  { color: 'blue', weight: 3 },
  { color: 'green', weight: 1 },
  { color: 'purple', weight: 1 },
];

R.sortBy(objects, x => x.weight, x => x.color);
R.sortBy(objects, [x => x.weight, 'desc'], [x => x.color, 'desc']);
R.sortBy(objects, x => x.weight, [x => x.color, 'desc']);
```