### PR TITLE
Upgrade node for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "16"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
We need to upgrade node to 16 in ci to properly install semantic-release in #187. I can't find a way to do that on node v10

@TkDodo I can't be sure that this PR wouldn't break travis check completely. But if you have admin right in this repo we would be able to revert changes.

Make sure that you:

- [X] Typedoc added for new methods and updated for changed
- [X] Tests added for new methods and updated for changed
- [X] New methods added to `src/index.ts`
- [X] New methods added to `mapping.md`
