### PR TITLE
feat(toPairs): Add 'strict' flavour

### DIFF
--- a/src/toPairs.test.ts
+++ b/src/toPairs.test.ts
@@ -1,4 +1,5 @@
 import { toPairs } from './toPairs';
+import type { AssertEqual } from './_types';
 
 test('should return pairs', () => {
   const actual = toPairs({ a: 1, b: 2, c: 3 });
@@ -7,4 +8,46 @@ test('should return pairs', () => {
     ['b', 2],
     ['c', 3],
   ]);
+});
+
+test('should return pairs, strict', () => {
+  const actual = toPairs.strict({ a: 1, b: 2, c: 3 });
+  expect(actual).toEqual([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ]);
+});
+
+test('stricter typing', () => {
+  const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as const);
+  const isEqual: AssertEqual<
+    typeof actual,
+    Array<['a' | 'b' | 'c', 1 | 2 | 3]>
+  > = true;
+  expect(isEqual).toEqual(true);
+});
+
+test('stricter typing with optional', () => {
+  const actual = toPairs.strict({} as { a?: string });
+  const isEqual: AssertEqual<typeof actual, Array<['a', string]>> = true;
+  expect(isEqual).toEqual(true);
+});
+
+test('stricter typing with undefined', () => {
+  const actual = toPairs.strict({ a: undefined } as { a: string | undefined });
+  const isEqual: AssertEqual<
+    typeof actual,
+    Array<['a', string | undefined]>
+  > = true;
+  expect(isEqual).toEqual(true);
+});
+
+test('stricter with a broad type', () => {
+  const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as Record<
+    string,
+    unknown
+  >);
+  const isEqual: AssertEqual<typeof actual, Array<[string, unknown]>> = true;
+  expect(isEqual).toEqual(true);
 });

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -3,10 +3,37 @@
  * @param object
  * @signature
  *    R.toPairs(object)
+ *    R.toPairs.strict(object)
  * @example
  *    R.toPairs({ a: 1, b: 2, c: 3 }) // => [['a', 1], ['b', 2], ['c', 3]]
+ *    R.toPairs.strict({ a: 1 } as { a?: number }) // => [['a', 1]] typed Array<['a', number]>
+ * @strict
  * @category Object
  */
 export function toPairs<T>(object: { [s: string]: T }): Array<[string, T]> {
   return Object.entries(object);
+}
+
+// Inspired and largely copied from `sindresorhus/ts-extras`:
+// @see https://github.com/sindresorhus/ts-extras/blob/44f57392c5f027268330771996c4fdf9260b22d6/source/object-keys.ts
+// @see https://github.com/sindresorhus/ts-extras/blob/44f57392c5f027268330771996c4fdf9260b22d6/source/object-entries.ts
+type ObjectKeys<T extends object> = `${Exclude<keyof T, symbol>}`;
+type ObjectValues<T extends Record<PropertyKey, unknown>> =
+  Required<T>[ObjectKeys<T>];
+type ObjectEntry<T extends Record<PropertyKey, unknown>> = [
+  ObjectKeys<T>,
+  ObjectValues<T>
+];
+type ObjectEntries<T extends Record<PropertyKey, unknown>> = Array<
+  ObjectEntry<T>
+>;
+
+export namespace toPairs {
+  export function strict<T extends Record<PropertyKey, unknown>>(
+    object: T
+  ): ObjectEntries<T> {
+    // @ts-expect-error [ts2322] - This is deliberately stricter than what TS
+    // provides out of the box.
+    return Object.entries(object);
+  }
 }

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -6,7 +6,7 @@
  *    R.toPairs.strict(object)
  * @example
  *    R.toPairs({ a: 1, b: 2, c: 3 }) // => [['a', 1], ['b', 2], ['c', 3]]
- *    R.toPairs.strict({ a: 1 } as { a?: number }) // => [['a', 1]] typed Array<['a', number]>
+ *    R.toPairs.strict({ a: 1 } as const) // => [['a', 1]] typed Array<['a', 1]>
  * @strict
  * @category Object
  */


### PR DESCRIPTION
Similar to `keys`, the existing `toPairs` function strips the typing of the object keys. Taking inspiration and largley copying the work in ts-extra's objectEntries, this version of toPairs will return the strictest type for the entries tuple.

I've added it as a strict option instead of replacing the `toPairs` impl for backwards compatibility and to align with `keys`.
---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`
