### PR TITLE
Fixes object generic constraints

### DIFF
--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -12,7 +12,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function addProp<T, K extends string, V>(
+export function addProp<T extends Record<PropertyKey, unknown>, K extends string, V>(
   obj: T,
   prop: K,
   value: V
@@ -29,7 +29,7 @@ export function addProp<T, K extends string, V>(
  * @data_last
  * @category Object
  */
-export function addProp<T, K extends string, V>(
+export function addProp<T extends Record<PropertyKey, unknown>, K extends string, V>(
   prop: K,
   value: V
 ): (obj: T) => T & { [x in K]: V };

--- a/src/forEachObj.ts
+++ b/src/forEachObj.ts
@@ -1,11 +1,11 @@
 import { purry } from './purry';
 
-type IndexedIteratee<T extends object, K extends keyof T> = (
+type IndexedIteratee<T extends Record<PropertyKey, unknown>, K extends keyof T> = (
   value: T[K],
   key: K,
   obj: T
 ) => void;
-type UnindexedIteratee<T extends object> = (value: T[keyof T]) => void;
+type UnindexedIteratee<T extends Record<PropertyKey, unknown>> = (value: T[keyof T]) => void;
 
 /**
  * Iterate an object using a defined callback function. The original object is returned.
@@ -24,7 +24,7 @@ type UnindexedIteratee<T extends object> = (value: T[keyof T]) => void;
  * @data_first
  * @category Object
  */
-export function forEachObj<T extends object>(
+export function forEachObj<T extends Record<PropertyKey, unknown>>(
   object: T,
   fn: UnindexedIteratee<T>
 ): T;
@@ -46,7 +46,7 @@ export function forEachObj<T extends object>(
  * @data_last
  * @category Object
  */
-export function forEachObj<T extends object>(
+export function forEachObj<T extends Record<PropertyKey, unknown>>(
   fn: UnindexedIteratee<T>
 ): (object: T) => T;
 
@@ -69,11 +69,11 @@ const _forEachObj = (indexed: boolean) => (
 };
 
 export namespace forEachObj {
-  export function indexed<T extends object>(
+  export function indexed<T extends Record<PropertyKey, unknown>>(
     object: T,
     fn: IndexedIteratee<T, keyof T>
   ): T;
-  export function indexed<T extends object>(
+  export function indexed<T extends Record<PropertyKey, unknown>>(
     fn: IndexedIteratee<T, keyof T>
   ): (object: T) => T;
   export function indexed() {

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -9,7 +9,7 @@
  * @data_first
  * @category Object
  */
-export function mapValues<T extends object, S>(
+export function mapValues<T extends Record<PropertyKey, unknown>, S>(
   object: T,
   fn: (value: T[keyof T], key: keyof T) => S
 ): Record<keyof T, S>;
@@ -24,7 +24,7 @@ export function mapValues<T extends object, S>(
  * @data_last
  * @category Object
  */
-export function mapValues<T extends object, S>(
+export function mapValues<T extends Record<PropertyKey, unknown>, S>(
   fn: (value: T[keyof T], key: keyof T) => S
 ): (object: T) => Record<keyof T, S>;
 

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -11,7 +11,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function omit<T extends {}, K extends keyof T>(
+export function omit<T extends Record<PropertyKey, unknown>, K extends keyof T>(
   object: T,
   names: readonly K[]
 ): Omit<T, K>;
@@ -27,7 +27,7 @@ export function omit<T extends {}, K extends keyof T>(
  * @data_last
  * @category Object
  */
-export function omit<T extends {}, K extends keyof T>(
+export function omit<T extends Record<PropertyKey, unknown>, K extends keyof T>(
   names: readonly K[]
 ): (object: T) => Omit<T, K>;
 
@@ -35,7 +35,7 @@ export function omit() {
   return purry(_omit, arguments);
 }
 
-function _omit<T extends {}, K extends keyof T>(
+function _omit<T extends Record<PropertyKey, unknown>, K extends keyof T>(
   object: T,
   names: K[]
 ): Omit<T, K> {

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -10,7 +10,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function pick<T extends {}, K extends keyof T>(
+export function pick<T extends Record<PropertyKey, unknown>, K extends keyof T>(
   object: T,
   names: readonly K[]
 ): Pick<T, K>;
@@ -24,7 +24,7 @@ export function pick<T extends {}, K extends keyof T>(
  * @data_last
  * @category Object
  */
-export function pick<T extends {}, K extends keyof T>(
+export function pick<T extends Record<PropertyKey, unknown>, K extends keyof T>(
   names: readonly K[]
 ): (object: T) => Pick<T, K>;
 

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -10,7 +10,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function pick<T extends Record<PropertyKey, unknown>, K extends keyof T>(
+export function pick<T extends object, K extends keyof T>(
   object: T,
   names: readonly K[]
 ): Pick<T, K>;
@@ -24,7 +24,7 @@ export function pick<T extends Record<PropertyKey, unknown>, K extends keyof T>(
  * @data_last
  * @category Object
  */
-export function pick<T extends Record<PropertyKey, unknown>, K extends keyof T>(
+export function pick<T extends object, K extends keyof T>(
   names: readonly K[]
 ): (object: T) => Pick<T, K>;
 


### PR DESCRIPTION
In this PR I suggest to change the way that generic object types are declared. This is because the way that the project is using them is wrong, let me explain that (all example have links to [TypeScript playground](https://www.typescriptlang.org/)):

- T extending `unknown` type
```typescript
export function addProp<T, K extends string, V>(obj: T, prop: K, value: V) => T & { [x in K]: V }
```
When no types constraint are declared on a generic, TypeScript assumes that the generic type is `unknown`. So according with that, in `addProp` function I can write any type and TypeScript compiler will not alert me, [like that](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXymGAAUYcAHAHgBUAaeAaXhAA8MRVgBneLjGLKgDm9AGoA+ABQBYAFDx4OAEYArAFzw6cheTLkNDWtvgA3KBGQgNouQEoN1eADJ4Ab3gBtFvEGMAutbwAL4A3HJyhCR6kgDkALYAnvAA7mTCvPyCQjH08Qm6FDnweWYWIDG2YbKRpBSS7lAaMXBCyNAwiqrgGDHBuYkF5EUl5pYVVXIA9JPwAGJYLCDA8Bj5CKCQsFDYeFxq4bIb7Qgo6Dv4APo1ejTMbBzc8ABK4DgwwJS15CAwqwwgCXoaAA1qgcMlUOJ6ExWOxODw+AJhGIpMZlOpNEZ5PBBgYsQpSpZrHYHM43J5vL4GAF4KJghNZFciF9YokUmkhBkkdl+vk9MNEoTypU5EyonUGk0Wm1YJ0VN1ekFeYMBQkheM5EA):

```javascript
addProp('my wrong string', 'myprop', 'myvalue');
```

- T extending `object` type
```typescript
export function forEachObj<T extends object>(object: T, fn: UnindexedIteratee<T>): T
```
In JavaScript a function is an object, so according with `forEachObj` declaration type, I can write the bellow call and [TS compiler will say nothing to me](https://www.typescriptlang.org/play?#code/C4TwDgpgBAkgdgEwgDwgmwICcCGmIA8AKlCpogM5QD2ARgFYQDGwANFANKnLkJUDWEENQBmUIgD4oAXigAKALAAoKFABuOADYBXCAC5xAbQ4BdVstWCQBjuZU0GBosoCUMqWuoBLBAG5loJBQAKpwXogoaBjYeBCEJGQQlA6MLFKycho6+kZWouImbtIe3n7KykhMmjhY0CLacCxe1HBQItRYAKI4TAAWAPIMxNy8VHSpwBKK9uPMwE52qiJwBqHhSKjomLj4xBKuTv5Kyu1dPQMMcnJFJT5QAOS4iNQAtlAUwNoiIvfscpgdLxMLSaEAAQTggwmNygAG8LFAmC0KNRNBAAHSaagAc3+EEBwM0oIhULmLmUAF9ycclAB6WlQABiXk2UEC0Eq1R2zTgFD05SU7KgAH14BsottYvERkk+FAAErMDoIAgABSw1EgWFAHCE7Aa-Dg1AA7nAJOwuIlknkxJIZPIEVldE5jGYEVYbIsUk5XO51KUjkLhWsIptojs4sMrXLFUisCr1ZrsDq9VADUbTRJ0vInTkiIYbQUYZ4fEcKswuXUGk0WiLTt0+lCozxZVRY8q1RqtSmQPq4IaTWapgjZiwFgjlgZg2FQxKYrtJAdxGWlML6+coVdi6UHk8EK93p9vr95ACsECQeDIQwyX74fYkbzURisbizxeiVfSSxqVSgA):

```javascript
forEachObj(() => void 'random stuff', (teoricallyAnObject) => {
  ...
})
```

- T extending `{}` type
```typescript
export function omit<T extends {}, K extends keyof T>(names: readonly K[]): (object: T) => Omit<T, K>
```
And the last but not least, the empty type is equivalent to write `any` because I can use any type when `T extends {}` is declared as a type, [let me exemplify](https://www.typescriptlang.org/play?ssl=6&ssc=33&pln=6&pc=1#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXxwFssMAeAFXhAA8MRVgBneAbwF8AaeAaStvqbwA1iACeORPHIA+ABQBYAFDwCAIwBW4DAC4pHJStRRCIRrrhRgeCKJ4BtALpKAlLoDyxMuS7dpAbiUlIhJZAHIYKAYieEYMZEREUK47ULA8MCgMUIdnQMUAenz4ADEsahBgeAxRAAcEUEhYTNxUMzyG6DgkNEwW+AB9YK8+OgZmACVwHBhgUgAFGBw6mGruMS40IVQcAHdUaR8RgWYRcUkZBWU1TUxdbwN4IxMzeAsrVBt7J0VXeA8SCg+fx5QaeMIRKKEGJxBJJeApNLoTLZZxAA):

```javascript
omit('random stuff', ['concat'])
```

Hope this PR helps with the project :)