### PR TITLE
move to vitest's assertType

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -12,10 +12,4 @@ export type Key = string | number | symbol;
 /** Mapped type to remove optional, null, and undefined from all props */
 export type NonNull<T> = { [K in keyof T]-?: Exclude<T[K], null | undefined> };
 
-export type AssertEqual<Type, Expected> = Array<Type> extends Array<Expected>
-  ? Array<Expected> extends Array<Type>
-    ? true
-    : never
-  : never;
-
 export type NonEmptyArray<T> = [T, ...Array<T>];

--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,5 +1,4 @@
 import { fromPairs } from './fromPairs';
-import { AssertEqual } from './_types';
 
 const tuples: Array<[string, number]> = [
   ['a', 1],
@@ -29,18 +28,13 @@ describe('fromPairs', () => {
 describe('typings', () => {
   test('arrays', () => {
     const actual = fromPairs(tuples);
-    const result: AssertEqual<typeof actual, Record<string, number>> = true;
-    expect(result).toBe(true);
+    assertType<Record<string, number>>(actual);
   });
   test('arrays with mixed type value', () => {
     const actual = fromPairs<string | number>([
       ['a', 2],
       ['b', 'c'],
     ]);
-    const result: AssertEqual<
-      typeof actual,
-      Record<string, string | number>
-    > = true;
-    expect(result).toBe(true);
+    assertType<Record<string, string | number>>(actual);
   });
 });

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,6 +1,6 @@
 import { groupBy } from './groupBy';
 import { pipe } from './pipe';
-import { AssertEqual, NonEmptyArray } from './_types';
+import { NonEmptyArray } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -54,42 +54,23 @@ describe('data last', () => {
 describe('Result key types', () => {
   test('Union of string literals', () => {
     const data = groupBy.strict(array2, x => x.a);
-    const result: AssertEqual<
-      typeof data,
-      Partial<Record<'cat' | 'dog', NonEmptyArray<Array2Item>>>
-    > = true;
-    expect(result).toEqual(true);
+
+    assertType<Partial<Record<'cat' | 'dog', NonEmptyArray<Array2Item>>>>(data);
   });
   test('Union of number literals', () => {
     const data = groupBy.strict(array2, x => x.b);
-    const result: AssertEqual<
-      typeof data,
-      Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>
-    > = true;
-    expect(result).toEqual(true);
+    assertType<Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>>(data);
   });
   test('string', () => {
     const data = groupBy.strict(array2, (x): string => x.a);
-    const result: AssertEqual<
-      typeof data,
-      Record<string, NonEmptyArray<Array2Item>>
-    > = true;
-    expect(result).toEqual(true);
+    assertType<Record<string, NonEmptyArray<Array2Item>>>(data);
   });
   test('number', () => {
     const data = groupBy.strict(array2, (x): number => x.b);
-    const result: AssertEqual<
-      typeof data,
-      Record<number, NonEmptyArray<Array2Item>>
-    > = true;
-    expect(result).toEqual(true);
+    assertType<Record<number, NonEmptyArray<Array2Item>>>(data);
   });
   test('string | number', () => {
     const data = groupBy.strict(array2, (x): string | number => x.b);
-    const result: AssertEqual<
-      typeof data,
-      Record<string | number, NonEmptyArray<Array2Item>>
-    > = true;
-    expect(result).toEqual(true);
+    assertType<Record<string | number, NonEmptyArray<Array2Item>>>(data);
   });
 });

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -102,7 +102,7 @@ describe('isString', () => {
       dataProvider('boolean'),
     ].filter(isString);
     expect(data.every(c => typeof c === 'string')).toEqual(true);
-    assertType<string[]>(data);
+    assertType<Array<string>>(data);
   });
 });
 
@@ -136,7 +136,7 @@ describe('isBoolean', () => {
       dataProvider('boolean'),
     ].filter(isBoolean);
     expect(data.every(c => typeof c === 'boolean')).toEqual(true);
-    assertType<boolean[]>(data);
+    assertType<Array<boolean>>(data);
   });
 });
 
@@ -145,12 +145,12 @@ describe('isArray', () => {
     const data = dataProvider('array');
     if (isArray(data)) {
       expect(Array.isArray(data)).toEqual(true);
-      assertType<number[]>(data);
+      assertType<Array<number>>(data);
     }
 
     const data1: unknown = dataProvider('array');
     if (isArray(data1)) {
-      assertType<readonly unknown[]>(data1);
+      assertType<ReadonlyArray<unknown>>(data1);
     }
   });
   test('isArray: should work as type guard in filter', () => {
@@ -163,7 +163,7 @@ describe('isArray', () => {
       dataProvider('date'),
     ].filter(isArray);
     expect(data.every(c => Array.isArray(c))).toEqual(true);
-    assertType<number[][]>(data);
+    assertType<Array<Array<number>>>(data);
   });
 });
 
