### PR TITLE
chore(lint): autofixers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,13 +50,6 @@ module.exports = {
 
     // TODO: These all have autofixers
     '@typescript-eslint/array-type': 'off',
-    '@typescript-eslint/ban-tslint-comment': 'off',
-    '@typescript-eslint/consistent-indexed-object-style': 'off',
-    '@typescript-eslint/no-inferrable-types': 'off',
-    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
-    '@typescript-eslint/prefer-reduce-type-parameter': 'off',
-    '@typescript-eslint/prefer-ts-expect-error': 'off',
-    'prefer-const': 'off',
 
     // TODO: These have trivial manual fixes
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,14 @@ module.exports = {
     // etc...) via namespaces by design.
     '@typescript-eslint/no-namespace': 'off',
 
+    '@typescript-eslint/array-type': [
+      'warn',
+      {
+        // We like it this way...
+        default: 'generic',
+      },
+    ],
+
     // TODO: There are a ton of `any` throughout the codebase, they should be
     // replaced by `unknown` or better types.
     '@typescript-eslint/no-explicit-any': 'off',
@@ -47,9 +55,6 @@ module.exports = {
     // reserved keyword, but it's recommended to use a variadic instead (e.g.
     // `function foo(...args: readonly unknown[])`)
     'prefer-rest-params': 'off',
-
-    // TODO: These all have autofixers
-    '@typescript-eslint/array-type': 'off',
 
     // TODO: These have trivial manual fixes
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     '@typescript-eslint/no-namespace': 'off',
 
     '@typescript-eslint/array-type': [
-      'warn',
+      'error',
       {
         // We like it this way...
         default: 'generic',

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -30,7 +30,7 @@ export function _reduceLazy<T, K>(
     const result = indexed ? lazy(item, index, array) : lazy(item);
     if (result.hasMany === true) {
       acc.push(...result.next);
-    } else if (result.hasNext === true) {
+    } else if (result.hasNext) {
       acc.push(result.next);
     }
     return acc;

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -18,15 +18,15 @@ interface LazyMany<T> {
   done: boolean;
   hasNext: true;
   hasMany: true;
-  next: T[];
+  next: Array<T>;
 }
 
 export function _reduceLazy<T, K>(
-  array: T[],
-  lazy: (item: T, index?: number, array?: T[]) => LazyResult<K>,
+  array: Array<T>,
+  lazy: (item: T, index?: number, array?: Array<T>) => LazyResult<K>,
   indexed?: boolean
 ) {
-  return array.reduce((acc: K[], item, index) => {
+  return array.reduce((acc: Array<K>, item, index) => {
     const result = indexed ? lazy(item, index, array) : lazy(item);
     if (result.hasMany === true) {
       acc.push(...result.next);

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,9 +1,9 @@
 export type Pred<T, K> = (input: T) => K;
-export type PredIndexed<T, K> = (input: T, index: number, array: T[]) => K;
+export type PredIndexed<T, K> = (input: T, index: number, array: Array<T>) => K;
 export type PredIndexedOptional<T, K> = (
   input: T,
   index?: number,
-  array?: T[]
+  array?: Array<T>
 ) => K;
 
 /** types that may be returned by `keyof` */
@@ -18,4 +18,4 @@ export type AssertEqual<Type, Expected> = Array<Type> extends Array<Expected>
     : never
   : never;
 
-export type NonEmptyArray<T> = [T, ...T[]];
+export type NonEmptyArray<T> = [T, ...Array<T>];

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -12,7 +12,10 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function chunk<T>(array: readonly T[], size: number): T[][];
+export function chunk<T>(
+  array: ReadonlyArray<T>,
+  size: number
+): Array<Array<T>>;
 
 /**
  * Split an array into groups the length of `size`. If `array` can't be split evenly, the final chunk will be the remaining elements.
@@ -25,15 +28,17 @@ export function chunk<T>(array: readonly T[], size: number): T[][];
  * @data_last
  * @category Array
  */
-export function chunk<T>(size: number): (array: readonly T[]) => T[][];
+export function chunk<T>(
+  size: number
+): (array: ReadonlyArray<T>) => Array<Array<T>>;
 
 export function chunk() {
   return purry(_chunk, arguments);
 }
 
-function _chunk<T>(array: T[], size: number) {
-  const ret: T[][] = [];
-  let current: T[] | null = null;
+function _chunk<T>(array: Array<T>, size: number) {
+  const ret: Array<Array<T>> = [];
+  let current: Array<T> | null = null;
   array.forEach(x => {
     if (!current) {
       current = [];

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -155,7 +155,7 @@ describe('deep clone deep nested mixed objects', () => {
   });
 
   it('clones array with arrays', () => {
-    const list: any[][] = [[1], [[3]]];
+    const list: Array<Array<any>> = [[1], [[3]]];
     const cloned = clone(list);
     list[1][0] = null;
     eq(cloned, [[1], [[3]]]);

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -13,7 +13,12 @@ function _cloneRegExp(pattern: RegExp) {
   );
 }
 
-function _clone(value: any, refFrom: any[], refTo: any[], deep: boolean) {
+function _clone(
+  value: any,
+  refFrom: Array<any>,
+  refTo: Array<any>,
+  deep: boolean
+) {
   function copy(copiedValue: any) {
     const len = refFrom.length;
     let idx = 0;

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -25,7 +25,6 @@ function _clone(value: any, refFrom: any[], refTo: any[], deep: boolean) {
     }
     refFrom[idx + 1] = value;
     refTo[idx + 1] = copiedValue;
-    // tslint:disable-next-line:forin
     for (const key in value) {
       copiedValue[key] = deep
         ? _clone(value[key], refFrom, refTo, true)

--- a/src/compact.test.ts
+++ b/src/compact.test.ts
@@ -5,7 +5,7 @@ import { compact } from './compact';
 
 test('filter correctly', () => {
   const items = [false, null, 0, '', undefined, NaN, true, 1, 'a'] as const;
-  const results: (boolean | number | 'a')[] = compact(items);
+  const results: Array<boolean | number | 'a'> = compact(items);
   expect(results).toEqual([true, 1, 'a']);
 });
 

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -11,8 +11,8 @@ import { isTruthy } from './guards';
  * @pipeable
  */
 export function compact<T>(
-  items: readonly (T | null | undefined | false | '' | 0)[]
-): T[] {
+  items: ReadonlyArray<T | null | undefined | false | '' | 0>
+): Array<T> {
   // TODO: Make lazy version
   return items.filter(isTruthy);
 }

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -12,8 +12,8 @@ import { purry } from './purry';
  * @category Array
  */
 export function concat<T, K>(
-  arr1: readonly T[],
-  arr2: readonly K[]
+  arr1: ReadonlyArray<T>,
+  arr2: ReadonlyArray<K>
 ): Array<T | K>;
 
 /**
@@ -27,13 +27,13 @@ export function concat<T, K>(
  * @category Array
  */
 export function concat<T, K>(
-  arr2: readonly K[]
-): (arr1: readonly T[]) => Array<T | K>;
+  arr2: ReadonlyArray<K>
+): (arr1: ReadonlyArray<T>) => Array<T | K>;
 
 export function concat() {
   return purry(_concat, arguments);
 }
 
-function _concat(arr1: any[], arr2: any[]) {
+function _concat(arr1: Array<any>, arr2: Array<any>) {
   return arr1.concat(arr2);
 }

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -3,7 +3,7 @@ import { Pred, PredIndexed, PredIndexedOptional } from './_types';
 
 const _countBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     return array.reduce((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       return ret + (value ? 1 : 0);
@@ -22,11 +22,14 @@ const _countBy =
  * @indexed
  * @category Array
  */
-export function countBy<T>(items: readonly T[], fn: Pred<T, boolean>): number;
+export function countBy<T>(
+  items: ReadonlyArray<T>,
+  fn: Pred<T, boolean>
+): number;
 
 export function countBy<T>(
   fn: Pred<T, boolean>
-): (array: readonly T[]) => number;
+): (array: ReadonlyArray<T>) => number;
 
 /**
  * Counts how many values of the collection pass the specified predicate.
@@ -45,12 +48,12 @@ export function countBy() {
 
 export namespace countBy {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
   ): number;
   export function indexed<T, K>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => number;
+  ): (array: ReadonlyArray<T>) => number;
   export function indexed() {
     return purry(_countBy(true), arguments);
   }

--- a/src/difference.ts
+++ b/src/difference.ts
@@ -13,7 +13,10 @@ import { _reduceLazy, LazyResult } from './_reduceLazy';
  * @category Array
  * @pipeable
  */
-export function difference<T>(array: readonly T[], other: readonly T[]): T[];
+export function difference<T>(
+  array: ReadonlyArray<T>,
+  other: ReadonlyArray<T>
+): Array<T>;
 
 /**
  * Excludes the values from `other` array.
@@ -32,20 +35,20 @@ export function difference<T>(array: readonly T[], other: readonly T[]): T[];
  * @pipeable
  */
 export function difference<T, K>(
-  other: readonly T[]
-): (array: readonly K[]) => T[];
+  other: ReadonlyArray<T>
+): (array: ReadonlyArray<K>) => Array<T>;
 
 export function difference() {
   return purry(_difference, arguments, difference.lazy);
 }
 
-function _difference<T>(array: T[], other: T[]) {
+function _difference<T>(array: Array<T>, other: Array<T>) {
   const lazy = difference.lazy(other);
   return _reduceLazy(array, lazy);
 }
 
 export namespace difference {
-  export function lazy<T>(other: T[]) {
+  export function lazy<T>(other: Array<T>) {
     const set = new Set(other);
     return (value: T): LazyResult<T> => {
       if (!set.has(value)) {

--- a/src/differenceWith.ts
+++ b/src/differenceWith.ts
@@ -22,10 +22,10 @@ type IsEquals<TFirst, TSecond> = (a: TFirst, b: TSecond) => boolean;
  * @pipeable
  */
 export function differenceWith<TFirst, TSecond>(
-  array: readonly TFirst[],
-  other: readonly TSecond[],
+  array: ReadonlyArray<TFirst>,
+  other: ReadonlyArray<TSecond>,
   isEquals: IsEquals<TFirst, TSecond>
-): TFirst[];
+): Array<TFirst>;
 
 /**
  * Excludes the values from `other` array.
@@ -49,17 +49,17 @@ export function differenceWith<TFirst, TSecond>(
  * @pipeable
  */
 export function differenceWith<TFirst, TSecond>(
-  other: readonly TSecond[],
+  other: ReadonlyArray<TSecond>,
   isEquals: IsEquals<TFirst, TSecond>
-): (array: readonly TFirst[]) => TFirst[];
+): (array: ReadonlyArray<TFirst>) => Array<TFirst>;
 
 export function differenceWith() {
   return purry(_differenceWith, arguments, differenceWith.lazy);
 }
 
 function _differenceWith<TFirst, TSecond>(
-  array: TFirst[],
-  other: TSecond[],
+  array: Array<TFirst>,
+  other: Array<TSecond>,
   isEquals: IsEquals<TFirst, TSecond>
 ) {
   const lazy = differenceWith.lazy(other, isEquals);
@@ -68,7 +68,7 @@ function _differenceWith<TFirst, TSecond>(
 
 export namespace differenceWith {
   export function lazy<TFirst, TSecond>(
-    other: TSecond[],
+    other: Array<TSecond>,
     isEquals: IsEquals<TFirst, TSecond>
   ) {
     return (value: TFirst): LazyResult<TFirst> => {

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -13,7 +13,7 @@ import { _reduceLazy, LazyResult } from './_reduceLazy';
  * @pipeable
  * @category Array
  */
-export function drop<T>(array: readonly T[], n: number): T[];
+export function drop<T>(array: ReadonlyArray<T>, n: number): Array<T>;
 
 /**
  * Removes first `n` elements from the `array`.
@@ -27,13 +27,13 @@ export function drop<T>(array: readonly T[], n: number): T[];
  * @pipeable
  * @category Array
  */
-export function drop<T>(n: number): (array: readonly T[]) => T[];
+export function drop<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
 export function drop() {
   return purry(_drop, arguments, drop.lazy);
 }
 
-function _drop<T>(array: T[], n: number) {
+function _drop<T>(array: Array<T>, n: number) {
   return _reduceLazy(array, drop.lazy(n));
 }
 

--- a/src/dropLast.ts
+++ b/src/dropLast.ts
@@ -11,7 +11,7 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function dropLast<T>(array: readonly T[], n: number): T[];
+export function dropLast<T>(array: ReadonlyArray<T>, n: number): Array<T>;
 
 /**
  * Removes last `n` elements from the `array`.
@@ -24,13 +24,13 @@ export function dropLast<T>(array: readonly T[], n: number): T[];
  * @data_last
  * @category Array
  */
-export function dropLast<T>(n: number): (array: readonly T[]) => T[];
+export function dropLast<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
 export function dropLast() {
   return purry(_dropLast, arguments);
 }
 
-function _dropLast<T>(array: T[], n: number) {
+function _dropLast<T>(array: Array<T>, n: number) {
   const copy = [...array];
   if (n !== 0) {
     copy.splice(-n);

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -13,13 +13,13 @@ function isNumber<T>(data: T): data is Extract<T, number> {
 describe('data_first', () => {
   it('filter', () => {
     const result = filter([1, 2, 3] as const, x => x % 2 === 1);
-    assertType<(1 | 2 | 3)[]>(result); // Type test
+    assertType<Array<1 | 2 | 3>>(result); // Type test
     expect(result).toEqual([1, 3]);
   });
 
   it('data_first with typescript guard', () => {
     const result = filter([1, 2, 3, 'abc', true] as const, isNumber);
-    assertType<(1 | 2 | 3)[]>(result); // Type test
+    assertType<Array<1 | 2 | 3>>(result); // Type test
     expect(result).toEqual([1, 2, 3]);
   });
 
@@ -28,7 +28,7 @@ describe('data_first', () => {
       [1, 2, 3] as const,
       (x, i) => x % 2 === 1 && i !== 1
     );
-    assertType<(1 | 2 | 3)[]>(result); // Type test
+    assertType<Array<1 | 2 | 3>>(result); // Type test
     expect(result).toEqual([1, 3]);
   });
 
@@ -37,7 +37,7 @@ describe('data_first', () => {
       [1, 2, 3, false, 'text'] as const, // Type (1 | 2 | 3 | false | "text")[]
       isNumber
     );
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 2, 3]);
   });
 });
@@ -51,7 +51,7 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 3]);
   });
 
@@ -63,7 +63,7 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 3]);
   });
 
@@ -75,7 +75,7 @@ describe('data_last', () => {
       counter.fn()
     );
     expect(counter.count).toHaveBeenCalledTimes(3);
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 2, 3]);
   });
   it('filter.indexed with typescript guard', () => {
@@ -85,7 +85,7 @@ describe('data_last', () => {
       filter.indexed(isNumber),
       counter.fn()
     );
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([1, 2, 3]);
   });
@@ -96,7 +96,7 @@ describe('data_last', () => {
       filter.indexed((x, i) => x % 2 === 1 && i !== 1),
       counter.fn()
     );
-    assertType<(1 | 2 | 3)[]>(result); // Type test (1 | 2 | 3)[]
+    assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -19,10 +19,13 @@ import { _toLazyIndexed } from './_toLazyIndexed';
  * @category Array
  */
 export function filter<T, S extends T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: (value: T) => value is S
-): S[];
-export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
+): Array<S>;
+export function filter<T>(
+  array: ReadonlyArray<T>,
+  fn: Pred<T, boolean>
+): Array<T>;
 
 /**
  * Filter the elements of an array that meet the condition specified in a callback function.
@@ -40,8 +43,10 @@ export function filter<T>(array: readonly T[], fn: Pred<T, boolean>): T[];
  */
 export function filter<T, S extends T>(
   fn: (input: T) => input is S
-): (array: readonly T[]) => S[];
-export function filter<T>(fn: Pred<T, boolean>): (array: readonly T[]) => T[];
+): (array: ReadonlyArray<T>) => Array<S>;
+export function filter<T>(
+  fn: Pred<T, boolean>
+): (array: ReadonlyArray<T>) => Array<T>;
 
 export function filter() {
   return purry(_filter(false), arguments, filter.lazy);
@@ -49,7 +54,7 @@ export function filter() {
 
 const _filter =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     return _reduceLazy(
       array,
       indexed ? filter.lazyIndexed(fn) : filter.lazy(fn),
@@ -60,7 +65,7 @@ const _filter =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: T[]): LazyResult<T> => {
+    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       if (valid) {
         return {
@@ -78,22 +83,22 @@ const _lazy =
 
 export namespace filter {
   export function indexed<T, S extends T>(
-    array: readonly T[],
-    fn: (input: T, index: number, array: T[]) => input is S
-  ): S[];
+    array: ReadonlyArray<T>,
+    fn: (input: T, index: number, array: Array<T>) => input is S
+  ): Array<S>;
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
-  ): T[];
+  ): Array<T>;
   /**
    * @data_last
    */
   export function indexed<T, S extends T>(
-    fn: (input: T, index: number, array: T[]) => input is S
-  ): (array: readonly T[]) => S[];
+    fn: (input: T, index: number, array: Array<T>) => input is S
+  ): (array: ReadonlyArray<T>) => Array<S>;
   export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => T[];
+  ): (array: ReadonlyArray<T>) => Array<T>;
   export function indexed() {
     return purry(_filter(true), arguments, filter.lazyIndexed);
   }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -62,7 +62,7 @@ const _lazy =
   <T>(fn: PredIndexedOptional<T, boolean>) => {
     return (value: T, index?: number, array?: T[]): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
-      if (!!valid === true) {
+      if (valid) {
         return {
           done: false,
           hasNext: true,

--- a/src/find.ts
+++ b/src/find.ts
@@ -19,7 +19,7 @@ import { _toSingle } from './_toSingle';
  * @category Array
  */
 export function find<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: Pred<T, boolean>
 ): T | undefined;
 
@@ -45,7 +45,7 @@ export function find<T>(
  */
 export function find<T = never>(
   fn: Pred<T, boolean>
-): (array: readonly T[]) => T | undefined;
+): (array: ReadonlyArray<T>) => T | undefined;
 
 export function find() {
   return purry(_find(false), arguments, find.lazy);
@@ -53,7 +53,7 @@ export function find() {
 
 const _find =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     if (indexed) {
       return array.find(fn);
     }
@@ -64,7 +64,7 @@ const _find =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: T[]) => {
+    return (value: T, index?: number, array?: Array<T>) => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       return {
         done: valid,
@@ -76,12 +76,12 @@ const _lazy =
 
 export namespace find {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
   ): T | undefined;
   export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => T | undefined;
+  ): (array: ReadonlyArray<T>) => T | undefined;
   export function indexed() {
     return purry(_find(true), arguments, find.lazyIndexed);
   }

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -18,7 +18,10 @@ import { _toSingle } from './_toSingle';
  * @pipeable
  * @category Array
  */
-export function findIndex<T>(array: readonly T[], fn: Pred<T, boolean>): number;
+export function findIndex<T>(
+  array: ReadonlyArray<T>,
+  fn: Pred<T, boolean>
+): number;
 
 /**
  * Returns the index of the first element in the array where predicate is true, and -1 otherwise.
@@ -43,7 +46,7 @@ export function findIndex<T>(array: readonly T[], fn: Pred<T, boolean>): number;
  */
 export function findIndex<T>(
   fn: Pred<T, boolean>
-): (array: readonly T[]) => number;
+): (array: ReadonlyArray<T>) => number;
 
 export function findIndex() {
   return purry(_findIndex(false), arguments, findIndex.lazy);
@@ -51,7 +54,7 @@ export function findIndex() {
 
 const _findIndex =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     if (indexed) {
       return array.findIndex(fn);
     }
@@ -63,7 +66,7 @@ const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
     let i = 0;
-    return (value: T, index?: number, array?: T[]) => {
+    return (value: T, index?: number, array?: Array<T>) => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       if (valid) {
         return {
@@ -82,12 +85,12 @@ const _lazy =
 
 export namespace findIndex {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
   ): number;
   export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => number;
+  ): (array: ReadonlyArray<T>) => number;
   export function indexed() {
     return purry(_findIndex(true), arguments, findIndex.lazyIndexed);
   }

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -18,7 +18,7 @@ import { Pred, PredIndexedOptional, PredIndexed } from './_types';
  * @category Array
  */
 export function findLast<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: Pred<T, boolean>
 ): T | undefined;
 
@@ -45,7 +45,7 @@ export function findLast<T>(
  */
 export function findLast<T = never>(
   fn: Pred<T, boolean>
-): (array: readonly T[]) => T | undefined;
+): (array: ReadonlyArray<T>) => T | undefined;
 
 export function findLast() {
   return purry(_findLast(false), arguments);
@@ -53,7 +53,7 @@ export function findLast() {
 
 const _findLast =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
       if (indexed ? fn(array[i], i, array) : fn(array[i])) {
         return array[i];
@@ -63,12 +63,12 @@ const _findLast =
 
 export namespace findLast {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
   ): T | undefined;
   export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => T | undefined;
+  ): (array: ReadonlyArray<T>) => T | undefined;
 
   export function indexed() {
     return purry(_findLast(true), arguments);

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -17,7 +17,7 @@ import { Pred, PredIndexedOptional, PredIndexed } from './_types';
  * @category Array
  */
 export function findLastIndex<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: Pred<T, boolean>
 ): number;
 
@@ -44,7 +44,7 @@ export function findLastIndex<T>(
  */
 export function findLastIndex<T>(
   fn: Pred<T, boolean>
-): (array: readonly T[]) => number;
+): (array: ReadonlyArray<T>) => number;
 
 export function findLastIndex() {
   return purry(_findLastIndex(false), arguments);
@@ -52,7 +52,7 @@ export function findLastIndex() {
 
 const _findLastIndex =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
       if (indexed ? fn(array[i], i, array) : fn(array[i])) {
         return i;
@@ -64,12 +64,12 @@ const _findLastIndex =
 
 export namespace findLastIndex {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
   ): number;
   export function indexed<T>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => number;
+  ): (array: ReadonlyArray<T>) => number;
 
   export function indexed() {
     return purry(_findLastIndex(true), arguments);

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -64,7 +64,7 @@ describe('pipe', () => {
       [[1, 2, 3], [4, 5], [6]] as const,
       counter.fn(),
       first(),
-      defaultTo<readonly number[]>([]),
+      defaultTo<ReadonlyArray<number>>([]),
       first()
     );
     expect(counter.count).toHaveBeenCalledTimes(1);
@@ -79,7 +79,7 @@ describe('pipe', () => {
       counter1.fn(),
       filter(arr => arr.length === 4),
       first(),
-      defaultTo<readonly number[]>([]),
+      defaultTo<ReadonlyArray<number>>([]),
       counter2.fn(),
       filter(x => x % 2 === 1),
       first()

--- a/src/first.ts
+++ b/src/first.ts
@@ -19,14 +19,14 @@ import { purry } from './purry';
  * @category array
  * @pipeable
  */
-export function first<T>(array: readonly T[]): T | undefined;
-export function first<T>(): (array: readonly T[]) => T | undefined;
+export function first<T>(array: ReadonlyArray<T>): T | undefined;
+export function first<T>(): (array: ReadonlyArray<T>) => T | undefined;
 
 export function first() {
   return purry(_first, arguments, first.lazy);
 }
 
-function _first<T>(array: T[]) {
+function _first<T>(array: Array<T>) {
   return array[0];
 }
 

--- a/src/flatMap.ts
+++ b/src/flatMap.ts
@@ -14,9 +14,9 @@ import { purry } from './purry';
  * @category Array
  */
 export function flatMap<T, K>(
-  array: readonly T[],
-  fn: (input: T) => K | K[]
-): K[];
+  array: ReadonlyArray<T>,
+  fn: (input: T) => K | Array<K>
+): Array<K>;
 
 /**
  * Map each element of an array using a defined callback function and flatten the mapped result.
@@ -31,19 +31,19 @@ export function flatMap<T, K>(
  * @category Array
  */
 export function flatMap<T, K>(
-  fn: (input: T) => K | K[]
-): (array: readonly T[]) => K[];
+  fn: (input: T) => K | Array<K>
+): (array: ReadonlyArray<T>) => Array<K>;
 
 export function flatMap() {
   return purry(_flatMap, arguments, flatMap.lazy);
 }
 
-function _flatMap<T, K>(array: T[], fn: (input: T) => K[]): K[] {
+function _flatMap<T, K>(array: Array<T>, fn: (input: T) => Array<K>): Array<K> {
   return flatten(array.map(item => fn(item)));
 }
 
 export namespace flatMap {
-  export function lazy<T, K>(fn: (input: T) => K | K[]) {
+  export function lazy<T, K>(fn: (input: T) => K | Array<K>) {
     return (value: T) => {
       const next = fn(value);
       if (Array.isArray(next)) {

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -22,8 +22,8 @@ import { purry } from './purry';
  * @category Array
  */
 export function flatMapToObj<T, K extends keyof any, V>(
-  array: readonly T[],
-  fn: (element: T) => [K, V][]
+  array: ReadonlyArray<T>,
+  fn: (element: T) => Array<[K, V]>
 ): Record<K, V>;
 
 /**
@@ -50,8 +50,8 @@ export function flatMapToObj<T, K extends keyof any, V>(
  * @category Array
  */
 export function flatMapToObj<T, K extends keyof any, V>(
-  fn: (element: T) => [K, V][]
-): (array: readonly T[]) => Record<K, V>;
+  fn: (element: T) => Array<[K, V]>
+): (array: ReadonlyArray<T>) => Record<K, V>;
 
 export function flatMapToObj() {
   return purry(_flatMapToObj(false), arguments);
@@ -59,7 +59,7 @@ export function flatMapToObj() {
 
 const _flatMapToObj =
   (indexed: boolean) =>
-  <T>(array: any[], fn: PredIndexedOptional<any, any>) => {
+  <T>(array: Array<any>, fn: PredIndexedOptional<any, any>) => {
     return array.reduce((result, element, index) => {
       const items = indexed ? fn(element, index, array) : fn(element);
       items.forEach(([key, value]: [any, any]) => {
@@ -71,12 +71,12 @@ const _flatMapToObj =
 
 export namespace flatMapToObj {
   export function indexed<T, K extends keyof any, V>(
-    array: readonly T[],
-    fn: (element: T, index: number, array: readonly T[]) => [K, V][]
+    array: ReadonlyArray<T>,
+    fn: (element: T, index: number, array: ReadonlyArray<T>) => Array<[K, V]>
   ): Record<K, V>;
   export function indexed<T, K extends keyof any, V>(
-    fn: (element: T, index: number, array: readonly T[]) => [K, V][]
-  ): (array: readonly T[]) => Record<K, V>;
+    fn: (element: T, index: number, array: ReadonlyArray<T>) => Array<[K, V]>
+  ): (array: ReadonlyArray<T>) => Record<K, V>;
   export function indexed() {
     return purry(_flatMapToObj(true), arguments);
   }

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -18,15 +18,15 @@ type Flatten<T> = T extends ReadonlyArray<infer K> ? K : T;
  * @category Array
  * @pipeable
  */
-export function flatten<T>(items: readonly T[]): Array<Flatten<T>>;
+export function flatten<T>(items: ReadonlyArray<T>): Array<Flatten<T>>;
 
-export function flatten<T>(): (items: readonly T[]) => Array<Flatten<T>>;
+export function flatten<T>(): (items: ReadonlyArray<T>) => Array<Flatten<T>>;
 
 export function flatten() {
   return purry(_flatten, arguments, flatten.lazy);
 }
 
-function _flatten<T>(items: T[]): Array<Flatten<T>> {
+function _flatten<T>(items: Array<T>): Array<Flatten<T>> {
   return _reduceLazy(items, flatten.lazy());
 }
 

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -20,10 +20,10 @@ type FlattenDeep4<T> = T extends ReadonlyArray<infer K> ? K : T;
  * @category Array
  * @pipeable
  */
-export function flattenDeep<T>(items: readonly T[]): Array<FlattenDeep<T>>;
+export function flattenDeep<T>(items: ReadonlyArray<T>): Array<FlattenDeep<T>>;
 
 export function flattenDeep<T>(): (
-  items: readonly T[]
+  items: ReadonlyArray<T>
 ) => Array<FlattenDeep<T>>;
 
 export function flattenDeep() {
@@ -38,7 +38,7 @@ function _flattenDeepValue<T>(value: T | Array<T>): T | Array<FlattenDeep<T>> {
   if (!Array.isArray(value)) {
     return value;
   }
-  const ret: any[] = [];
+  const ret: Array<any> = [];
   value.forEach(item => {
     if (Array.isArray(item)) {
       ret.push(...flattenDeep(item));

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -23,7 +23,10 @@ import { Pred, PredIndexedOptional, PredIndexed } from './_types';
  * @pipeable
  * @category Array
  */
-export function forEach<T>(array: readonly T[], fn: Pred<T, void>): T[];
+export function forEach<T>(
+  array: ReadonlyArray<T>,
+  fn: Pred<T, void>
+): Array<T>;
 
 /**
  * Iterate an array using a defined callback function. The original array is returned instead of `void`.
@@ -49,7 +52,9 @@ export function forEach<T>(array: readonly T[], fn: Pred<T, void>): T[];
  * @pipeable
  * @category Array
  */
-export function forEach<T>(fn: Pred<T, void>): (array: readonly T[]) => T[];
+export function forEach<T>(
+  fn: Pred<T, void>
+): (array: ReadonlyArray<T>) => Array<T>;
 
 export function forEach() {
   return purry(_forEach(false), arguments, forEach.lazy);
@@ -57,7 +62,7 @@ export function forEach() {
 
 const _forEach =
   (indexed: boolean) =>
-  <T, K>(array: T[], fn: PredIndexedOptional<T, K>) => {
+  <T, K>(array: Array<T>, fn: PredIndexedOptional<T, K>) => {
     return _reduceLazy(
       array,
       indexed ? forEach.lazyIndexed(fn) : forEach.lazy(fn),
@@ -68,7 +73,7 @@ const _forEach =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, void>) => {
-    return (value: T, index?: number, array?: T[]): LazyResult<T> => {
+    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
       if (indexed) {
         fn(value, index, array);
       } else {
@@ -84,12 +89,12 @@ const _lazy =
 
 export namespace forEach {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, void>
-  ): T[];
+  ): Array<T>;
   export function indexed<T>(
     fn: PredIndexed<T, void>
-  ): (array: readonly T[]) => T[];
+  ): (array: ReadonlyArray<T>) => Array<T>;
   export function indexed() {
     return purry(_forEach(true), arguments, forEach.lazyIndexed);
   }

--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,7 +1,7 @@
 import { fromPairs } from './fromPairs';
 import { AssertEqual } from './_types';
 
-const tuples: [string, number][] = [
+const tuples: Array<[string, number]> = [
   ['a', 1],
   ['b', 2],
   ['c', 3],

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -17,13 +17,13 @@ import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
  * @category Array
  */
 export function groupBy<T>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   fn: (item: T) => PropertyKey
 ): Record<PropertyKey, NonEmptyArray<T>>;
 
 export function groupBy<T>(
   fn: (item: T) => PropertyKey
-): (array: readonly T[]) => Record<PropertyKey, NonEmptyArray<T>>;
+): (array: ReadonlyArray<T>) => Record<PropertyKey, NonEmptyArray<T>>;
 
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.
@@ -42,8 +42,8 @@ export function groupBy() {
 
 const _groupBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, any>) => {
-    const ret: Record<string, T[]> = {};
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
+    const ret: Record<string, Array<T>> = {};
     array.forEach((item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
@@ -77,23 +77,23 @@ type Out<Value, Key extends PropertyKey = PropertyKey> =
 
 export namespace groupBy {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, PropertyKey>
   ): Record<string, NonEmptyArray<T>>;
   export function indexed<T, K>(
     fn: PredIndexed<T, PropertyKey>
-  ): (array: readonly T[]) => Record<string, NonEmptyArray<T>>;
+  ): (array: ReadonlyArray<T>) => Record<string, NonEmptyArray<T>>;
   export function indexed() {
     return purry(_groupBy(true), arguments);
   }
   export function strict<Value, Key extends PropertyKey = PropertyKey>(
-    items: readonly Value[],
+    items: ReadonlyArray<Value>,
     fn: (item: Value) => Key
   ): Out<Value, Key>;
 
   export function strict<Value, Key extends PropertyKey = PropertyKey>(
     fn: (item: Value) => Key
-  ): (array: readonly Value[]) => Out<Value, Key>;
+  ): (array: ReadonlyArray<Value>) => Out<Value, Key>;
 
   export function strict() {
     return purry(_groupBy(false), arguments);
@@ -101,12 +101,12 @@ export namespace groupBy {
 
   export namespace strict {
     export function indexed<Value, Key extends PropertyKey = PropertyKey>(
-      array: readonly Value[],
+      array: ReadonlyArray<Value>,
       fn: PredIndexed<Value, Key>
     ): Out<Value, Key>;
     export function indexed<Value, Key extends PropertyKey = PropertyKey>(
       fn: PredIndexed<Value, Key>
-    ): (array: readonly Value[]) => Out<Value, Key>;
+    ): (array: ReadonlyArray<Value>) => Out<Value, Key>;
     export function indexed() {
       return purry(_groupBy(true), arguments);
     }

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -20,7 +20,7 @@ type TestObj =
   | string
   | { a: string }
   | (() => void)
-  | number[]
+  | Array<number>
   | Date
   | undefined
   | null
@@ -106,7 +106,7 @@ describe('isString', () => {
       dataProvider('boolean'),
     ].filter(isString);
     expect(data.every(c => typeof c === 'string')).toEqual(true);
-    const result: AssertEqual<typeof data, string[]> = true;
+    const result: AssertEqual<typeof data, Array<string>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -144,7 +144,7 @@ describe('isBoolean', () => {
       dataProvider('boolean'),
     ].filter(isBoolean);
     expect(data.every(c => typeof c === 'boolean')).toEqual(true);
-    const result: AssertEqual<typeof data, boolean[]> = true;
+    const result: AssertEqual<typeof data, Array<boolean>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -154,13 +154,13 @@ describe('isArray', () => {
     const data = dataProvider('array');
     if (isArray(data)) {
       expect(Array.isArray(data)).toEqual(true);
-      const result: AssertEqual<typeof data, number[]> = true;
+      const result: AssertEqual<typeof data, Array<number>> = true;
       expect(result).toEqual(true);
     }
 
     const data1: unknown = dataProvider('array');
     if (isArray(data1)) {
-      const result: AssertEqual<typeof data1, readonly unknown[]> = true;
+      const result: AssertEqual<typeof data1, ReadonlyArray<unknown>> = true;
       expect(result).toEqual(true);
     }
   });
@@ -174,7 +174,7 @@ describe('isArray', () => {
       dataProvider('date'),
     ].filter(isArray);
     expect(data.every(c => Array.isArray(c))).toEqual(true);
-    const result: AssertEqual<typeof data, number[][]> = true;
+    const result: AssertEqual<typeof data, Array<Array<number>>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -204,7 +204,7 @@ describe('isDate', () => {
       dataProvider('date'),
     ].filter(isDate);
     expect(data.every(c => c instanceof Date)).toEqual(true);
-    const result: AssertEqual<typeof data, Date[]> = true;
+    const result: AssertEqual<typeof data, Array<Date>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -219,7 +219,7 @@ describe('isDefined', () => {
         | string
         | { a: string }
         | (() => void)
-        | number[]
+        | Array<number>
         | Date
         | Error
         | number
@@ -239,7 +239,7 @@ describe('isDefined', () => {
     expect(data.length === 4).toEqual(true);
     const result: AssertEqual<
       typeof data,
-      (
+      Array<
         | string
         | number
         | boolean
@@ -247,11 +247,11 @@ describe('isDefined', () => {
             a: string;
           }
         | (() => void)
-        | number[]
+        | Array<number>
         | Date
         | Error
         | Promise<number>
-      )[]
+      >
     > = true;
     expect(result).toEqual(true);
   });
@@ -276,7 +276,7 @@ describe('isNil', () => {
       dataProvider('number'),
     ].filter(isNil);
     expect(data.every(c => c == null)).toEqual(true);
-    const result: AssertEqual<typeof data, (undefined | null)[]> = true;
+    const result: AssertEqual<typeof data, Array<undefined | null>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -308,7 +308,7 @@ describe('isFunction', () => {
       dataProvider('number'),
     ].filter(isFunction);
     expect(data.every(c => typeof c === 'function')).toEqual(true);
-    const result: AssertEqual<typeof data, (() => void)[]> = true;
+    const result: AssertEqual<typeof data, Array<() => void>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -339,7 +339,7 @@ describe('isError', () => {
       dataProvider('number'),
     ].filter(isError);
     expect(data.every(c => c instanceof Error)).toEqual(true);
-    const result: AssertEqual<typeof data, Error[]> = true;
+    const result: AssertEqual<typeof data, Array<Error>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -362,7 +362,7 @@ describe('isNumber', () => {
       dataProvider('number'),
     ].filter(isNumber);
     expect(data.every(c => typeof c === 'number')).toEqual(true);
-    const result: AssertEqual<typeof data, number[]> = true;
+    const result: AssertEqual<typeof data, Array<number>> = true;
     expect(result).toEqual(true);
   });
   test('should work even if data type is unknown', () => {
@@ -454,14 +454,14 @@ describe('isObject', () => {
     );
     const result: AssertEqual<
       typeof data,
-      (
+      Array<
         | {
             a: string;
           }
         | Date
         | Error
         | Promise<number>
-      )[]
+      >
     > = true;
     expect(result).toEqual(true);
   });
@@ -484,7 +484,7 @@ describe('isPromise', () => {
       dataProvider('function'),
     ].filter(isPromise);
     expect(data.every(c => c instanceof Promise)).toEqual(true);
-    const result: AssertEqual<typeof data, Promise<number>[]> = true;
+    const result: AssertEqual<typeof data, Array<Promise<number>>> = true;
     expect(result).toEqual(true);
   });
 });
@@ -511,7 +511,7 @@ describe('isNot', () => {
             a: string;
           }
         | (() => void)
-        | number[]
+        | Array<number>
         | Date
         | Error
         | Promise<number>
@@ -533,18 +533,18 @@ describe('isNot', () => {
 
     const resultType: AssertEqual<
       typeof result,
-      (
+      Array<
         | boolean
         | string
         | { a: string }
         | (() => void)
-        | number[]
+        | Array<number>
         | Date
         | undefined
         | null
         | Error
         | number
-      )[]
+      >
     > = true;
     expect(resultType).toEqual(true);
   });

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -123,7 +123,7 @@ type DefinitelyObject<T extends unknown> = Exclude<
   Extract<T, object>,
   Array<any> | Function | ReadonlyArray<any>
 > extends never
-  ? { [k: string]: unknown }
+  ? Record<string, unknown>
   : Exclude<Extract<T, object>, Array<any> | Function | ReadonlyArray<any>>;
 /**
  * A function that checks if the passed parameter is of type Object and narrows its type accordingly

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -44,12 +44,12 @@ export function indexBy() {
 const _indexBy =
   (indexed: boolean) =>
   <T>(array: T[], fn: PredIndexedOptional<T, any>) => {
-    return array.reduce((ret, item, index) => {
+    return array.reduce<Record<string, T>>((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
       ret[key] = item;
       return ret;
-    }, {} as Record<string, T>);
+    }, {});
   };
 
 export namespace indexBy {

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -14,7 +14,7 @@ import { PredIndexedOptional, PredIndexed } from './_types';
  * @category Array
  */
 export function indexBy<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: (item: T) => any
 ): Record<string, T>;
 
@@ -35,7 +35,7 @@ export function indexBy<T>(
  */
 export function indexBy<T>(
   fn: (item: T) => any
-): (array: readonly T[]) => Record<string, T>;
+): (array: ReadonlyArray<T>) => Record<string, T>;
 
 export function indexBy() {
   return purry(_indexBy(false), arguments);
@@ -43,7 +43,7 @@ export function indexBy() {
 
 const _indexBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, any>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
     return array.reduce<Record<string, T>>((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
@@ -54,12 +54,12 @@ const _indexBy =
 
 export namespace indexBy {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, any>
   ): Record<string, T>;
   export function indexed<T, K>(
     fn: PredIndexed<T, any>
-  ): (array: readonly T[]) => Record<string, T>;
+  ): (array: ReadonlyArray<T>) => Record<string, T>;
   export function indexed() {
     return purry(_indexBy(true), arguments);
   }

--- a/src/intersection.ts
+++ b/src/intersection.ts
@@ -13,7 +13,10 @@ import { _reduceLazy, LazyResult } from './_reduceLazy';
  * @category Array
  * @pipeable
  */
-export function intersection<T>(source: readonly T[], other: readonly T[]): T[];
+export function intersection<T>(
+  source: ReadonlyArray<T>,
+  other: ReadonlyArray<T>
+): Array<T>;
 
 /**
  * Returns a list of elements that exist in both array.
@@ -28,20 +31,20 @@ export function intersection<T>(source: readonly T[], other: readonly T[]): T[];
  * @pipeable
  */
 export function intersection<T, K>(
-  other: readonly T[]
-): (source: readonly K[]) => T[];
+  other: ReadonlyArray<T>
+): (source: ReadonlyArray<K>) => Array<T>;
 
 export function intersection() {
   return purry(_intersection, arguments, intersection.lazy);
 }
 
-function _intersection<T>(array: T[], other: T[]) {
+function _intersection<T>(array: Array<T>, other: Array<T>) {
   const lazy = intersection.lazy(other);
   return _reduceLazy(array, lazy);
 }
 
 export namespace intersection {
-  export function lazy<T>(other: T[]) {
+  export function lazy<T>(other: Array<T>) {
     return (value: T): LazyResult<T> => {
       const set = new Set(other);
       if (set.has(value)) {

--- a/src/last.ts
+++ b/src/last.ts
@@ -27,6 +27,6 @@ export function last() {
   return purry(_last, arguments);
 }
 
-function _last<T>(array: T[]) {
+function _last<T>(array: Array<T>) {
   return array[array.length - 1];
 }

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -61,10 +61,10 @@ describe('pipe', () => {
   });
 
   it('indexed: check index and items', () => {
-    const indexes1: number[] = [];
-    const indexes2: number[] = [];
-    const anyItems1: number[][] = [];
-    const anyItems2: number[][] = [];
+    const indexes1: Array<number> = [];
+    const indexes2: Array<number> = [];
+    const anyItems1: Array<Array<number>> = [];
+    const anyItems2: Array<Array<number>> = [];
     const result = pipe(
       [1, 2, 3, 4, 5] as const,
       map.indexed((x, i, items) => {

--- a/src/map.ts
+++ b/src/map.ts
@@ -19,7 +19,7 @@ import { Pred, PredIndexedOptional, PredIndexed } from './_types';
  * @pipeable
  * @category Array
  */
-export function map<T, K>(array: readonly T[], fn: Pred<T, K>): K[];
+export function map<T, K>(array: ReadonlyArray<T>, fn: Pred<T, K>): Array<K>;
 
 /**
  * Map each value of an object using a defined callback function.
@@ -35,7 +35,9 @@ export function map<T, K>(array: readonly T[], fn: Pred<T, K>): K[];
  * @pipeable
  * @category Array
  */
-export function map<T, K>(fn: Pred<T, K>): (array: readonly T[]) => K[];
+export function map<T, K>(
+  fn: Pred<T, K>
+): (array: ReadonlyArray<T>) => Array<K>;
 
 export function map() {
   return purry(_map(false), arguments, map.lazy);
@@ -43,7 +45,7 @@ export function map() {
 
 const _map =
   (indexed: boolean) =>
-  <T, K>(array: T[], fn: PredIndexedOptional<T, K>) => {
+  <T, K>(array: Array<T>, fn: PredIndexedOptional<T, K>) => {
     return _reduceLazy(
       array,
       indexed ? map.lazyIndexed(fn) : map.lazy(fn),
@@ -54,7 +56,7 @@ const _map =
 const _lazy =
   (indexed: boolean) =>
   <T, K>(fn: PredIndexedOptional<T, K>) => {
-    return (value: T, index?: number, array?: T[]): LazyResult<K> => {
+    return (value: T, index?: number, array?: Array<T>): LazyResult<K> => {
       return {
         done: false,
         hasNext: true,
@@ -65,12 +67,12 @@ const _lazy =
 
 export namespace map {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, K>
-  ): K[];
+  ): Array<K>;
   export function indexed<T, K>(
     fn: PredIndexed<T, K>
-  ): (array: readonly T[]) => K[];
+  ): (array: ReadonlyArray<T>) => Array<K>;
   export function indexed() {
     return purry(_map(true), arguments, map.lazyIndexed);
   }

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -36,8 +36,8 @@ export function mapKeys(arg1: any, arg2?: any): any {
 }
 
 function _mapKeys(obj: any, fn: (key: string, value: any) => any) {
-  return Object.keys(obj).reduce((acc, key) => {
+  return Object.keys(obj).reduce<any>((acc, key) => {
     acc[fn(key, obj[key])] = obj[key];
     return acc;
-  }, {} as any);
+  }, {});
 }

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -17,7 +17,7 @@ import { purry } from './purry';
  * @category Array
  */
 export function mapToObj<T, K extends keyof any, V>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: (element: T) => [K, V]
 ): Record<K, V>;
 
@@ -43,7 +43,7 @@ export function mapToObj<T, K extends keyof any, V>(
  */
 export function mapToObj<T, K extends keyof any, V>(
   fn: (element: T) => [K, V]
-): (array: readonly T[]) => Record<K, V>;
+): (array: ReadonlyArray<T>) => Record<K, V>;
 
 export function mapToObj() {
   return purry(_mapToObj(false), arguments);
@@ -51,7 +51,7 @@ export function mapToObj() {
 
 const _mapToObj =
   (indexed: boolean) =>
-  <T>(array: any[], fn: PredIndexedOptional<any, any>) => {
+  <T>(array: Array<any>, fn: PredIndexedOptional<any, any>) => {
     return array.reduce((result, element, index) => {
       const [key, value] = indexed ? fn(element, index, array) : fn(element);
       result[key] = value;
@@ -61,12 +61,12 @@ const _mapToObj =
 
 export namespace mapToObj {
   export function indexed<T, K extends keyof any, V>(
-    array: readonly T[],
-    fn: (element: T, index: number, array: readonly T[]) => [K, V]
+    array: ReadonlyArray<T>,
+    fn: (element: T, index: number, array: ReadonlyArray<T>) => [K, V]
   ): Record<K, V>;
   export function indexed<T, K extends keyof any, V>(
-    fn: (element: T, index: number, array: readonly T[]) => [K, V]
-  ): (array: readonly T[]) => Record<K, V>;
+    fn: (element: T, index: number, array: ReadonlyArray<T>) => [K, V]
+  ): (array: ReadonlyArray<T>) => Record<K, V>;
   export function indexed() {
     return purry(_mapToObj(true), arguments);
   }

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -36,8 +36,8 @@ export function mapValues(arg1: any, arg2?: any): any {
 }
 
 function _mapValues(obj: any, fn: (key: string, value: any) => any) {
-  return Object.keys(obj).reduce((acc, key) => {
+  return Object.keys(obj).reduce<any>((acc, key) => {
     acc[key] = fn(obj[key], key);
     return acc;
-  }, {} as any);
+  }, {});
 }

--- a/src/maxBy.ts
+++ b/src/maxBy.ts
@@ -5,7 +5,7 @@ import { PredIndexed, PredIndexedOptional } from './_types';
 
 const _maxBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, number>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, number>) => {
     let ret: T | undefined = undefined;
     let retMax: number | undefined = undefined;
     array.forEach((item, i) => {
@@ -36,7 +36,7 @@ const _maxBy =
  */
 export function maxBy<T>(
   fn: (item: T) => number
-): (items: readonly T[]) => T | undefined;
+): (items: ReadonlyArray<T>) => T | undefined;
 
 /**
  * Returns the max element using the provided predicate.
@@ -55,7 +55,7 @@ export function maxBy<T>(
  * @category Array
  */
 export function maxBy<T>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   fn: (item: T) => number
 ): T | undefined;
 
@@ -65,12 +65,12 @@ export function maxBy() {
 
 export namespace maxBy {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, number>
   ): T | undefined;
   export function indexed<T>(
     fn: PredIndexed<T, number>
-  ): (array: readonly T[]) => T | undefined;
+  ): (array: ReadonlyArray<T>) => T | undefined;
   export function indexed() {
     return purry(_maxBy(true), arguments);
   }

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -3,7 +3,7 @@ import { PredIndexed, PredIndexedOptional } from './_types';
 
 const _meanBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, number>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, number>) => {
     if (array.length === 0) {
       return NaN;
     }
@@ -34,7 +34,7 @@ const _meanBy =
 
 export function meanBy<T>(
   fn: (item: T) => number
-): (items: readonly T[]) => number;
+): (items: ReadonlyArray<T>) => number;
 
 /**
  * Returns the mean of the elements of an array using the provided predicate.
@@ -53,7 +53,10 @@ export function meanBy<T>(
  * @category Array
  */
 
-export function meanBy<T>(items: readonly T[], fn: (item: T) => number): number;
+export function meanBy<T>(
+  items: ReadonlyArray<T>,
+  fn: (item: T) => number
+): number;
 
 export function meanBy() {
   return purry(_meanBy(false), arguments);
@@ -61,13 +64,13 @@ export function meanBy() {
 
 export namespace meanBy {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, number>
   ): number;
 
   export function indexed<T>(
     fn: PredIndexed<T, number>
-  ): (array: readonly T[]) => number;
+  ): (array: ReadonlyArray<T>) => number;
 
   export function indexed() {
     return purry(_meanBy(true), arguments);

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -31,6 +31,5 @@ export function merge() {
 }
 
 function _merge<A, B>(a: A, b: B) {
-  // tslint:disable-next-line:prefer-object-spread
   return Object.assign({}, a, b);
 }

--- a/src/mergeAll.ts
+++ b/src/mergeAll.ts
@@ -16,8 +16,8 @@ export function mergeAll<A, B, C, D>(
 export function mergeAll<A, B, C, D, E>(
   array: [A, B, C, D, E]
 ): A & B & C & D & E;
-export function mergeAll(array: readonly object[]): object;
+export function mergeAll(array: ReadonlyArray<object>): object;
 
-export function mergeAll(items: readonly any[]) {
+export function mergeAll(items: ReadonlyArray<any>) {
   return items.reduce((acc, x) => ({ ...acc, ...x }), {});
 }

--- a/src/minBy.ts
+++ b/src/minBy.ts
@@ -5,7 +5,7 @@ import { PredIndexed, PredIndexedOptional } from './_types';
 
 const _minBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, number>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, number>) => {
     let ret: T | undefined = undefined;
     let retMin: number | undefined = undefined;
     array.forEach((item, i) => {
@@ -36,7 +36,7 @@ const _minBy =
  */
 export function minBy<T>(
   fn: (item: T) => number
-): (items: readonly T[]) => T | undefined;
+): (items: ReadonlyArray<T>) => T | undefined;
 
 /**
  * Returns the min element using the provided predicate.
@@ -55,7 +55,7 @@ export function minBy<T>(
  * @category Array
  */
 export function minBy<T>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   fn: (item: T) => number
 ): T | undefined;
 
@@ -65,12 +65,12 @@ export function minBy() {
 
 export namespace minBy {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, number>
   ): T | undefined;
   export function indexed<T>(
     fn: PredIndexed<T, number>
-  ): (array: readonly T[]) => T | undefined;
+  ): (array: ReadonlyArray<T>) => T | undefined;
   export function indexed() {
     return purry(_minBy(true), arguments);
   }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -40,10 +40,10 @@ function _omit<T extends Record<PropertyKey, any>, K extends keyof T>(
   names: K[]
 ): Omit<T, K> {
   const set = new Set(names as string[]);
-  return Object.entries(object).reduce((acc, [name, value]) => {
+  return Object.entries(object).reduce<any>((acc, [name, value]) => {
     if (!set.has(name)) {
       acc[name] = value;
     }
     return acc;
-  }, {} as any) as Omit<T, K>;
+  }, {}) as Omit<T, K>;
 }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -13,7 +13,7 @@ import { purry } from './purry';
  */
 export function omit<T extends Record<PropertyKey, any>, K extends keyof T>(
   object: T,
-  names: readonly K[]
+  names: ReadonlyArray<K>
 ): Omit<T, K>;
 
 /**
@@ -28,7 +28,7 @@ export function omit<T extends Record<PropertyKey, any>, K extends keyof T>(
  * @category Object
  */
 export function omit<T extends Record<PropertyKey, any>, K extends keyof T>(
-  names: readonly K[]
+  names: ReadonlyArray<K>
 ): (object: T) => Omit<T, K>;
 
 export function omit() {
@@ -37,9 +37,9 @@ export function omit() {
 
 function _omit<T extends Record<PropertyKey, any>, K extends keyof T>(
   object: T,
-  names: K[]
+  names: Array<K>
 ): Omit<T, K> {
-  const set = new Set(names as string[]);
+  const set = new Set(names as Array<string>);
   return Object.entries(object).reduce<any>((acc, [name, value]) => {
     if (!set.has(name)) {
       acc[name] = value;

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -33,10 +33,10 @@ export function omitBy() {
 }
 
 function _omitBy(object: any, fn: (value: any, key: any) => boolean) {
-  return Object.keys(object).reduce((acc, key) => {
+  return Object.keys(object).reduce<any>((acc, key) => {
     if (!fn(object[key], key)) {
       acc[key] = object[key];
     }
     return acc;
-  }, {} as any);
+  }, {});
 }

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -30,7 +30,8 @@ describe('data first', () => {
       [1, 2],
       ['a', 'b'],
     ]);
-    const result: AssertEqual<typeof actual, [number[], string[]]> = true;
+    const result: AssertEqual<typeof actual, [Array<number>, Array<string>]> =
+      true;
     expect(result).toBe(true);
   });
   test('partition with type guard in pipe', () => {
@@ -44,7 +45,8 @@ describe('data first', () => {
       [1, 2],
       ['a', 'b'],
     ]);
-    const result: AssertEqual<typeof actual, [number[], string[]]> = true;
+    const result: AssertEqual<typeof actual, [Array<number>, Array<string>]> =
+      true;
     expect(result).toBe(true);
   });
   test('partition.indexed', () => {

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -15,9 +15,9 @@ import { PredIndexedOptional, PredIndexed } from './_types';
  * @category Array
  */
 export function partition<T, S extends T>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   predicate: (item: T) => item is S
-): [S[], Exclude<T, S>[]];
+): [Array<S>, Array<Exclude<T, S>>];
 
 /**
  * Splits a collection into two groups, the first of which contains elements the `predicate` function matches, and the second one containing the rest.
@@ -33,9 +33,9 @@ export function partition<T, S extends T>(
  * @category Array
  */
 export function partition<T>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   predicate: (item: T) => boolean
-): [T[], T[]];
+): [Array<T>, Array<T>];
 
 /**
  * Splits a collection into two groups, the first of which contains elements the `predicate` type guard passes, and the second one containing the rest.
@@ -51,7 +51,7 @@ export function partition<T>(
  */
 export function partition<T, S extends T>(
   predicate: (item: T) => item is S
-): (array: readonly T[]) => [S[], Exclude<T, S>[]];
+): (array: ReadonlyArray<T>) => [Array<S>, Array<Exclude<T, S>>];
 
 /**
  * Splits a collection into two groups, the first of which contains elements the `predicate` function matches, and the second one containing the rest.
@@ -67,7 +67,7 @@ export function partition<T, S extends T>(
  */
 export function partition<T>(
   predicate: (item: T) => boolean
-): (array: readonly T[]) => [T[], T[]];
+): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
 export function partition() {
   return purry(_partition(false), arguments);
@@ -75,8 +75,8 @@ export function partition() {
 
 const _partition =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, any>) => {
-    const ret: [T[], T[]] = [[], []];
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
+    const ret: [Array<T>, Array<T>] = [[], []];
     array.forEach((item, index) => {
       const matches = indexed ? fn(item, index, array) : fn(item);
       ret[matches ? 0 : 1].push(item);
@@ -86,12 +86,12 @@ const _partition =
 
 export namespace partition {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     predicate: PredIndexed<T, boolean>
-  ): [T[], T[]];
+  ): [Array<T>, Array<T>];
   export function indexed<T, K>(
     predicate: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => [T[], T[]];
+  ): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
   export function indexed() {
     return purry(_partition(true), arguments);
   }

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -45,8 +45,6 @@ describe('data first', () => {
   });
 
   test('should return value (3 level deep)', () => {
-    // TODO: fix typing
-    // @ts-ignore
     expect(pathOr(obj, ['a', 'b', 'c'] as const, 0)).toEqual(1);
   });
 });
@@ -59,7 +57,6 @@ describe('data last', () => {
     expect(pipe(obj, pathOr(['a', 'z'], 1))).toEqual(1);
   });
   test('3 level', () => {
-    // @ts-ignore
     expect(pipe(obj, pathOr(['a', 'b', 'd'] as const, 1))).toEqual(1);
   });
 });

--- a/src/pathOr.ts
+++ b/src/pathOr.ts
@@ -142,7 +142,7 @@ export function pathOr() {
   return purry(_pathOr, arguments);
 }
 
-function _pathOr(object: any, path: any[], defaultValue: any): any {
+function _pathOr(object: any, path: Array<any>, defaultValue: any): any {
   let current = object;
   for (const prop of path) {
     if (current == null || current[prop] == null) {

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -12,7 +12,7 @@ import { purry } from './purry';
  */
 export function pick<T extends object, K extends keyof T>(
   object: T,
-  names: readonly K[]
+  names: ReadonlyArray<K>
 ): Pick<T, K>;
 
 /**
@@ -25,14 +25,14 @@ export function pick<T extends object, K extends keyof T>(
  * @category Object
  */
 export function pick<T extends object, K extends keyof T>(
-  names: readonly K[]
+  names: ReadonlyArray<K>
 ): (object: T) => Pick<T, K>;
 
 export function pick() {
   return purry(_pick, arguments);
 }
 
-function _pick(object: any, names: string[]) {
+function _pick(object: any, names: Array<string>) {
   if (object == null) {
     return {};
   }

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -36,10 +36,10 @@ function _pick(object: any, names: string[]) {
   if (object == null) {
     return {};
   }
-  return names.reduce((acc, name) => {
+  return names.reduce<any>((acc, name) => {
     if (name in object) {
       acc[name] = object[name];
     }
     return acc;
-  }, {} as any);
+  }, {});
 }

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -36,10 +36,10 @@ function _pickBy(object: any, fn: (value: any, key: any) => boolean) {
   if (object == null) {
     return {};
   }
-  return Object.keys(object).reduce((acc, key) => {
+  return Object.keys(object).reduce<any>((acc, key) => {
     if (fn(object[key], key)) {
       acc[key] = object[key];
     }
     return acc;
-  }, {} as any);
+  }, {});
 }

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -106,10 +106,10 @@ export function pipe(
       }
     }
 
-    let acc: any[] = [];
+    const acc: any[] = [];
 
     for (let j = 0; j < ret.length; j++) {
-      let item = ret[j];
+      const item = ret[j];
       if (_processItem({ item, acc, lazySeq })) {
         break;
       }

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -94,7 +94,7 @@ export function pipe(
       opIdx++;
       continue;
     }
-    const lazySeq: LazyFn[] = [];
+    const lazySeq: Array<LazyFn> = [];
     for (let j = opIdx; j < operations.length; j++) {
       if (lazyOps[j]) {
         lazySeq.push(lazyOps[j]);
@@ -106,7 +106,7 @@ export function pipe(
       }
     }
 
-    const acc: any[] = [];
+    const acc: Array<any> = [];
 
     for (let j = 0; j < ret.length; j++) {
       const item = ret[j];
@@ -128,11 +128,11 @@ export function pipe(
 type LazyFn = (value: any, index?: number, items?: any) => LazyResult<any>;
 
 type LazyOp = ((input: any) => any) & {
-  lazy: ((...args: any[]) => LazyFn) & {
+  lazy: ((...args: Array<any>) => LazyFn) & {
     indexed: boolean;
     single: boolean;
   };
-  lazyArgs: any[];
+  lazyArgs: Array<any>;
 };
 
 function _processItem({
@@ -141,8 +141,8 @@ function _processItem({
   acc,
 }: {
   item: any;
-  lazySeq: any[];
-  acc: any[];
+  lazySeq: Array<any>;
+  acc: Array<any>;
 }): boolean {
   if (lazySeq.length === 0) {
     acc.push(item);
@@ -160,7 +160,7 @@ function _processItem({
     lazyFn.index++;
     if (lazyResult.hasNext) {
       if (lazyResult.hasMany) {
-        const nextValues: any[] = lazyResult.next;
+        const nextValues: Array<any> = lazyResult.next;
         for (const subItem of nextValues) {
           const subResult = _processItem({
             item: subItem,

--- a/src/purry.test.ts
+++ b/src/purry.test.ts
@@ -5,21 +5,21 @@ function sub(a: number, b: number) {
 }
 
 test('all arguments', () => {
-  function fn(...args: any[]) {
+  function fn(...args: Array<any>) {
     return purry(sub, args);
   }
   expect(fn(10, 5)).toEqual(5);
 });
 
 test('1 missing', () => {
-  function fn(...args: any[]) {
+  function fn(...args: Array<any>) {
     return purry(sub, args);
   }
   expect(fn(5)(10)).toEqual(5);
 });
 
 test('wrong number of arguments', () => {
-  function fn(...args: any[]) {
+  function fn(...args: Array<any>) {
     return purry(sub, args);
   }
   expect(() => fn(5, 10, 40)).toThrowError('Wrong number of arguments');

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -28,7 +28,11 @@
  *    }
  * @category Function
  */
-export function purry(fn: any, args: IArguments | readonly any[], lazy?: any) {
+export function purry(
+  fn: any,
+  args: IArguments | ReadonlyArray<any>,
+  lazy?: any
+) {
   const diff = fn.length - args.length;
   const arrayArgs = Array.from(args);
   if (diff === 0) {

--- a/src/range.ts
+++ b/src/range.ts
@@ -10,7 +10,7 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function range(start: number, end: number): number[];
+export function range(start: number, end: number): Array<number>;
 
 /**
  * Returns a list of numbers from `start` (inclusive) to `end` (exclusive).
@@ -21,14 +21,14 @@ export function range(start: number, end: number): number[];
  * @data_first
  * @category Array
  */
-export function range(end: number): (start: number) => number[];
+export function range(end: number): (start: number) => Array<number>;
 
 export function range() {
   return purry(_range, arguments);
 }
 
 function _range(start: number, end: number) {
-  const ret: number[] = [];
+  const ret: Array<number> = [];
   for (let i = start; i < end; i++) {
     ret.push(i);
   }

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -16,7 +16,7 @@ import { purry } from './purry';
  * @category Array
  */
 export function reduce<T, K>(
-  items: readonly T[],
+  items: ReadonlyArray<T>,
   fn: (acc: K, item: T) => K,
   initialValue: K
 ): K;
@@ -37,7 +37,7 @@ export function reduce<T, K>(
 export function reduce<T, K>(
   fn: (acc: K, item: T) => K,
   initialValue: K
-): (items: readonly T[]) => K;
+): (items: ReadonlyArray<T>) => K;
 
 export function reduce() {
   return purry(_reduce(false), arguments);
@@ -46,8 +46,8 @@ export function reduce() {
 const _reduce =
   (indexed: boolean) =>
   <T, K>(
-    items: T[],
-    fn: (acc: K, item: T, index?: number, items?: T[]) => K,
+    items: Array<T>,
+    fn: (acc: K, item: T, index?: number, items?: Array<T>) => K,
     initialValue: K
   ): K => {
     return items.reduce(
@@ -59,14 +59,14 @@ const _reduce =
 
 export namespace reduce {
   export function indexed<T, K>(
-    array: readonly T[],
-    fn: (acc: K, item: T, index: number, items: T[]) => K,
+    array: ReadonlyArray<T>,
+    fn: (acc: K, item: T, index: number, items: Array<T>) => K,
     initialValue: K
   ): K;
   export function indexed<T, K>(
-    fn: (acc: K, item: T, index: number, items: T[]) => K,
+    fn: (acc: K, item: T, index: number, items: Array<T>) => K,
     initialValue: K
-  ): (array: readonly T[]) => K;
+  ): (array: ReadonlyArray<T>) => K;
   export function indexed() {
     return purry(_reduce(true), arguments);
   }

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -56,7 +56,7 @@ const _lazy =
   <T>(fn: PredIndexedOptional<T, boolean>) => {
     return (value: T, index?: number, array?: T[]): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
-      if (!valid === true) {
+      if (!valid) {
         return {
           done: false,
           hasNext: true,

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -18,7 +18,10 @@ import { _toLazyIndexed } from './_toLazyIndexed';
  * @pipeable
  * @category Array
  */
-export function reject<T>(items: readonly T[], fn: Pred<T, boolean>): T[];
+export function reject<T>(
+  items: ReadonlyArray<T>,
+  fn: Pred<T, boolean>
+): Array<T>;
 
 /**
  * Reject the elements of an array that meet the condition specified in a callback function.
@@ -35,7 +38,9 @@ export function reject<T>(items: readonly T[], fn: Pred<T, boolean>): T[];
  * @pipeable
  * @category Array
  */
-export function reject<T>(fn: Pred<T, boolean>): (items: readonly T[]) => T[];
+export function reject<T>(
+  fn: Pred<T, boolean>
+): (items: ReadonlyArray<T>) => Array<T>;
 
 export function reject() {
   return purry(_reject(false), arguments, reject.lazy);
@@ -43,7 +48,7 @@ export function reject() {
 
 const _reject =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     return _reduceLazy(
       array,
       indexed ? reject.lazyIndexed(fn) : reject.lazy(fn),
@@ -54,7 +59,7 @@ const _reject =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: T[]): LazyResult<T> => {
+    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       if (!valid) {
         return {
@@ -72,12 +77,12 @@ const _lazy =
 
 export namespace reject {
   export function indexed<T, K>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, boolean>
-  ): K[];
+  ): Array<K>;
   export function indexed<T, K>(
     fn: PredIndexed<T, boolean>
-  ): (array: readonly T[]) => K[];
+  ): (array: ReadonlyArray<T>) => Array<K>;
   export function indexed() {
     return purry(_reject(true), arguments, reject.lazyIndexed);
   }

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -10,7 +10,7 @@ describe('data first', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = reverse([1, 2, 3]);
-      const result: AssertEqual<typeof actual, number[]> = true;
+      const result: AssertEqual<typeof actual, Array<number>> = true;
       expect(result).toEqual(true);
     });
     test('tuples', () => {
@@ -38,7 +38,7 @@ describe('data last', () => {
   describe('reverse typings', () => {
     test('arrays', () => {
       const actual = pipe([1, 2, 3], reverse());
-      const result: AssertEqual<typeof actual, number[]> = true;
+      const result: AssertEqual<typeof actual, Array<number>> = true;
       expect(result).toEqual(true);
     });
     test('tuples', () => {

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -1,8 +1,8 @@
 import { purry } from './purry';
 
 type Reverse<
-  T extends readonly unknown[],
-  R extends readonly unknown[] = []
+  T extends ReadonlyArray<unknown>,
+  R extends ReadonlyArray<unknown> = []
 > = ReturnType<
   T extends IsNoTuple<T>
     ? () => [...T, ...R]
@@ -11,7 +11,7 @@ type Reverse<
     : () => R
 >;
 
-type IsNoTuple<T> = T extends readonly [unknown, ...unknown[]] ? never : T;
+type IsNoTuple<T> = T extends readonly [unknown, ...Array<unknown>] ? never : T;
 
 /**
  * Reverses array.
@@ -23,7 +23,7 @@ type IsNoTuple<T> = T extends readonly [unknown, ...unknown[]] ? never : T;
  * @data_first
  * @category Array
  */
-export function reverse<T extends readonly unknown[]>(array: T): Reverse<T>;
+export function reverse<T extends ReadonlyArray<unknown>>(array: T): Reverse<T>;
 
 /**
  * Reverses array.
@@ -35,7 +35,7 @@ export function reverse<T extends readonly unknown[]>(array: T): Reverse<T>;
  * @data_last
  * @category Array
  */
-export function reverse<T extends readonly unknown[]>(): (
+export function reverse<T extends ReadonlyArray<unknown>>(): (
   array: T
 ) => Reverse<T>;
 
@@ -43,6 +43,6 @@ export function reverse() {
   return purry(_reverse, arguments);
 }
 
-function _reverse(array: any[]) {
+function _reverse(array: Array<any>) {
   return array.slice().reverse();
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -12,7 +12,10 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function sort<T>(items: readonly T[], cmp: (a: T, b: T) => number): T[];
+export function sort<T>(
+  items: ReadonlyArray<T>,
+  cmp: (a: T, b: T) => number
+): Array<T>;
 
 /**
  * Sorts an array. The comparator function should accept two values at a time and return a negative number if the first value is smaller, a positive number if it's larger, and zero if they are equal.
@@ -27,13 +30,13 @@ export function sort<T>(items: readonly T[], cmp: (a: T, b: T) => number): T[];
  */
 export function sort<T>(
   cmp: (a: T, b: T) => number
-): (items: readonly T[]) => T[];
+): (items: ReadonlyArray<T>) => Array<T>;
 
 export function sort<T>() {
   return purry(_sort, arguments);
 }
 
-function _sort<T>(items: T[], cmp: (a: T, b: T) => number) {
+function _sort<T>(items: Array<T>, cmp: (a: T, b: T) => number) {
   const ret = [...items];
   ret.sort(cmp);
   return ret;

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -71,12 +71,12 @@ describe('data first', () => {
     test('SortProjection', () => {
       const actual = sortBy(items, x => x.a);
       type T = (typeof items)[number];
-      assertType<T[]>(actual);
+      assertType<Array<T>>(actual);
     });
     test('SortPair', () => {
       const actual = sortBy(objects, [x => x.active, 'desc']);
       type T = (typeof objects)[number];
-      assertType<T[]>(actual);
+      assertType<Array<T>>(actual);
     });
   });
 });
@@ -123,7 +123,7 @@ describe('data last', () => {
         sortBy(x => x.a)
       );
       type T = (typeof items)[number];
-      assertType<T[]>(actual);
+      assertType<Array<T>>(actual);
     });
     test('SortPair', () => {
       const actual = pipe(
@@ -131,7 +131,7 @@ describe('data last', () => {
         sortBy([x => x.weight, 'asc'], [x => x.color, 'desc'])
       );
       type T = (typeof objects)[number];
-      assertType<T[]>(actual);
+      assertType<Array<T>>(actual);
     });
   });
 });

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -26,8 +26,8 @@ type SortRule<T> = SortProjection<T> | SortPair<T>;
  */
 export function sortBy<T>(
   sort: SortRule<T>,
-  ...sorts: SortRule<T>[]
-): (array: readonly T[]) => T[];
+  ...sorts: Array<SortRule<T>>
+): (array: ReadonlyArray<T>) => Array<T>;
 
 /**
  * Sorts the list according to the supplied functions and directions.
@@ -62,32 +62,35 @@ export function sortBy<T>(
  * @data_first
  * @category Array
  */
-export function sortBy<T>(array: readonly T[], ...sorts: SortRule<T>[]): T[];
+export function sortBy<T>(
+  array: ReadonlyArray<T>,
+  ...sorts: Array<SortRule<T>>
+): Array<T>;
 
 export function sortBy<T>(
-  arrayOrSort: readonly T[] | SortRule<T>,
-  ...sorts: SortRule<T>[]
+  arrayOrSort: ReadonlyArray<T> | SortRule<T>,
+  ...sorts: Array<SortRule<T>>
 ): any {
   if (!isSortRule(arrayOrSort)) {
-    return purry(_sortBy, [arrayOrSort, sorts]) as T[];
+    return purry(_sortBy, [arrayOrSort, sorts]) as Array<T>;
   }
   return purry(_sortBy, [[arrayOrSort, ...sorts]]) as (
-    arr: readonly T[]
-  ) => T[];
+    arr: ReadonlyArray<T>
+  ) => Array<T>;
 }
 
-function isSortRule<T>(x: readonly T[] | SortRule<T>): x is SortRule<T> {
+function isSortRule<T>(x: ReadonlyArray<T> | SortRule<T>): x is SortRule<T> {
   if (typeof x == 'function') return true; // must be a SortProjection
   if (x.length != 2) return false; // cannot be a SortRule
   return typeof x[0] == 'function' && (x[1] === 'asc' || x[1] === 'desc');
 }
 
-function _sortBy<T>(array: T[], sorts: SortRule<T>[]): T[] {
+function _sortBy<T>(array: Array<T>, sorts: Array<SortRule<T>>): Array<T> {
   const sort = (
     a: T,
     b: T,
     sortRule: SortRule<T>,
-    sortRules: SortRule<T>[]
+    sortRules: Array<SortRule<T>>
   ): number => {
     let fn: SortProjection<T>;
     let direction: Direction;

--- a/src/splitAt.ts
+++ b/src/splitAt.ts
@@ -12,7 +12,10 @@ import { purry } from './purry';
  * @data_first
  * @category Array
  */
-export function splitAt<T>(array: readonly T[], index: number): [T[], T[]];
+export function splitAt<T>(
+  array: ReadonlyArray<T>,
+  index: number
+): [Array<T>, Array<T>];
 
 /**
  * Splits a given array at a given index.
@@ -26,13 +29,15 @@ export function splitAt<T>(array: readonly T[], index: number): [T[], T[]];
  * @data_last
  * @category Array
  */
-export function splitAt<T>(index: number): (array: readonly T[]) => [T[], T[]];
+export function splitAt<T>(
+  index: number
+): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
 export function splitAt() {
   return purry(_splitAt, arguments);
 }
 
-function _splitAt<T>(array: T[], index: number) {
+function _splitAt<T>(array: Array<T>, index: number) {
   const copy = [...array];
   const tail = copy.splice(index);
   return [copy, tail];

--- a/src/splitWhen.test.ts
+++ b/src/splitWhen.test.ts
@@ -8,8 +8,8 @@ it('should split array', () => {
 });
 
 it('should with no matches', () => {
-  const n: number = 1232;
-  expect(splitWhen([1, 2, 3, 1, 2, 3] as const, x => x === n)).toEqual([
+  const n = 1232;
+  expect(splitWhen([1, 2, 3, 1, 2, 3], x => x === n)).toEqual([
     [1, 2, 3, 1, 2, 3],
     [],
   ]);

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -13,9 +13,9 @@ import { purry } from './purry';
  * @category Array
  */
 export function splitWhen<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: (item: T) => boolean
-): [T[], T[]];
+): [Array<T>, Array<T>];
 
 /**
  * Splits a given array at an index where the given predicate returns true.
@@ -29,13 +29,13 @@ export function splitWhen<T>(
  */
 export function splitWhen<T>(
   fn: (item: T) => boolean
-): (array: readonly T[]) => [T[], T[]];
+): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
 export function splitWhen() {
   return purry(_splitWhen, arguments);
 }
 
-function _splitWhen<T>(array: T[], fn: (item: T) => boolean) {
+function _splitWhen<T>(array: Array<T>, fn: (item: T) => boolean) {
   for (let i = 0; i < array.length; i++) {
     if (fn(array[i])) {
       return splitAt(array, i);

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -3,7 +3,7 @@ import { PredIndexed, PredIndexedOptional } from './_types';
 
 const _sumBy =
   (indexed: boolean) =>
-  <T>(array: T[], fn: PredIndexedOptional<T, number>) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, number>) => {
     let sum = 0;
     array.forEach((item, i) => {
       const summand = indexed ? fn(item, i, array) : fn(item);
@@ -30,7 +30,7 @@ const _sumBy =
 
 export function sumBy<T>(
   fn: (item: T) => number
-): (items: readonly T[]) => number;
+): (items: ReadonlyArray<T>) => number;
 
 /**
  * Returns the sum of the elements of an array using the provided predicate.
@@ -49,7 +49,10 @@ export function sumBy<T>(
  * @category Array
  */
 
-export function sumBy<T>(items: readonly T[], fn: (item: T) => number): number;
+export function sumBy<T>(
+  items: ReadonlyArray<T>,
+  fn: (item: T) => number
+): number;
 
 export function sumBy() {
   return purry(_sumBy(false), arguments);
@@ -57,13 +60,13 @@ export function sumBy() {
 
 export namespace sumBy {
   export function indexed<T>(
-    array: readonly T[],
+    array: ReadonlyArray<T>,
     fn: PredIndexed<T, number>
   ): number;
 
   export function indexed<T>(
     fn: PredIndexed<T, number>
-  ): (array: readonly T[]) => number;
+  ): (array: ReadonlyArray<T>) => number;
 
   export function indexed() {
     return purry(_sumBy(true), arguments);

--- a/src/take.ts
+++ b/src/take.ts
@@ -13,7 +13,7 @@ import { _reduceLazy, LazyResult } from './_reduceLazy';
  * @pipeable
  * @category Array
  */
-export function take<T>(array: readonly T[], n: number): T[];
+export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
 
 /**
  * Returns the first `n` elements of `array`.
@@ -26,13 +26,13 @@ export function take<T>(array: readonly T[], n: number): T[];
  * @pipeable
  * @category Array
  */
-export function take<T>(n: number): (array: readonly T[]) => T[];
+export function take<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
 export function take() {
   return purry(_take, arguments, take.lazy);
 }
 
-function _take<T>(array: T[], n: number) {
+function _take<T>(array: Array<T>, n: number) {
   return _reduceLazy(array, take.lazy(n));
 }
 

--- a/src/takeWhile.ts
+++ b/src/takeWhile.ts
@@ -12,9 +12,9 @@ import { purry } from './purry';
  * @category Array
  */
 export function takeWhile<T>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   fn: (item: T) => boolean
-): T[];
+): Array<T>;
 
 /**
  * Returns elements from the array until predicate returns false.
@@ -28,14 +28,14 @@ export function takeWhile<T>(
  */
 export function takeWhile<T>(
   fn: (item: T) => boolean
-): (array: readonly T[]) => T[];
+): (array: ReadonlyArray<T>) => Array<T>;
 
 export function takeWhile() {
   return purry(_takeWhile, arguments);
 }
 
-function _takeWhile<T>(array: T[], fn: (item: T) => boolean) {
-  const ret: T[] = [];
+function _takeWhile<T>(array: Array<T>, fn: (item: T) => boolean) {
+  const ret: Array<T> = [];
   for (const item of array) {
     if (!fn(item)) {
       break;

--- a/src/times.ts
+++ b/src/times.ts
@@ -13,7 +13,7 @@ import { purry } from './purry';
  * @example times(identity, 5); //=> [0, 1, 2, 3, 4]
  * @data_first
  */
-export function times<T>(count: number, fn: (n: number) => T): T[];
+export function times<T>(count: number, fn: (n: number) => T): Array<T>;
 
 /**
  * Calls an input function `n` times, returning an array containing the results
@@ -28,13 +28,13 @@ export function times<T>(count: number, fn: (n: number) => T): T[];
  * @example times(5)(identity); //=> [0, 1, 2, 3, 4]
  * @data_last
  */
-export function times<T>(fn: (n: number) => T): (count: number) => T[];
+export function times<T>(fn: (n: number) => T): (count: number) => Array<T>;
 
 export function times() {
   return purry(_times, arguments);
 }
 
-function _times<T>(count: number, fn: (n: number) => T): T[] {
+function _times<T>(count: number, fn: (n: number) => T): Array<T> {
   if (count < 0) {
     throw new RangeError('n must be a non-negative number');
   }

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -10,7 +10,7 @@
  * @strict
  * @category Object
  */
-export function toPairs<T>(object: { [s: string]: T }): Array<[string, T]> {
+export function toPairs<T>(object: Record<string, T>): Array<[string, T]> {
   return Object.entries(object);
 }
 

--- a/src/type.test.ts
+++ b/src/type.test.ts
@@ -25,7 +25,6 @@ it('"String" if given a String literal', () => {
 });
 
 it('"String" if given a String object', () => {
-  // tslint:disable-next-line:no-construct
   expect(type(new String('I am a String object'))).toEqual('String');
 });
 

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -19,14 +19,14 @@ import { _reduceLazy, LazyResult } from './_reduceLazy';
  * @category Array
  */
 
-export function uniq<T>(array: readonly T[]): T[];
-export function uniq<T>(): (array: readonly T[]) => T[];
+export function uniq<T>(array: ReadonlyArray<T>): Array<T>;
+export function uniq<T>(): (array: ReadonlyArray<T>) => Array<T>;
 
 export function uniq() {
   return purry(_uniq, arguments, uniq.lazy);
 }
 
-function _uniq<T>(array: T[]) {
+function _uniq<T>(array: Array<T>) {
   return _reduceLazy(array, uniq.lazy());
 }
 

--- a/src/uniqBy.ts
+++ b/src/uniqBy.ts
@@ -2,9 +2,9 @@ import { purry } from './purry';
 import { _reduceLazy, LazyResult } from './_reduceLazy';
 
 export function uniqBy<T, K>(
-  array: readonly T[],
+  array: ReadonlyArray<T>,
   transformer: (item: T) => K
-): T[];
+): Array<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original list transformed by a function.
@@ -28,13 +28,13 @@ export function uniqBy<T, K>(
 
 export function uniqBy<T, K>(
   transformer: (item: T) => K
-): (array: readonly T[]) => T[];
+): (array: ReadonlyArray<T>) => Array<T>;
 
 export function uniqBy() {
   return purry(_uniqBy, arguments, lazyUniqBy);
 }
 
-function _uniqBy<T, K>(array: T[], transformer: (item: T) => K) {
+function _uniqBy<T, K>(array: Array<T>, transformer: (item: T) => K) {
   return _reduceLazy(array, lazyUniqBy(transformer));
 }
 

--- a/src/uniqWith.ts
+++ b/src/uniqWith.ts
@@ -19,7 +19,10 @@ type IsEquals<T> = (a: T, b: T) => boolean;
  * @data_first
  * @category Array
  */
-export function uniqWith<T>(array: readonly T[], isEquals: IsEquals<T>): T[];
+export function uniqWith<T>(
+  array: ReadonlyArray<T>,
+  isEquals: IsEquals<T>
+): Array<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original list.
@@ -40,19 +43,19 @@ export function uniqWith<T>(array: readonly T[], isEquals: IsEquals<T>): T[];
  */
 export function uniqWith<T>(
   isEquals: IsEquals<T>
-): (array: readonly T[]) => T[];
+): (array: ReadonlyArray<T>) => Array<T>;
 
 export function uniqWith() {
   return purry(_uniqWith, arguments, uniqWith.lazy);
 }
 
-function _uniqWith<T>(array: T[], isEquals: IsEquals<T>) {
+function _uniqWith<T>(array: Array<T>, isEquals: IsEquals<T>) {
   const lazy = uniqWith.lazy(isEquals);
   return _reduceLazy(array, lazy, true);
 }
 
 function _lazy<T>(isEquals: IsEquals<T>) {
-  return (value: T, index?: number, array?: T[]): LazyResult<T> => {
+  return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
     if (
       array &&
       array.findIndex(otherValue => isEquals(value, otherValue)) === index

--- a/src/values.ts
+++ b/src/values.ts
@@ -15,6 +15,8 @@
  * @category Object
  */
 
-export function values<T>(source: Record<PropertyKey, T> | ArrayLike<T>): T[] {
+export function values<T>(
+  source: Record<PropertyKey, T> | ArrayLike<T>
+): Array<T> {
   return Object.values(source);
 }

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -31,13 +31,15 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('arrays', () => {
     const actual = zip(first, second);
-    const result: AssertEqual<typeof actual, [number, string][]> = true;
+    const result: AssertEqual<typeof actual, Array<[number, string]>> = true;
     expect(result).toBe(true);
   });
   test('tuples', () => {
     const actual = zip(first as [1, 2, 3], second as ['a', 'b', 'c']);
-    const result: AssertEqual<typeof actual, [1 | 2 | 3, 'a' | 'b' | 'c'][]> =
-      true;
+    const result: AssertEqual<
+      typeof actual,
+      Array<[1 | 2 | 3, 'a' | 'b' | 'c']>
+    > = true;
     expect(result).toBe(true);
   });
   test('variadic tuples', () => {
@@ -46,7 +48,7 @@ describe('data first typings', () => {
     const actual = zip(firstVariadic, secondVariadic);
     const result: AssertEqual<
       typeof actual,
-      [string | number, string | number][]
+      Array<[string | number, string | number]>
     > = true;
     expect(result).toBe(true);
   });
@@ -77,13 +79,15 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('arrays', () => {
     const actual = zip(second)(first);
-    const result: AssertEqual<typeof actual, [number, string][]> = true;
+    const result: AssertEqual<typeof actual, Array<[number, string]>> = true;
     expect(result).toBe(true);
   });
   test('tuples', () => {
     const actual = zip(second as ['a', 'b', 'c'])(first as [1, 2, 3]);
-    const result: AssertEqual<typeof actual, [1 | 2 | 3, 'a' | 'b' | 'c'][]> =
-      true;
+    const result: AssertEqual<
+      typeof actual,
+      Array<[1 | 2 | 3, 'a' | 'b' | 'c']>
+    > = true;
     expect(result).toBe(true);
   });
   test('variadic tuples', () => {
@@ -92,7 +96,7 @@ describe('data second typings', () => {
     const actual = zip(secondVariadic)(firstVariadic);
     const result: AssertEqual<
       typeof actual,
-      [string | number, string | number][]
+      Array<[string | number, string | number]>
     > = true;
     expect(result).toBe(true);
   });

--- a/src/zipWith.test.ts
+++ b/src/zipWith.test.ts
@@ -23,7 +23,7 @@ describe('data first', () => {
 describe('data first typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(first, second, pred);
-    const result: AssertEqual<typeof actual, string[]> = true;
+    const result: AssertEqual<typeof actual, Array<string>> = true;
     expect(result).toBe(true);
   });
 });
@@ -43,7 +43,7 @@ describe('data second', () => {
 describe('data second typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred)(first, second);
-    const result: AssertEqual<typeof actual, string[]> = true;
+    const result: AssertEqual<typeof actual, Array<string>> = true;
     expect(result).toBe(true);
   });
 });
@@ -63,7 +63,7 @@ describe('data second with initial arg', () => {
 describe('data second with initial arg typings', () => {
   test('infers typing from predicate', () => {
     const actual = zipWith(pred, second)(first);
-    const result: AssertEqual<typeof actual, string[]> = true;
+    const result: AssertEqual<typeof actual, Array<string>> = true;
     expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
Enabling all rules with autofixers and then running them.

There is literally no manual changes done in this PR, so if we trust the autofixers (which I think is reasonable) we can feel confident in the changes.

For easier review I split the PR into 2 commits, one without the "@typescript-eslint/array-type" rule, and one with only that (as it changes a lot of files).
