### PR TITLE
feat: add overload to partition with type guard support

### DIFF
--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -1,5 +1,6 @@
 import { partition } from './partition';
 import { pipe } from './pipe';
+import { AssertEqual } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -19,6 +20,18 @@ const expected = [
 describe('data first', () => {
   test('partition', () => {
     expect(partition(array, x => x.a === 1)).toEqual(expected);
+  });
+  test('partition with type guard', () => {
+    const isNumber = function (value: any): value is number {
+      return typeof value === "number"
+    };
+    const actual = partition([1, "a", 2, "b"], isNumber);
+    expect(actual).toEqual([[1, 2], ["a", "b"]]);
+    const result: AssertEqual<
+      typeof actual,
+      [number[], string[]]
+    > = true;
+    expect(result).toBe(true);
   });
   test('partition.indexed', () => {
     expect(partition.indexed(array, (_, index) => index !== 2)).toEqual(

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -2,6 +2,24 @@ import { purry } from './purry';
 import { PredIndexedOptional, PredIndexed } from './_types';
 
 /**
+ * Splits a collection into two groups, the first of which contains elements the `predicate` type guard passes, and the second one containing the rest.
+ * @param items the items to split
+ * @param predicate a type guard function to invoke on every item
+ * @returns the array of grouped elements.
+ * @signature
+ *    R.partition(array, fn)
+ * @example
+ *    R.partition(['one', 'two', 'forty two'], x => x.length === 3) // => [['one', 'two'], ['forty two']]
+ * @data_first
+ * @indexed
+ * @category Array
+ */
+export function partition<T, S extends T>(
+  items: readonly T[],
+  predicate: (item: T) => item is S
+): [S[], Exclude<T, S>[]];
+
+/**
  * Splits a collection into two groups, the first of which contains elements the `predicate` function matches, and the second one containing the rest.
  * @param items the items to split
  * @param predicate the function invoked per iteration


### PR DESCRIPTION
This PR adds an overload to partition that supports type guards. See the added test for an example.
Before remeda had this function we implemented it like this, it would be nice to merge this and drop our implementation.

```ts
test('partition with type guard', () => {
    const isNumber = function (value: any): value is number {
      return typeof value === "number"
    };
    const actual = partition([1, "a", 2, "b"], isNumber);
    expect(actual).toEqual([[1, 2], ["a", "b"]]);
    const result: AssertEqual<
      typeof actual,
      [number[], string[]]
    > = true;
    expect(result).toBe(true);
  });
```
