### PR TITLE
docs(mapping.md): orderBy support

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -61,6 +61,7 @@ documentation when migrating._
 | `set`            | `set`            | `set`               |
 | `sort`           | `-`              | `sort`              |
 | `sortBy`         | `sortBy`         | `sortBy`            |
+| `sortBy`         | `orderBy`        | `-`                 |
 | `splitAt`        | `-`              | `splitAt`           |
 | `splitWhen`      | `-`              | `splitWhen`         |
 | `take`           | `take`           | `take`              |


### PR DESCRIPTION
Closes #208

After investigating it appears `sortBy` can imitate `lodash/orderBy` effectively. So I am updating `mapping.md`, thus closing the main issue.

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
