### PR TITLE
Let 'set' narrow type of the set property

### DIFF
--- a/src/set.ts
+++ b/src/set.ts
@@ -12,7 +12,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function set<T, K extends keyof T>(obj: T, prop: K, value: T[K]): T;
+export function set<T, K extends keyof T, A extends T[K]>(obj: T, prop: K, value: A): Omit<T, K> & { [key in K]: A };
 
 /**
  * Sets the `value` at `prop` of `object`.
@@ -25,7 +25,7 @@ export function set<T, K extends keyof T>(obj: T, prop: K, value: T[K]): T;
  * @data_last
  * @category Object
  */
-export function set<T, K extends keyof T>(prop: K, value: T[K]): (obj: T) => T;
+export function set<T, K extends keyof T, A extends T[K]>(prop: K, value: A): (obj: T) => Omit<T, K> & { [key in K]: A };
 
 export function set() {
   return purry(_set, arguments);


### PR DESCRIPTION
Greetings!

One unfortunate thing about Typescript is that after narrowing the type of the property, there's a mismatch of the type of a property when the object as a whole is considered versus when the property is considered on its own. An example:
```typescript
function takeDefinedNumber(x: number) {}
function takeOWithDefinedX(o: {x: number, s: string}) {}

function checkPropType(o: {x: number | undefined, s: string}) {
  o.x ??= 5;

  takeDefinedNumber(o.x); // Great! When directly accessed, o.x is inferred as 'number'
  takeOWithDefinedX(o) // Error - As part of the object, o.x is inferred as 'number | undefined'
}
``` 
This is a limitation of Typescript; it is clearly impossible that the type of o.x when considered separately and the type of the property x when considered as part of o are different.

Since _set()_ sets a property to _value_, we can be certain that the property of the returned object does in fact have the type of that value. It would thus be nice if this was reflected on the returned object.

Right now: 

```typescript
import {set} from 'remeda';
function takeDefinedNumber(x: number) {}
function takeOWithDefinedX(o: {x: number, s: string}) {}

function checkPropType(o: {x: number | undefined, s: string}) {
  const newO = set(o, 'x', 5);

  takeDefinedNumber(newO.x); // Error - newO.x is still 'number | undefined'
  takeOWithDefinedX(newO) // Error - As part of the object, newO.x is still 'number | undefined'
}
``` 

With the suggested change:

```typescript
import {set, pipe} from 'remeda';
function takeDefinedNumber(x: number) {}
function takeOWithDefinedX(o: {x: number, s: string}) {}
function takeOWithDefinedXY(o: {x: number, y: number, s: string}) {}

function checkPropType(o: {x: number | undefined, y: number | undefined, s: string}) {
  const newO = set(o, 'x', 5);

  takeDefinedNumber(o.x); // Works! - newO.x is 'number'
  takeOWithDefinedX(o) // Works! As part of the object, newO.x is now 'number'

  takeOWithDefinedXY(pipe(o, set('x', 5), set('y', 7));) // Works! Both x and y are 'number'
}
``` 

Especially this last use case is useful when you have an object with a lot of properties and you want to set a few of them and then call a function which requires those properties to be set.