### PR TITLE
fix: fix typo of map example

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -28,7 +28,7 @@ export function map<T, K>(array: readonly T[], fn: Pred<T, K>): K[];
  *    R.map(fn)(array)
  *    R.map.indexed(fn)(array)
  * @example
- *    R.pipe([0, 1, 2], R.map(x => x * 2)) // => [2, 4, 6]
+ *    R.pipe([0, 1, 2], R.map(x => x * 2)) // => [0, 2, 4]
  *    R.pipe([0, 0, 0], R.map.indexed((x, i) => i)) // => [0, 1, 2]
  * @data_last
  * @indexed


### PR DESCRIPTION
I found the map example with typo.

```typescript
/**
 * Map each value of an object using a defined callback function.
 * @param fn the function mapper
 * @signature
 *    R.map(fn)(array)
 *    R.map.indexed(fn)(array)
 * @example
 *    R.pipe([0, 1, 2], R.map(x => x * 2)) // => [2, 4, 6]
 *    R.pipe([0, 0, 0], R.map.indexed((x, i) => i)) // => [0, 1, 2]
 * @data_last
 * @indexed
 * @pipeable
 * @category Array
 */
export function map<T, K>(fn: Pred<T, K>): (array: readonly T[]) => K[];
```

so I fix the typo from ```R.pipe([0, 1, 2], R.map(x => x * 2)) // => [2, 4, 6]``` to ```R.pipe([0, 1, 2], R.map(x => x * 2)) // => [0,  2, 4]```

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
