### PR TITLE
feat(groupBy): add support for generic key types

### DIFF
--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -84,4 +84,13 @@ describe('Result key types', () => {
     > = true;
     expect(result).toEqual(true);
   });
+  test('string | number', () => {
+    const data = groupBy(array2, (x):  string | number => x.b);
+    const result: AssertEqual<
+      typeof data,
+      Record<string | number, NonEmptyArray<Array2Item>>
+    > = true;
+    expect(result).toEqual(true);
+  });
 });
+

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -85,7 +85,7 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
   test('string | number', () => {
-    const data = groupBy(array2, (x):  string | number => x.b);
+    const data = groupBy(array2, (x): string | number => x.b);
     const result: AssertEqual<
       typeof data,
       Record<string | number, NonEmptyArray<Array2Item>>
@@ -93,4 +93,3 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
 });
-

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,5 +1,6 @@
 import { groupBy } from './groupBy';
 import { pipe } from './pipe';
+import { AssertEqual, NonEmptyArray } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -15,6 +16,12 @@ const expected = {
   ],
   2: [{ a: 2, b: 1 }],
 };
+
+const array2 = [
+  { a: 'cat', b: 123 },
+  { a: 'dog', b: 456 },
+] as const;
+type Array2Item = typeof array2[number];
 
 describe('data first', () => {
   test('groupBy', () => {
@@ -41,5 +48,40 @@ describe('data last', () => {
         groupBy.indexed(x => x.a)
       )
     ).toEqual(expected);
+  });
+});
+
+describe('Result key types', () => {
+  test('Union of string literals', () => {
+    const data = groupBy(array2, x => x.a);
+    const result: AssertEqual<
+      typeof data,
+      Partial<Record<'cat' | 'dog', NonEmptyArray<Array2Item>>>
+    > = true;
+    expect(result).toEqual(true);
+  });
+  test('Union of number literals', () => {
+    const data = groupBy(array2, x => x.b);
+    const result: AssertEqual<
+      typeof data,
+      Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>
+    > = true;
+    expect(result).toEqual(true);
+  });
+  test('string', () => {
+    const data = groupBy(array2, (x): string => x.a);
+    const result: AssertEqual<
+      typeof data,
+      Record<string, NonEmptyArray<Array2Item>>
+    > = true;
+    expect(result).toEqual(true);
+  });
+  test('number', () => {
+    const data = groupBy(array2, (x): number => x.b);
+    const result: AssertEqual<
+      typeof data,
+      Record<number, NonEmptyArray<Array2Item>>
+    > = true;
+    expect(result).toEqual(true);
   });
 });

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -53,7 +53,7 @@ describe('data last', () => {
 
 describe('Result key types', () => {
   test('Union of string literals', () => {
-    const data = groupBy(array2, x => x.a);
+    const data = groupBy.strict(array2, x => x.a);
     const result: AssertEqual<
       typeof data,
       Partial<Record<'cat' | 'dog', NonEmptyArray<Array2Item>>>
@@ -61,7 +61,7 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
   test('Union of number literals', () => {
-    const data = groupBy(array2, x => x.b);
+    const data = groupBy.strict(array2, x => x.b);
     const result: AssertEqual<
       typeof data,
       Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>
@@ -69,7 +69,7 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
   test('string', () => {
-    const data = groupBy(array2, (x): string => x.a);
+    const data = groupBy.strict(array2, (x): string => x.a);
     const result: AssertEqual<
       typeof data,
       Record<string, NonEmptyArray<Array2Item>>
@@ -77,7 +77,7 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
   test('number', () => {
-    const data = groupBy(array2, (x): number => x.b);
+    const data = groupBy.strict(array2, (x): number => x.b);
     const result: AssertEqual<
       typeof data,
       Record<number, NonEmptyArray<Array2Item>>
@@ -85,7 +85,7 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
   test('string | number', () => {
-    const data = groupBy(array2, (x): string | number => x.b);
+    const data = groupBy.strict(array2, (x): string | number => x.b);
     const result: AssertEqual<
       typeof data,
       Record<string | number, NonEmptyArray<Array2Item>>

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { NonEmptyArray, PredIndexed, PredIndexedOptional } from './_types';
+import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
 
 // Records keyed with generic `string` and `number` have different semantics
 // to those with a a union of literal values (e.g. 'cat' | 'dog') when using

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
+import { NonEmptyArray, PredIndexed, PredIndexedOptional } from './_types';
 
 // Records keyed with generic `string` and `number` have different semantics
 // to those with a a union of literal values (e.g. 'cat' | 'dog') when using
@@ -8,18 +8,17 @@ import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
 // record by definition, we need to make sure the result is properly partial
 // when using it with a refined key.
 type Out<Value, Key extends PropertyKey = PropertyKey> =
-  // Key === string
+  // If either string, number or symbol extend Key it means that Key is at least
+  // as wide as them, so we don't need to wrap the returned record with Partial.
   string extends Key
-    ? Record<string, NonEmptyArray<Value>>
-    : // Key === number
-    number extends Key
-    ? Record<number, NonEmptyArray<Value>>
-    : // Key === symbol (do we need this case? can symbols be generic?)
-    symbol extends Key
-    ? Record<symbol, NonEmptyArray<Value>>
-    : // If the key is specific, e.g. 'cat' | 'dog', the result is partial because
-      // we can't statically know what values the mapper would return on a
-      // specific input
+    ? Record<Key, NonEmptyArray<Value>>
+    : number extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : symbol extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
+      // because we can't statically know what values the mapper would return on
+      // a specific input
       Partial<Record<Key, NonEmptyArray<Value>>>;
 
 /**

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,46 +1,29 @@
 import { purry } from './purry';
 import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
 
-// Records keyed with generic `string` and `number` have different semantics
-// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
-// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
-// the latter are implicitly `Required`. Because groupBy returns a partial
-// record by definition, we need to make sure the result is properly partial
-// when using it with a refined key.
-type Out<Value, Key extends PropertyKey = PropertyKey> =
-  // If either string, number or symbol extend Key it means that Key is at least
-  // as wide as them, so we don't need to wrap the returned record with Partial.
-  string extends Key
-    ? Record<Key, NonEmptyArray<Value>>
-    : number extends Key
-    ? Record<Key, NonEmptyArray<Value>>
-    : symbol extends Key
-    ? Record<Key, NonEmptyArray<Value>>
-    : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
-      // because we can't statically know what values the mapper would return on
-      // a specific input
-      Partial<Record<Key, NonEmptyArray<Value>>>;
-
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.
  * @param items the items to group
  * @param fn the grouping function
  * @signature
  *    R.groupBy(array, fn)
+ *    R.groupBy.strict(array, fn)
  * @example
  *    R.groupBy(['one', 'two', 'three'], x => x.length) // => {3: ['one', 'two'], 5: ['three']}
+ *    R.groupBy.strict([{a: 'cat'}, {b: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
  * @data_first
  * @indexed
+ * @strict
  * @category Array
  */
-export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
-  items: readonly Value[],
-  fn: (item: Value) => Key
-): Out<Value, Key>;
+export function groupBy<T>(
+  items: readonly T[],
+  fn: (item: T) => PropertyKey
+): Record<PropertyKey, NonEmptyArray<T>>;
 
-export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
-  fn: (item: Value) => Key
-): (array: readonly Value[]) => Out<Value, Key>;
+export function groupBy<T>(
+  fn: (item: T) => PropertyKey
+): (array: readonly T[]) => Record<PropertyKey, NonEmptyArray<T>>;
 
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.
@@ -72,15 +55,60 @@ const _groupBy =
     return ret;
   };
 
+// Records keyed with generic `string` and `number` have different semantics
+// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
+// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
+// the latter are implicitly `Required`. Because groupBy returns a partial
+// record by definition, we need to make sure the result is properly partial
+// when using it with a refined key.
+type Out<Value, Key extends PropertyKey = PropertyKey> =
+  // If either string, number or symbol extend Key it means that Key is at least
+  // as wide as them, so we don't need to wrap the returned record with Partial.
+  string extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : number extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : symbol extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
+      // because we can't statically know what values the mapper would return on
+      // a specific input
+      Partial<Record<Key, NonEmptyArray<Value>>>;
+
 export namespace groupBy {
-  export function indexed<Value, Key extends PropertyKey = PropertyKey>(
-    array: readonly Value[],
-    fn: PredIndexed<Value, Key>
-  ): Out<Value, Key>;
-  export function indexed<Value, Key extends PropertyKey = PropertyKey>(
-    fn: PredIndexed<Value, Key>
-  ): (array: readonly Value[]) => Out<Value, Key>;
+  export function indexed<T, K>(
+    array: readonly T[],
+    fn: PredIndexed<T, PropertyKey>
+  ): Record<string, NonEmptyArray<T>>;
+  export function indexed<T, K>(
+    fn: PredIndexed<T, PropertyKey>
+  ): (array: readonly T[]) => Record<string, NonEmptyArray<T>>;
   export function indexed() {
     return purry(_groupBy(true), arguments);
+  }
+  export function strict<Value, Key extends PropertyKey = PropertyKey>(
+    items: readonly Value[],
+    fn: (item: Value) => Key
+  ): Out<Value, Key>;
+
+  export function strict<Value, Key extends PropertyKey = PropertyKey>(
+    fn: (item: Value) => Key
+  ): (array: readonly Value[]) => Out<Value, Key>;
+
+  export function strict() {
+    return purry(_groupBy(false), arguments);
+  }
+
+  export namespace strict {
+    export function indexed<Value, Key extends PropertyKey = PropertyKey>(
+      array: readonly Value[],
+      fn: PredIndexed<Value, Key>
+    ): Out<Value, Key>;
+    export function indexed<Value, Key extends PropertyKey = PropertyKey>(
+      fn: PredIndexed<Value, Key>
+    ): (array: readonly Value[]) => Out<Value, Key>;
+    export function indexed() {
+      return purry(_groupBy(true), arguments);
+    }
   }
 }


### PR DESCRIPTION
`groupBy` currently doesn't support refined types for it's grouper function, so you lose typing information in cases where those are available.

This diff only touches typing, and doesn't change anything in the runtime behaviour of the function.

It maintains backwards compatibility by still returning `Record<string, T>` if the grouper function returns a string. And for literal unions it will return a Partial record.

I tried adding tests, and they do provide some protection, but I'm not sure I'm using AssertEqual correctly, as it doesn't fail on the wrong types (sometimes). I validated manually via the IDE that the types returned are correct. 

Fixes: #262

---

Make sure that you:

- [?] Typedoc added for new methods and updated for changed
- [+] Tests added for new methods and updated for changed
- [-] New methods added to `src/index.ts`
- [-] New methods added to `mapping.md`
