### PR TITLE
add zipObj

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -76,6 +76,9 @@ documentation when migrating._
 | `uniq`           | `uniq`           | `uniq`              |
 | `uniqBy`         | `uniqBy`         | `uniqBy`            |
 | `uniqWith`       | `uniqWith`       | `uniqWith`          |
+| `zip`            | `zip `           |                     |
+| `zipObj`         | `zipObject`      |                     |
+
 
 ### Helpful one-liners
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,4 +75,5 @@ export * from './uniqBy';
 export * from './uniqWith';
 export * from './values';
 export * from './zip';
+export * from './zipObj';
 export * from './zipWith';

--- a/src/zipObj.test.ts
+++ b/src/zipObj.test.ts
@@ -1,0 +1,41 @@
+import { zipObj } from './zipObj';
+
+const expectType = <E>(result: E) => result;
+
+describe('data first', () => {
+  test('equal lengths', () => {
+    const result = zipObj(['a', 'b'], [1, 2]);
+
+    expectType<Record<string, number>>(result);
+
+    expect(result).toEqual({
+      a: 1,
+      b: 2,
+    });
+  });
+  test('more keys', () => {
+    expect(zipObj(['a', 'b', 'c'], [1, 2])).toEqual({
+      a: 1,
+      b: 2,
+      c: undefined,
+    });
+  });
+  test('more values', () => {
+    expect(() => zipObj(['a', 'b'], [1, 2, 2])).toThrow(
+      'Number of values exceeds number of keys (2 keys, 3 values)'
+    );
+  });
+});
+
+describe('data last', () => {
+  test('equal lengths', () => {
+    const partial = zipObj([1, 2]);
+
+    expectType<(keys: any[]) => Record<any, number>>(partial);
+
+    expect(partial(['a', 'b'])).toEqual({
+      a: 1,
+      b: 2,
+    });
+  });
+});

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -16,7 +16,7 @@ import { zip } from './zip';
  * @data_first
  * @category Object
  */
-export function zipObj<K extends any, V extends any>(
+export function zipObj<K extends string | number | symbol, V extends any>(
   keys: ReadonlyArray<K>,
   values: ReadonlyArray<V>
 ): Record<K, V>;
@@ -37,7 +37,7 @@ export function zipObj<K extends any, V extends any>(
  */
 export function zipObj<V extends any>(
   values: ReadonlyArray<V>
-): <K extends any>(keys: ReadonlyArray<K>) => Record<K, V>;
+): <K extends string | number | symbol>(keys: ReadonlyArray<K>) => Record<K, V>;
 
 export function zipObj() {
   return purry(_zipObj, arguments);

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -1,0 +1,60 @@
+import { purry } from './purry';
+import { zip } from './zip';
+
+/**
+ * Creates a new object from a list of keys and a list of values.
+ * If the list of keys is longer than the list of values, the unmatches
+ * keys will have a value of `undefined`. If the list of values is longer than
+ * the list of keys, an error will be throw (TODO: is that the desired
+ * behavior?)
+ * @param keys the list of keys
+ * @param values the list of values
+ * @signature
+ *   R.zipObj(keys, values)
+ * @example
+ *   R.zip(['a', 'b'],[1,2]) // => { a: 1, b: 2 }
+ * @data_first
+ * @category Object
+ */
+export function zipObj<K extends any, V extends any>(
+  keys: ReadonlyArray<K>,
+  values: ReadonlyArray<V>
+): Record<K, V>;
+
+/**
+ * Creates a new object from a list of keys and a list of values.
+ * If the list of keys is longer than the list of values, the unmatches
+ * keys will have a value of `undefined`. If the list of values is longer than
+ * the list of keys, an error will be throw (TODO: does it make sense to have a
+ * data last version of this function?)
+ * @param values the list of values
+ * @signature
+ *   R.zip(values)(keys)
+ * @example
+ *   R.zip([1, 2])(['a', 'b']) // => { a: 1, b: 2 }
+ * @data_last
+ * @category Object
+ */
+export function zipObj<V extends any>(
+  values: ReadonlyArray<V>
+): <K extends any>(keys: ReadonlyArray<K>) => Record<K, V>;
+
+export function zipObj() {
+  return purry(_zipObj, arguments);
+}
+
+function _zipObj(keys: Array<unknown>, values: Array<unknown>) {
+  const keysLength = keys.length;
+  const valuesLength = values.length;
+
+  if (valuesLength > keysLength)
+    throw new Error(
+      `Number of values exceeds number of keys (${keysLength} keys, ${valuesLength} values)`
+    );
+
+  if (valuesLength < keysLength) {
+    values = values.concat(Array(keys.length - values.length).fill(undefined));
+  }
+
+  return Object.fromEntries(zip(keys, values));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 
     "lib": [
       "es6",
-      "es2017.object"
+      "es2017.object",
+      "es2019"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
For #72 

There are two TBDs in there:

1. If there are more values than keys passed in, I throw an error. Do we want to be more forgiving?
2. I've added the data last, curried version of the function, but in this instance it doesn't seem super-useful Should it be there for uniformity's sake, or should it be removed?

---

Make sure that you:

- [x ] Typedoc added for new methods and updated for changed
- [ x] Tests added for new methods and updated for changed
- [ x] New methods added to `src/index.ts`
- [ x] New methods added to `mapping.md`
