### PR TITLE
chore: Add pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,24 @@
+name: GH pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 10 # we'll upgrade it later
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build docs
+        run: yarn docs:build
+      - name: Deploy pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/dist

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node index",
     "watch": "parcel serve index.html",
-    "build": "cross-env NODE_ENV=production parcel build index.html --public-url ./  --out-file index.html && cp _redirects dist/_redirects"
+    "build": "cross-env NODE_ENV=production parcel build index.html --public-url ./  --out-file index.html && cp _redirects dist/_redirects && cp dist/index.html dist/404.html"
   },
   "dependencies": {
     "@types/react-router-dom": "^4.3.0",


### PR DESCRIPTION
Add GH pages build and publishing. Would work only on merge to main branch so we need to use something like Netify for PRs. Example: https://remeda.vlad-yakovlev.dev/

Could be safely merged because current website uses travis & netify

---

Make sure that you:

- [X] Typedoc added for new methods and updated for changed
- [X] Tests added for new methods and updated for changed
- [X] New methods added to `src/index.ts`
- [X] New methods added to `mapping.md`