@@ -190,7 +190,7 @@ describe('isDate', () => {
       dataProvider('date'),
     ].filter(isDate);
     expect(data.every(c => c instanceof Date)).toEqual(true);
-    assertType<Date[]>(data);
+    assertType<Array<Date>>(data);
   });
 });
 describe('isDefined', () => {
@@ -221,8 +221,7 @@ describe('isDefined', () => {
     ].filter(isDefined);
     expect(data.length === 4).toEqual(true);
     assertType<
-      (
-        | string
+      Array<| string
         | number
         | boolean
         | {
@@ -232,8 +231,7 @@ describe('isDefined', () => {
         | Array<number>
         | Date
         | Error
-        | Promise<number>
-      )[]
+        | Promise<number>>
     >(data);
   });
 });
@@ -256,7 +254,7 @@ describe('isNil', () => {
       dataProvider('number'),
     ].filter(isNil);
     expect(data.every(c => c == null)).toEqual(true);
-    assertType<(undefined | null)[]>(data);
+    assertType<Array<undefined | null>>(data);
   });
 });
 
@@ -284,7 +282,7 @@ describe('isFunction', () => {
       dataProvider('number'),
     ].filter(isFunction);
     expect(data.every(c => typeof c === 'function')).toEqual(true);
-    assertType<(() => void)[]>(data);
+    assertType<Array<() => void>>(data);
   });
 });
 describe('isError', () => {
@@ -312,7 +310,7 @@ describe('isError', () => {
       dataProvider('number'),
     ].filter(isError);
     expect(data.every(c => c instanceof Error)).toEqual(true);
-    assertType<Error[]>(data);
+    assertType<Array<Error>>(data);
   });
 });
 describe('isNumber', () => {
@@ -333,7 +331,7 @@ describe('isNumber', () => {
       dataProvider('number'),
     ].filter(isNumber);
     expect(data.every(c => typeof c === 'number')).toEqual(true);
-    assertType<number[]>(data);
+    assertType<Array<number>>(data);
   });
   test('should work even if data type is unknown', () => {
     const data: unknown = dataProvider('number');
@@ -410,14 +408,12 @@ describe('isObject', () => {
       true
     );
     assertType<
-      (
-        | {
+      Array<| {
             a: string;
           }
         | Date
         | Error
-        | Promise<number>
-      )[]
+        | Promise<number>>
     >(data);
   });
 });
@@ -438,7 +434,7 @@ describe('isPromise', () => {
       dataProvider('function'),
     ].filter(isPromise);
     expect(data.every(c => c instanceof Promise)).toEqual(true);
-    assertType<Promise<number>[]>(data);
+    assertType<Array<Promise<number>>>(data);
   });
 });
 describe('isTruthy', () => {
@@ -482,8 +478,7 @@ describe('isNot', () => {
     expect(result.some(c => c instanceof Promise)).toEqual(false);
 
     assertType<
-      (
-        | boolean
+      Array<| boolean
         | string
         | { a: string }
         | (() => void)
@@ -492,8 +487,7 @@ describe('isNot', () => {
         | undefined
         | null
         | Error
-        | number
-      )[]
+        | number>
     >(result);
   });
 });

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -221,7 +221,8 @@ describe('isDefined', () => {
     ].filter(isDefined);
     expect(data.length === 4).toEqual(true);
     assertType<
-      Array<| string
+      Array<
+        | string
         | number
         | boolean
         | {
@@ -231,7 +232,8 @@ describe('isDefined', () => {
         | Array<number>
         | Date
         | Error
-        | Promise<number>>
+        | Promise<number>
+      >
     >(data);
   });
 });
@@ -408,12 +410,14 @@ describe('isObject', () => {
       true
     );
     assertType<
-      Array<| {
+      Array<
+        | {
             a: string;
           }
         | Date
         | Error
-        | Promise<number>>
+        | Promise<number>
+      >
     >(data);
   });
 });
@@ -478,7 +482,8 @@ describe('isNot', () => {
     expect(result.some(c => c instanceof Promise)).toEqual(false);
 
     assertType<
-      Array<| boolean
+      Array<
+        | boolean
         | string
         | { a: string }
         | (() => void)
@@ -487,7 +492,8 @@ describe('isNot', () => {
         | undefined
         | null
         | Error
-        | number>
+        | number
+      >
     >(result);
   });
 });

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -11,7 +11,6 @@ import { isObject } from './isObject';
 import { isPromise } from './isPromise';
 import { isTruthy } from './isTruthy';
 import { isString } from './isString';
-import { AssertEqual } from '../src/_types';
 
 type TestObj =
   | boolean
@@ -72,16 +71,14 @@ describe('isString', () => {
     const data = dataProvider('string');
     if (isString(data)) {
       expect(typeof data).toEqual('string');
-      const result: AssertEqual<typeof data, string> = true;
-      expect(result).toEqual(true);
+      assertType<string>(data);
     }
   });
   test('isString: should work even if data type is unknown', () => {
     const data: unknown = dataProvider('string');
     if (isString(data)) {
       expect(typeof data).toEqual('string');
-      const result: AssertEqual<typeof data, string> = true;
-      expect(result).toEqual(true);
+      assertType<string>(data);
     }
   });
 
