### PR TITLE
fix(partition): export partition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export * from './noop';
 export * from './objOf';
 export * from './omit';
 export * from './once';
+export * from './partition';
 export * from './pathOr';
 export * from './pick';
 export * from './pipe';


### PR DESCRIPTION
Add missing export of `partition`

Relates to remeda#169