### PR TITLE
fix bug where last was behaving like first on pipe #177

### DIFF
--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -3,16 +3,6 @@ import { pipe } from './pipe';
 import { AssertEqual, NonEmptyArray } from './_types';
 
 describe('last', () => {
-  describe('data first', () => {
-    test('should return last', () => {
-      expect(last([1, 2, 3] as const)).toEqual(3);
-    });
-
-    test('empty array', () => {
-      expect(last([] as const)).toEqual(undefined);
-    });
-  });
-
   describe('data last', () => {
     test('should return last', () => {
       expect(last([1, 2, 3] as const)).toEqual(3);
@@ -21,6 +11,11 @@ describe('last', () => {
     test('empty array', () => {
       expect(last([] as const)).toEqual(undefined);
     });
+
+    test('should work in pipe', () => {
+      const result = pipe([1, 2, 3] as const, last);
+      expect(result).toEqual(3);
+    })
   });
 
   describe('types', () => {

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -3,7 +3,7 @@ import { pipe } from './pipe';
 import { AssertEqual, NonEmptyArray } from './_types';
 
 describe('last', () => {
-  describe('data last', () => {
+  describe('data first', () => {
     test('should return last', () => {
       expect(last([1, 2, 3] as const)).toEqual(3);
     });
@@ -11,11 +11,16 @@ describe('last', () => {
     test('empty array', () => {
       expect(last([] as const)).toEqual(undefined);
     });
+  });
+  
+  describe('data last', () => {
+    test('should return last', () => {
+      expect(pipe([1, 2, 3] as const, last())).toEqual(3);
+    });
 
-    test('should work in pipe', () => {
-      const result = pipe([1, 2, 3] as const, last);
-      expect(result).toEqual(3);
-    })
+    test('empty array', () => {
+      expect(pipe([] as const, last())).toEqual(undefined);
+    });
   });
 
   describe('types', () => {

--- a/src/last.ts
+++ b/src/last.ts
@@ -24,24 +24,9 @@ export function last<T>(array: NonEmptyArray<T>): T;
 export function last<T>(array: ReadonlyArray<T>): T | undefined;
 export function last<T>(): (array: ReadonlyArray<T>) => T | undefined;
 export function last() {
-  return purry(_last, arguments, last.lazy);
+  return purry(_last, arguments);
 }
 
 function _last<T>(array: T[]) {
   return array[array.length - 1];
-}
-
-export namespace last {
-  export function lazy<T>() {
-    return (value: T) => {
-      return {
-        done: true,
-        hasNext: true,
-        next: value,
-      };
-    };
-  }
-  export namespace lazy {
-    export const single = true;
-  }
 }


### PR DESCRIPTION
Fixes: https://github.com/remeda/remeda/issues/177

Adds a test case to handle the scenario covered by the issue.
Removes code copied over from first.ts that forces function last() to behave like first.