@@ -92,8 +89,7 @@ describe('isString', () => {
     const x = data();
     if (isString(x)) {
       expect(typeof x).toEqual('string');
-      const result: AssertEqual<typeof x, 'a' | 'b' | 'c'> = true;
-      expect(result).toEqual(true);
+      assertType<'a' | 'b' | 'c'>(x);
     }
   });
   test('isString: should work as type guard in array', () => {
@@ -106,8 +102,7 @@ describe('isString', () => {
       dataProvider('boolean'),
     ].filter(isString);
     expect(data.every(c => typeof c === 'string')).toEqual(true);
-    const result: AssertEqual<typeof data, Array<string>> = true;
-    expect(result).toEqual(true);
+    assertType<string[]>(data);
   });
 });
 
@@ -116,22 +111,19 @@ describe('isBoolean', () => {
     const data = dataProvider('boolean');
     if (isBoolean(data)) {
       expect(typeof data).toEqual('boolean');
-      const result: AssertEqual<typeof data, boolean> = true;
-      expect(result).toEqual(true);
+      assertType<boolean>(data);
     }
 
     const data1: unknown = dataProvider('boolean');
     if (isBoolean(data1)) {
       expect(typeof data1).toEqual('boolean');
-      const result: AssertEqual<typeof data1, boolean> = true;
-      expect(result).toEqual(true);
+      assertType<boolean>(data1);
     }
 
     const data2: any = dataProvider('boolean');
     if (isBoolean(data2)) {
       expect(typeof data2).toEqual('boolean');
-      const result: AssertEqual<typeof data2, boolean> = true;
-      expect(result).toEqual(true);
+      assertType<boolean>(data2);
     }
   });
   test('isBoolean: should work as type guard in filter', () => {
@@ -144,8 +136,7 @@ describe('isBoolean', () => {
       dataProvider('boolean'),
     ].filter(isBoolean);
     expect(data.every(c => typeof c === 'boolean')).toEqual(true);
-    const result: AssertEqual<typeof data, Array<boolean>> = true;
-    expect(result).toEqual(true);
+    assertType<boolean[]>(data);
   });
 });
 
@@ -154,14 +145,12 @@ describe('isArray', () => {
     const data = dataProvider('array');
     if (isArray(data)) {
       expect(Array.isArray(data)).toEqual(true);
-      const result: AssertEqual<typeof data, Array<number>> = true;
-      expect(result).toEqual(true);
+      assertType<number[]>(data);
     }
 
     const data1: unknown = dataProvider('array');
     if (isArray(data1)) {
-      const result: AssertEqual<typeof data1, ReadonlyArray<unknown>> = true;
-      expect(result).toEqual(true);
+      assertType<readonly unknown[]>(data1);
     }
   });
   test('isArray: should work as type guard in filter', () => {
@@ -174,8 +163,7 @@ describe('isArray', () => {
       dataProvider('date'),
     ].filter(isArray);
     expect(data.every(c => Array.isArray(c))).toEqual(true);
-    const result: AssertEqual<typeof data, Array<Array<number>>> = true;
-    expect(result).toEqual(true);
+    assertType<number[][]>(data);
   });
 });
 
