### PR TITLE
Change noop return typing to just 'undefined'

### DIFF
--- a/src/noop.ts
+++ b/src/noop.ts
@@ -6,4 +6,4 @@
  *    onSomething(R.noop)
  * @category Function
  */
-export const noop = () => undefined as any;
+export const noop = () => undefined;


### PR DESCRIPTION
The `as any` has bad results when it comes to inferring result types in anything actually expecting or differentiating on `undefined`. It's better for type inference purposes to just let the return type be `undefined`.