### PR TITLE
Add invert function

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -36,6 +36,7 @@ documentation when migrating._
 | `isNil`          | `isNil`          | `isNil`             |
 | `indexBy`        | `keyBy`          | `indexBy`           |
 | `intersection`   | `intersection`   | `intersection`      |
+| `invert`         | `invert`         | `invertObj`         |
 | `last`           | `last`           | `last`              |
 | `map`            | `map`            | `map`               |
 | `mapKeys`        | `mapKeys`        | `-`                 |

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from './guards';
 export * from './identity';
 export * from './indexBy';
 export * from './intersection';
+export * from './invert';
 export * from './keys';
 export * from './last';
 export * from './map';

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -1,43 +1,55 @@
-import { invert } from './invert'
+import { invert } from './invert';
 import { pipe } from './pipe';
 
-describe('invert', function() {
+describe('invert', function () {
+  describe('with parameter', () => {
+    test('empty object', () => {
+      expect(invert({})).toEqual({});
+    });
 
-  describe("with parameter", () => {
+    test('no duplicate values', () => {
+      expect(invert({ a: 'd', b: 'e', c: 'f' })).toEqual({
+        d: 'a',
+        e: 'b',
+        f: 'c',
+      });
+    });
 
-    test("empty object", () => {
-      expect(invert({})).toEqual({})
-    })
+    test('duplicate values', () => {
+      expect(invert({ a: 'd', b: 'e', c: 'd' })).toEqual({ e: 'b', d: 'c' });
+    });
 
-    test("no duplicate values", () => {
-      expect(invert({ a: "d", b: "e", c: "f" })).toEqual({ d: "a", e: "b", f: "c" })
-    })
+    test('numeric values', () => {
+      expect(invert(['a', 'b', 'c'])).toEqual({ a: '0', b: '1', c: '2' });
+    });
+  });
 
-    test("duplicate values", () => {
-      expect(invert({ a: "d", b: "e", c: "d" })).toEqual({ e: "b", d: "c" })
-    })
+  describe('without parameter', () => {
+    test('empty object', () => {
+      expect(pipe({}, invert())).toEqual({});
+    });
 
-    test("numeric values", () => {
-      expect(invert(["a", "b", "c"])).toEqual({ a: "0", b: "1", c: "2" })
-    })
-  })
+    test('no duplicate values', () => {
+      expect(pipe({ a: 'd', b: 'e', c: 'f' }, invert())).toEqual({
+        d: 'a',
+        e: 'b',
+        f: 'c',
+      });
+    });
 
-  describe("without parameter", () => {
+    test('duplicate values', () => {
+      expect(pipe({ a: 'd', b: 'e', c: 'd' }, invert())).toEqual({
+        e: 'b',
+        d: 'c',
+      });
+    });
 
-    test("empty object", () => {
-      expect(pipe({}, invert())).toEqual({})
-    })
-
-    test("no duplicate values", () => {
-      expect(pipe({ a: "d", b: "e", c: "f" }, invert())).toEqual({ d: "a", e: "b", f: "c" })
-    })
-
-    test("duplicate values", () => {
-      expect(pipe({ a: "d", b: "e", c: "d" }, invert())).toEqual({ e: "b", d: "c" })
-    })
-
-    test("numeric values", () => {
-      expect(pipe(["a", "b", "c"], invert())).toEqual({ a: "0", b: "1", c: "2" })
-    })
-  })
+    test('numeric values', () => {
+      expect(pipe(['a', 'b', 'c'], invert())).toEqual({
+        a: '0',
+        b: '1',
+        c: '2',
+      });
+    });
+  });
 });

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -1,0 +1,43 @@
+import { invert } from './invert'
+import { pipe } from './pipe';
+
+describe('invert', function() {
+
+  describe("with parameter", () => {
+
+    test("empty object", () => {
+      expect(invert({})).toEqual({})
+    })
+
+    test("no duplicate values", () => {
+      expect(invert({ a: "d", b: "e", c: "f" })).toEqual({ d: "a", e: "b", f: "c" })
+    })
+
+    test("duplicate values", () => {
+      expect(invert({ a: "d", b: "e", c: "d" })).toEqual({ e: "b", d: "c" })
+    })
+
+    test("numeric values", () => {
+      expect(invert(["a", "b", "c"])).toEqual({ a: "0", b: "1", c: "2" })
+    })
+  })
+
+  describe("without parameter", () => {
+
+    test("empty object", () => {
+      expect(pipe({}, invert())).toEqual({})
+    })
+
+    test("no duplicate values", () => {
+      expect(pipe({ a: "d", b: "e", c: "f" }, invert())).toEqual({ d: "a", e: "b", f: "c" })
+    })
+
+    test("duplicate values", () => {
+      expect(pipe({ a: "d", b: "e", c: "d" }, invert())).toEqual({ e: "b", d: "c" })
+    })
+
+    test("numeric values", () => {
+      expect(pipe(["a", "b", "c"], invert())).toEqual({ a: "0", b: "1", c: "2" })
+    })
+  })
+});

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -31,5 +31,5 @@ function _invert(object: Invertable): Inverted {
   return Object.entries(object).reduce((accumulator, [key, value]) => {
     accumulator[value] = key;
     return accumulator;
-  }, {} as Inverted)
+  }, {} as Inverted);
 }

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -1,0 +1,35 @@
+import { purry } from './purry';
+
+type Invertable = { [index: string]: string } | { [index: number]: string };
+type Inverted = { [index: string]: string };
+
+/**
+ * Returns an object whose keys are values are swapped. If the object contains duplicate values,
+ * subsequent values will overwrite previous values.
+ * @param object the object
+ * @signature
+ *    R.invert(object)
+ * @example
+ *    R.invert({ a: "d", b: "e", c: "f" }) // => { d: "a", e: "b", f: "c" }
+ *    R.invert({}) // => {}
+ *    R.pipe(
+ *      { a: "d", b: "e", c: "f" }
+ *      R.invert()
+ *    ); // => { d: "a", e: "b", f: "c" }
+ *
+ * @category object
+ * @pipeable
+ */
+export function invert<T>(object: Invertable): Inverted;
+export function invert<T>(): (object: Invertable) => Inverted;
+
+export function invert() {
+  return purry(_invert, arguments);
+}
+
+function _invert(object: Invertable): Inverted {
+  return Object.entries(object).reduce((accumulator, [key, value]) => {
+    accumulator[value] = key;
+    return accumulator;
+  }, {} as Inverted)
+}


### PR DESCRIPTION
This adds the handy `invert` method, which swaps the keys and values in an object. This method is present in both Lodash and Ramda, and I needed it for my current project, so I thought I'd add it here as well.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
