### PR TITLE
docs(readme): Make data-last support more obvious to new readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ R.pick(['firstName', 'lastName'], obj);
 _.pick(obj, ['firstName', 'lastName']);
 ```
 
+> For readers looking for data-last forms like `R.filter(fn)(array)`, Remeda supports it. Keep reading along!
+
 In the above example, "data-first" approach is more natural and more programmer friendly because when you type the second argument, you get the auto-complete from IDE. It's not possible to get the auto-complete in Ramda because the data argument is not provided.
 
 "data-last" approach is helpful when writing data transformations aka pipes.

--- a/docs/src/Home.tsx
+++ b/docs/src/Home.tsx
@@ -79,6 +79,9 @@ R.pick(['firstName', 'lastName'], obj);
 // Lodash
 _.pick(obj, ['firstName', 'lastName']);`}
           />
+          <blockquote>
+            For readers looking for data-last forms like `R.filter(fn)(array)`, Remeda supports it. Keep reading along!
+          </blockquote>
           <p>
             In the above example, &quot;data-first&quot; approach is more
             natural and more programmer friendly because when you type the
@@ -112,7 +115,7 @@ R.pipe(
   R.filter(x => x.gender === 'f'),
   R.groupBy(x => x.age),
 )(users) // broken typings in TS :(
-  
+
 // Lodash
 _(users)
   .filter(x => x.gender === 'f')
@@ -168,7 +171,7 @@ const result = R.pipe(
   R.uniq(),
   R.take(3)
 ); // => [1, 2, 3]
-  
+
 /**
  * Console output:
  * iterate 1
@@ -187,7 +190,7 @@ const result = R.pipe(
           <CodeBlock
             type="dark"
             code={`const arr = [10, 12, 13, 3];
-  
+
 // filter even values
 R.filter(arr, x => x % 2 === 0); // => [10, 12]
 
@@ -205,7 +208,7 @@ R.filter.indexed(arr, (x, i) => i % 2 === 0); // => [10, 13] `}
 
 const result = R.keys(input)
 // ^? Array<string>
-  
+
 const resultStrict = R.keys.strict(input)
 // ^? Array<'a' | 'b' | 'c'>`}
           />


### PR DESCRIPTION
Just discovered your library today and really nice work! 

Wanted to update the docs very slightly to make it clearer to new readers that Remeda is in fact a data-last library like one would expect. When I first landed on the README i scanned it looking for code, and when I saw that the Remeda / Ramda examples didn't match I immediately assumed that this wasn't actually data-last support and figured that lodash was sufficient. And then I read it again! And dove into the docs and saw that it does everything I'd like. This update makes that clearer for the new arrival, and particularly the type of new arrival who doesn't read words too closely. 