@@ -184,14 +172,12 @@ describe('isDate', () => {
     const data = dataProvider('date');
     if (isDate(data)) {
       expect(data instanceof Date).toEqual(true);
-      const result: AssertEqual<typeof data, Date> = true;
-      expect(result).toEqual(true);
+      assertType<Date>(data);
     }
 
     const data1: unknown = dataProvider('date');
     if (isDate(data1)) {
-      const result: AssertEqual<typeof data1, Date> = true;
-      expect(result).toEqual(true);
+      assertType<Date>(data1);
     }
   });
   test('isDate: should work as type guard in filter', () => {
@@ -204,8 +190,7 @@ describe('isDate', () => {
       dataProvider('date'),
     ].filter(isDate);
     expect(data.every(c => c instanceof Date)).toEqual(true);
-    const result: AssertEqual<typeof data, Array<Date>> = true;
-    expect(result).toEqual(true);
+    assertType<Date[]>(data);
   });
 });
 describe('isDefined', () => {
@@ -213,8 +198,7 @@ describe('isDefined', () => {
     const data = dataProvider('date');
     if (isDefined(data)) {
       expect(data instanceof Date).toEqual(true);
-      const result: AssertEqual<
-        typeof data,
+      assertType<
         | boolean
         | string
         | { a: string }
@@ -224,8 +208,7 @@ describe('isDefined', () => {
         | Error
         | number
         | Promise<number>
-      > = true;
-      expect(result).toEqual(true);
+      >(data);
     }
   });
   test('isDefined: should work as type guard in filter', () => {
@@ -237,9 +220,8 @@ describe('isDefined', () => {
       dataProvider('number'),
     ].filter(isDefined);
     expect(data.length === 4).toEqual(true);
-    const result: AssertEqual<
-      typeof data,
-      Array<
+    assertType<
+      (
         | string
         | number
         | boolean
@@ -251,9 +233,8 @@ describe('isDefined', () => {
         | Date
         | Error
         | Promise<number>
-      >
-    > = true;
-    expect(result).toEqual(true);
+      )[]
+    >(data);
   });
 });
 
@@ -262,8 +243,7 @@ describe('isNil', () => {
     const data = dataProvider('null');
     if (isNil(data)) {
       expect(data).toEqual(null);
-      const result: AssertEqual<typeof data, undefined | null> = true;
-      expect(result).toEqual(true);
+      assertType<undefined | null>(data);
     }
   });
   test('isNil: should work as type guard in filter', () => {
@@ -276,8 +256,7 @@ describe('isNil', () => {
       dataProvider('number'),
     ].filter(isNil);
     expect(data.every(c => c == null)).toEqual(true);
-    const result: AssertEqual<typeof data, Array<undefined | null>> = true;
-    expect(result).toEqual(true);
+    assertType<(undefined | null)[]>(data);
   });
 });
 
@@ -286,16 +265,13 @@ describe('isFunction', () => {
     const data = dataProvider('null');
     if (isFunction(data)) {
       expect(data).toEqual(null);
-      const result: AssertEqual<typeof data, () => void> = true;
-      expect(result).toEqual(true);
+      assertType<() => void>(data);
     }
 
     let maybeFunction: string | ((a: number) => string) | undefined;
     if (isFunction(maybeFunction)) {
       maybeFunction(1);
-      const result1: AssertEqual<typeof maybeFunction, (a: number) => string> =
-        true;
-      expect(result1).toEqual(true);
+      assertType<(a: number) => string>(maybeFunction);
     }
   });
   test('isFunction: should work as type guard in filter', () => {
@@ -308,8 +284,7 @@ describe('isFunction', () => {
       dataProvider('number'),
     ].filter(isFunction);
     expect(data.every(c => typeof c === 'function')).toEqual(true);
-    const result: AssertEqual<typeof data, Array<() => void>> = true;
-    expect(result).toEqual(true);
+    assertType<(() => void)[]>(data);
   });
 });
 describe('isError', () => {
@@ -317,16 +292,14 @@ describe('isError', () => {
     const data = dataProvider('error');
     if (isError(data)) {
       expect(data instanceof Error).toEqual(true);
-      const result: AssertEqual<typeof data, Error> = true;
-      expect(result).toEqual(true);
+      assertType<Error>(data);
     }
 
     class MyError extends Error {}
 
     let maybeError: MyError | undefined;
     if (isError(maybeError)) {
-      const result1: AssertEqual<typeof maybeError, MyError> = true;
-      expect(result1).toEqual(true);
+      assertType<MyError>(maybeError);
     }
   });
   test('isError: should work as type guard in filter', () => {
@@ -339,8 +312,7 @@ describe('isError', () => {
       dataProvider('number'),
     ].filter(isError);
     expect(data.every(c => c instanceof Error)).toEqual(true);
-    const result: AssertEqual<typeof data, Array<Error>> = true;
-    expect(result).toEqual(true);
+    assertType<Error[]>(data);
   });
 });
 describe('isNumber', () => {
@@ -348,8 +320,7 @@ describe('isNumber', () => {
     const data = dataProvider('number');
     if (isNumber(data)) {
       expect(typeof data).toEqual('number');
-      const result: AssertEqual<typeof data, number> = true;
-      expect(result).toEqual(true);
+      assertType<number>(data);
     }
   });
   test('isNumber: should work as type guard in filter', () => {
@@ -362,15 +333,13 @@ describe('isNumber', () => {
       dataProvider('number'),
     ].filter(isNumber);
     expect(data.every(c => typeof c === 'number')).toEqual(true);
-    const result: AssertEqual<typeof data, Array<number>> = true;
-    expect(result).toEqual(true);
+    assertType<number[]>(data);
   });
   test('should work even if data type is unknown', () => {
     const data: unknown = dataProvider('number');
     if (isNumber(data)) {
       expect(typeof data).toEqual('number');
-      const result: AssertEqual<typeof data, number> = true;
-      expect(result).toEqual(true);
+      assertType<number>(data);
     }
   });
   test('should work with literal types', () => {
@@ -380,8 +349,7 @@ describe('isNumber', () => {
     const x = data();
     if (isNumber(x)) {
       expect(typeof x).toEqual('number');
-      const result: AssertEqual<typeof x, 1 | 2 | 3> = true;
-      expect(result).toEqual(true);
+      assertType<1 | 2 | 3>(x);
     }
   });
 });
@@ -391,16 +359,14 @@ describe('isObject', () => {
     const data = dataProvider('object');
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      const result: AssertEqual<
-        typeof data,
+      assertType<
         | {
             a: string;
           }
         | Date
         | Error
         | Promise<number>
-      > = true;
-      expect(result).toEqual(true);
+      >(data);
     }
   });
 
@@ -408,13 +374,9 @@ describe('isObject', () => {
     const data = { data: 5 } as ReadonlyArray<number> | { data: 5 };
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      const result: AssertEqual<
-        typeof data,
-        {
-          data: 5;
-        }
-      > = true;
-      expect(result).toEqual(true);
+      assertType<{
+        data: 5;
+      }>(data);
     }
   });
 
@@ -422,13 +384,9 @@ describe('isObject', () => {
     const data = { data: 5 } as Array<number> | { data: number };
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      const result: AssertEqual<
-        typeof data,
-        {
-          data: number;
-        }
-      > = true;
-      expect(result).toEqual(true);
+      assertType<{
+        data: number;
+      }>(data);
     }
   });
 
@@ -436,8 +394,7 @@ describe('isObject', () => {
     const data: unknown = dataProvider('object');
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      const result: AssertEqual<typeof data, Record<string, unknown>> = true;
-      expect(result).toEqual(true);
+      assertType<Record<string, unknown>>(data);
     }
   });
 
@@ -452,18 +409,16 @@ describe('isObject', () => {
     expect(data.every(c => typeof c === 'object' && !Array.isArray(c))).toEqual(
       true
     );
-    const result: AssertEqual<
-      typeof data,
-      Array<
+    assertType<
+      (
         | {
             a: string;
           }
         | Date
         | Error
         | Promise<number>
-      >
-    > = true;
-    expect(result).toEqual(true);
+      )[]
+    >(data);
   });
 });
 
@@ -472,8 +427,7 @@ describe('isPromise', () => {
     const data = dataProvider('promise');
     if (isPromise(data)) {
       expect(data instanceof Promise).toEqual(true);
-      const result: AssertEqual<typeof data, Promise<number>> = true;
-      expect(result).toEqual(true);
+      assertType<Promise<number>>(data);
     }
   });
   test('isPromise: should work as type guard in filter', () => {
@@ -484,8 +438,7 @@ describe('isPromise', () => {
       dataProvider('function'),
     ].filter(isPromise);
     expect(data.every(c => c instanceof Promise)).toEqual(true);
-    const result: AssertEqual<typeof data, Array<Promise<number>>> = true;
-    expect(result).toEqual(true);
+    assertType<Promise<number>[]>(data);
   });
 });
 describe('isTruthy', () => {
@@ -493,8 +446,7 @@ describe('isTruthy', () => {
     const data: false | '' | 0 | { a: string } = { a: 'asd' };
     if (isTruthy(data)) {
       expect(data).toEqual({ a: 'asd' });
-      const result: AssertEqual<typeof data, { a: string }> = true;
-      expect(result).toEqual(true);
+      assertType<{ a: string }>(data);
     }
   });
 });
