### PR TITLE
chore: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Remeda Design Goals
 ----------
 1. The usage must be programmer friendly, and that's more important than following XYZ paradigm strictly.
 2. Manual annotation should never be required, and proper typings should infer everything. The only exception is the first function in `createPipe`.
-3. E6 polyfill is required. Core methods are reused, and data structure (like Map/Set) are not re-implemented.
+3. ES6 polyfill is required. Core methods are reused, and data structure (like Map/Set) are not re-implemented.
 4. The implementation of each function should be as minimal as possible. Tree-shaking is supported by default. (Do you know that `lodash.keyBy` has 14KB after minification?)
 5. All functions are immutable, and there are no side-effects.
 6. Fixed number of arguments.


### PR DESCRIPTION
Fix typo in README.md: `E6` -> `ES6`