@@ -503,8 +455,7 @@ describe('isNot', () => {
     const data = dataProvider('promise');
     if (isNot(isString)(data)) {
       expect(data instanceof Promise).toEqual(true);
-      const result: AssertEqual<
-        typeof data,
+      assertType<
         | number
         | boolean
         | {
@@ -517,8 +468,7 @@ describe('isNot', () => {
         | Promise<number>
         | null
         | undefined
-      > = true;
-      expect(result).toEqual(true);
+      >(data);
     }
   });
   test('isNot: should work as type guard in filter', () => {
@@ -531,9 +481,8 @@ describe('isNot', () => {
     const result = data.filter(isNot(isPromise));
     expect(result.some(c => c instanceof Promise)).toEqual(false);
 
-    const resultType: AssertEqual<
-      typeof result,
-      Array<
+    assertType<
+      (
         | boolean
         | string
         | { a: string }
@@ -544,8 +493,7 @@ describe('isNot', () => {
         | null
         | Error
         | number
-      >
-    > = true;
-    expect(resultType).toEqual(true);
+      )[]
+    >(result);
   });
 });

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -1,6 +1,5 @@
 import { keys } from './keys';
 import { pipe } from './pipe';
-import { AssertEqual } from './_types';
 
 describe('Test for keys', () => {
   it('should return keys of array', () => {
@@ -16,9 +15,7 @@ describe('Test for keys', () => {
       const actual = keys.strict({ 5: 'x', b: 'y', c: 'z' } as const);
       expect(actual).toEqual(['5', 'b', 'c']);
 
-      const result: AssertEqual<typeof actual, Array<'5' | 'b' | 'c'>> = true;
-
-      expect(result).toEqual(true);
+      assertType<Array<'5' | 'b' | 'c'>>(actual);
     });
 
     it('should work with Partial in pipe', () => {
@@ -29,9 +26,7 @@ describe('Test for keys', () => {
       const actual = pipe(data, keys.strict);
       expect(actual).toEqual(['foo', 'bar']);
 
-      const result: AssertEqual<typeof actual, Array<'foo' | 'bar'>> = true;
-
-      expect(result).toEqual(true);
+      assertType<Array<'foo' | 'bar'>>(actual);
     });
   });
 });

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -1,6 +1,6 @@
 import { last } from './last';
 import { pipe } from './pipe';
-import { AssertEqual, NonEmptyArray } from './_types';
+import { NonEmptyArray } from './_types';
 
 describe('last', () => {
   describe('data first', () => {
@@ -27,21 +27,18 @@ describe('last', () => {
     test('should return T | undefined for Array input', () => {
       const input: Array<number> = [1, 2, 3];
       const actual = last(input);
-      const result: AssertEqual<typeof actual, number | undefined> = true;
-      expect(result).toEqual(true);
+      assertType<number | undefined>(actual);
     });
 
     test('should not return undefined for non empty arrays', () => {
       const input: NonEmptyArray<number> = [1, 2, 3];
       const data = last(input);
-      const result: AssertEqual<typeof data, number> = true;
-      expect(result).toEqual(true);
+      assertType<number>(data);
     });
 
     test('should infer type in pipes', () => {
       const data = pipe('this is a text', data => data.split(''), last());
-      const result: AssertEqual<typeof data, string | undefined> = true;
-      expect(result).toEqual(true);
+      assertType<string | undefined>(data);
     });
   });
 });

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -1,6 +1,5 @@
 import { omitBy } from './omitBy';
 import { pipe } from './pipe';
-import { AssertEqual } from './_types';
 
 describe('data first', () => {
   test('it should omit props', () => {
@@ -8,24 +7,16 @@ describe('data first', () => {
       { a: 1, b: 2, A: 3, B: 4 },
       (val, key) => key.toUpperCase() === key
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Record<'a' | 'b' | 'A' | 'B', number>
-    > = true;
+    assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
-    expect(resultType).toStrictEqual(true);
   });
   test('allow partial type', () => {
     const result = omitBy(
       {} as Partial<{ a: string; b: number }>,
       (val, key) => key === 'a'
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Partial<{ a: string; b: number }>
-    > = true;
+    assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
-    expect(resultType).toStrictEqual(true);
   });
 });
 
@@ -35,23 +26,15 @@ describe('data last', () => {
       { a: 1, b: 2, A: 3, B: 4 },
       omitBy((val, key) => key.toUpperCase() === key)
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Record<'a' | 'b' | 'A' | 'B', number>
-    > = true;
+    assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
-    expect(resultType).toStrictEqual(true);
   });
   test('allow partial type', () => {
     const result = pipe(
       {} as Partial<{ a: string; b: number }>,
       omitBy((val, key) => key.toUpperCase() === key)
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Partial<{ a: string; b: number }>
-    > = true;
+    assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
-    expect(resultType).toStrictEqual(true);
   });
 });

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -1,6 +1,5 @@
 import { partition } from './partition';
 import { pipe } from './pipe';
-import { AssertEqual } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -30,9 +29,7 @@ describe('data first', () => {
       [1, 2],
       ['a', 'b'],
     ]);
-    const result: AssertEqual<typeof actual, [Array<number>, Array<string>]> =
-      true;
-    expect(result).toBe(true);
+    assertType<[number[], string[]]>(actual);
   });
   test('partition with type guard in pipe', () => {
     const actual = pipe(
@@ -45,9 +42,7 @@ describe('data first', () => {
       [1, 2],
       ['a', 'b'],
     ]);
-    const result: AssertEqual<typeof actual, [Array<number>, Array<string>]> =
-      true;
-    expect(result).toBe(true);
+    assertType<[Array<number>, Array<string>]>(actual);
   });
   test('partition.indexed', () => {
     expect(partition.indexed(array, (_, index) => index !== 2)).toEqual(

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -29,7 +29,7 @@ describe('data first', () => {
       [1, 2],
       ['a', 'b'],
     ]);
-    assertType<[number[], string[]]>(actual);
+    assertType<[Array<number>, Array<string>]>(actual);
   });
   test('partition with type guard in pipe', () => {
     const actual = pipe(

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -1,6 +1,5 @@
 import { pickBy } from './pickBy';
 import { pipe } from './pipe';
-import { AssertEqual } from './_types';
 
 describe('data first', () => {
   test('it should pick props', () => {
@@ -8,12 +7,8 @@ describe('data first', () => {
       { a: 1, b: 2, A: 3, B: 4 },
       (val, key) => key.toUpperCase() === key
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Record<'a' | 'b' | 'A' | 'B', number>
-    > = true;
+    assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
-    expect(resultType).toStrictEqual(true);
   });
   test('allow undefined or null', () => {
     expect(pickBy(undefined as any, (val, key) => key === 'foo')).toEqual({});
@@ -24,12 +19,8 @@ describe('data first', () => {
       {} as { a?: string; b?: number },
       (val, key) => key === 'a'
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Partial<{ a: string; b: number }>
-    > = true;
+    assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
-    expect(resultType).toStrictEqual(true);
   });
 });
 
@@ -39,23 +30,15 @@ describe('data last', () => {
       { a: 1, b: 2, A: 3, B: 4 },
       pickBy((val, key) => key.toUpperCase() === key)
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Record<'a' | 'b' | 'A' | 'B', number>
-    > = true;
+    assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
-    expect(resultType).toStrictEqual(true);
   });
   test('allow partial type', () => {
     const result = pipe(
       {} as { a?: string; b?: number },
       pickBy((val, key) => key.toUpperCase() === key)
     );
-    const resultType: AssertEqual<
-      typeof result,
-      Partial<{ a: string; b: number }>
-    > = true;
+    assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
-    expect(resultType).toStrictEqual(true);
   });
 });

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -9,7 +9,7 @@ describe('data first', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = reverse([1, 2, 3]);
-      assertType<number[]>(actual);
+      assertType<Array<number>>(actual);
     });
     test('tuples', () => {
       const actual = reverse([1, 2, [true], 'a'] as const);
@@ -32,7 +32,7 @@ describe('data last', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = pipe([1, 2, 3], reverse());
-      assertType<number[]>(actual);
+      assertType<Array<number>>(actual);
     });
     test('tuples', () => {
       const actual = pipe([1, 2, [true], 'a'] as const, reverse());

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -1,6 +1,5 @@
-import { pipe } from './pipe';
 import { reverse } from './reverse';
-import { AssertEqual } from './_types';
+import { pipe } from './pipe';
 
 describe('data first', () => {
   test('reverse', () => {
@@ -10,22 +9,17 @@ describe('data first', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = reverse([1, 2, 3]);
-      const result: AssertEqual<typeof actual, Array<number>> = true;
-      expect(result).toEqual(true);
+      assertType<number[]>(actual);
     });
     test('tuples', () => {
       const actual = reverse([1, 2, [true], 'a'] as const);
-      const result: AssertEqual<typeof actual, ['a', readonly [true], 2, 1]> =
-        true;
-      expect(result).toEqual(true);
+      assertType<['a', readonly [true], 2, 1]>(actual);
     });
 
     test('variadic tuples', () => {
       const input: [number, ...Array<string>] = [1, 'two', 'three'];
       const actual = reverse(input);
-      const result: AssertEqual<typeof actual, [...Array<string>, number]> =
-        true;
-      expect(result).toEqual(true);
+      assertType<[...Array<string>, number]>(actual);
     });
   });
 });
@@ -38,22 +32,17 @@ describe('data last', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = pipe([1, 2, 3], reverse());
-      const result: AssertEqual<typeof actual, Array<number>> = true;
-      expect(result).toEqual(true);
+      assertType<number[]>(actual);
     });
     test('tuples', () => {
       const actual = pipe([1, 2, [true], 'a'] as const, reverse());
-      const result: AssertEqual<typeof actual, ['a', readonly [true], 2, 1]> =
-        true;
-      expect(result).toEqual(true);
+      assertType<['a', readonly [true], 2, 1]>(actual);
     });
 
     test('variadic tuples', () => {
       const input: [number, ...Array<string>] = [1, 'two', 'three'];
       const actual = pipe(input, reverse());
-      const result: AssertEqual<typeof actual, [...Array<string>, number]> =
-        true;
-      expect(result).toEqual(true);
+      assertType<[...Array<string>, number]>(actual);
     });
   });
 });

--- a/src/toPairs.test.ts
+++ b/src/toPairs.test.ts
@@ -1,5 +1,4 @@
 import { toPairs } from './toPairs';
-import type { AssertEqual } from './_types';
 
 test('should return pairs', () => {
   const actual = toPairs({ a: 1, b: 2, c: 3 });
@@ -21,26 +20,17 @@ test('should return pairs, strict', () => {
 
 test('stricter typing', () => {
   const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as const);
-  const isEqual: AssertEqual<
-    typeof actual,
-    Array<['a' | 'b' | 'c', 1 | 2 | 3]>
-  > = true;
-  expect(isEqual).toEqual(true);
+  assertType<Array<['a' | 'b' | 'c', 1 | 2 | 3]>>(actual);
 });
 
 test('stricter typing with optional', () => {
   const actual = toPairs.strict({} as { a?: string });
-  const isEqual: AssertEqual<typeof actual, Array<['a', string]>> = true;
-  expect(isEqual).toEqual(true);
+  assertType<Array<['a', string]>>(actual);
 });
 
 test('stricter typing with undefined', () => {
   const actual = toPairs.strict({ a: undefined } as { a: string | undefined });
-  const isEqual: AssertEqual<
-    typeof actual,
-    Array<['a', string | undefined]>
-  > = true;
-  expect(isEqual).toEqual(true);
+  assertType<Array<['a', string | undefined]>>(actual);
 });
 
 test('stricter with a broad type', () => {
@@ -48,6 +38,6 @@ test('stricter with a broad type', () => {
     string,
     unknown
   >);
-  const isEqual: AssertEqual<typeof actual, Array<[string, unknown]>> = true;
-  expect(isEqual).toEqual(true);
+
+  assertType<Array<[string, unknown]>>(actual);
 });

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -36,10 +36,6 @@ describe('data first typings', () => {
     const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
     assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
   });
-  test('tuples', () => {
-    const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
-    assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
-  });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -30,7 +30,7 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('arrays', () => {
     const actual = zip(first, second);
-    assertType<[number, string][]>(actual);
+    assertType<Array<[number, string]>>(actual);
   });
   test('tuples', () => {
     const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
@@ -38,13 +38,13 @@ describe('data first typings', () => {
   });
   test('tuples', () => {
     const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
-    assertType<[1 | 2 | 3, 'a' | 'b' | 'c'][]>(actual);
+    assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
   });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
     const actual = zip(firstVariadic, secondVariadic);
-    assertType<[string | number, string | number][]>(actual);
+    assertType<Array<[string | number, string | number]>>(actual);
   });
 });
 
@@ -73,16 +73,16 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('arrays', () => {
     const actual = zip(second)(first);
-    assertType<[number, string][]>(actual);
+    assertType<Array<[number, string]>>(actual);
   });
   test('tuples', () => {
     const actual = zip(second as ['a', 'b', 'c'])(first as [1, 2, 3]);
-    assertType<[1 | 2 | 3, 'a' | 'b' | 'c'][]>(actual);
+    assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
   });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
     const actual = zip(secondVariadic)(firstVariadic);
-    assertType<[string | number, string | number][]>(actual);
+    assertType<Array<[string | number, string | number]>>(actual);
   });
 });

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,5 +1,4 @@
 import { zip } from './zip';
-import { AssertEqual } from './_types';
 
 const first = [1, 2, 3];
 const second = ['a', 'b', 'c'];
@@ -31,26 +30,21 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('arrays', () => {
     const actual = zip(first, second);
-    const result: AssertEqual<typeof actual, Array<[number, string]>> = true;
-    expect(result).toBe(true);
+    assertType<[number, string][]>(actual);
   });
   test('tuples', () => {
     const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
-    const result: AssertEqual<
-      typeof actual,
-      Array<[1 | 2 | 3, 'a' | 'b' | 'c']>
-    > = true;
-    expect(result).toBe(true);
+    assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
+  });
+  test('tuples', () => {
+    const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
+    assertType<[1 | 2 | 3, 'a' | 'b' | 'c'][]>(actual);
   });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
     const actual = zip(firstVariadic, secondVariadic);
-    const result: AssertEqual<
-      typeof actual,
-      Array<[string | number, string | number]>
-    > = true;
-    expect(result).toBe(true);
+    assertType<[string | number, string | number][]>(actual);
   });
 });
 
@@ -79,25 +73,16 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('arrays', () => {
     const actual = zip(second)(first);
-    const result: AssertEqual<typeof actual, Array<[number, string]>> = true;
-    expect(result).toBe(true);
+    assertType<[number, string][]>(actual);
   });
   test('tuples', () => {
     const actual = zip(second as ['a', 'b', 'c'])(first as [1, 2, 3]);
-    const result: AssertEqual<
-      typeof actual,
-      Array<[1 | 2 | 3, 'a' | 'b' | 'c']>
-    > = true;
-    expect(result).toBe(true);
+    assertType<[1 | 2 | 3, 'a' | 'b' | 'c'][]>(actual);
   });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
     const actual = zip(secondVariadic)(firstVariadic);
-    const result: AssertEqual<
-      typeof actual,
-      Array<[string | number, string | number]>
-    > = true;
-    expect(result).toBe(true);
+    assertType<[string | number, string | number][]>(actual);
   });
 });

--- a/src/zipWith.test.ts
+++ b/src/zipWith.test.ts
@@ -1,5 +1,4 @@
 import { zipWith } from './zipWith';
-import { AssertEqual } from './_types';
 
 const pred = (a: string, b: string) => a + b;
 
@@ -23,8 +22,7 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(first, second, pred);
-    const result: AssertEqual<typeof actual, Array<string>> = true;
-    expect(result).toBe(true);
+    assertType<string[]>(actual);
   });
 });
 
@@ -43,8 +41,7 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred)(first, second);
-    const result: AssertEqual<typeof actual, Array<string>> = true;
-    expect(result).toBe(true);
+    assertType<string[]>(actual);
   });
 });
 
@@ -63,7 +60,6 @@ describe('data second with initial arg', () => {
 describe('data second with initial arg typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred, second)(first);
-    const result: AssertEqual<typeof actual, Array<string>> = true;
-    expect(result).toBe(true);
+    assertType<string[]>(actual);
   });
 });

--- a/src/zipWith.test.ts
+++ b/src/zipWith.test.ts
@@ -22,7 +22,7 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(first, second, pred);
-    assertType<string[]>(actual);
+    assertType<Array<string>>(actual);
   });
 });
 
@@ -41,7 +41,7 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred)(first, second);
-    assertType<string[]>(actual);
+    assertType<Array<string>>(actual);
   });
 });
 
@@ -60,6 +60,6 @@ describe('data second with initial arg', () => {
 describe('data second with initial arg typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred, second)(first);
-    assertType<string[]>(actual);
+    assertType<Array<string>>(actual);
   });
 });


### PR DESCRIPTION
See https://github.com/remeda/remeda/pull/238#issuecomment-1383131398

Basically, use the `expectType` function of `ts-expect` to check for types instead of the bespoke checking that was there. Technically it does the same thing, the syntax is just a wee bit shorter. 