### PR TITLE
chore(groupBy): filter on undefined

### DIFF
--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -93,3 +93,43 @@ describe('Result key types', () => {
     expect(result).toEqual(true);
   });
 });
+
+describe('Filtering groupBy', () => {
+  // These are all contrived examples because they are effectively filters, but
+  // they are used to validate that all possible combinations of the API can
+  // take an undefined value.
+
+  test('groupBy', () => {
+    const result = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8], item =>
+      item % 2 === 0 ? 'even' : undefined
+    );
+    expect(Object.values(result)).toHaveLength(1);
+    expect(result).toHaveProperty('even');
+    expect(result.even).toEqual([0, 2, 4, 6, 8]);
+  });
+  test('groupBy.indexed', () => {
+    const result = groupBy.indexed(
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+      (_, index) => (index % 2 === 0 ? 'even' : undefined)
+    );
+    expect(Object.values(result)).toHaveLength(1);
+    expect(result).toHaveProperty('even');
+    expect(result.even).toEqual(['a', 'c', 'e', 'g', 'i']);
+  });
+  test('groupBy.strict', () => {
+    const { even, ...rest } = groupBy.strict(
+      [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      item => (item % 2 === 0 ? 'even' : undefined)
+    );
+    expectTypeOf(rest).toEqualTypeOf({} as const);
+    expect(even).toEqual([0, 2, 4, 6, 8]);
+  });
+  test('groupBy.strict.indexed', () => {
+    const { even, ...rest } = groupBy.strict.indexed(
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+      (_, index) => (index % 2 === 0 ? 'even' : undefined)
+    );
+    expectTypeOf(rest).toEqualTypeOf({} as const);
+    expect(even).toEqual(['a', 'c', 'e', 'g', 'i']);
+  });
+});

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -4,13 +4,14 @@ import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.
  * @param items the items to group
- * @param fn the grouping function
+ * @param fn the grouping function. When the function returns `undefined` the item would be filtered out and not be added to any group.
  * @signature
  *    R.groupBy(array, fn)
  *    R.groupBy.strict(array, fn)
  * @example
  *    R.groupBy(['one', 'two', 'three'], x => x.length) // => {3: ['one', 'two'], 5: ['three']}
  *    R.groupBy.strict([{a: 'cat'}, {b: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *    R.groupBy.strict<{ name: string, type: "cat" | "dog" | undefined }>(arr, prop('type')) // All animals without a type would be filtered out
  * @data_first
  * @indexed
  * @strict
@@ -18,11 +19,11 @@ import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
  */
 export function groupBy<T>(
   items: ReadonlyArray<T>,
-  fn: (item: T) => PropertyKey
+  fn: (item: T) => PropertyKey | undefined
 ): Record<PropertyKey, NonEmptyArray<T>>;
 
 export function groupBy<T>(
-  fn: (item: T) => PropertyKey
+  fn: (item: T) => PropertyKey | undefined
 ): (array: ReadonlyArray<T>) => Record<PropertyKey, NonEmptyArray<T>>;
 
 /**
@@ -42,15 +43,20 @@ export function groupBy() {
 
 const _groupBy =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
+  <T, Key extends PropertyKey>(
+    array: Array<T>,
+    fn: PredIndexedOptional<T, Key | undefined>
+  ) => {
     const ret: Record<string, Array<T>> = {};
     array.forEach((item, index) => {
-      const value = indexed ? fn(item, index, array) : fn(item);
-      const key = String(value);
-      if (!ret[key]) {
-        ret[key] = [];
+      const key = indexed ? fn(item, index, array) : fn(item);
+      if (key !== undefined) {
+        const keyStr = String(key);
+        if (!ret[keyStr]) {
+          ret[keyStr] = [];
+        }
+        ret[keyStr].push(item);
       }
-      ret[key].push(item);
     });
     return ret;
   };
@@ -78,21 +84,21 @@ type Out<Value, Key extends PropertyKey = PropertyKey> =
 export namespace groupBy {
   export function indexed<T>(
     array: ReadonlyArray<T>,
-    fn: PredIndexed<T, PropertyKey>
+    fn: PredIndexed<T, PropertyKey | undefined>
   ): Record<string, NonEmptyArray<T>>;
   export function indexed<T>(
-    fn: PredIndexed<T, PropertyKey>
+    fn: PredIndexed<T, PropertyKey | undefined>
   ): (array: ReadonlyArray<T>) => Record<string, NonEmptyArray<T>>;
   export function indexed() {
     return purry(_groupBy(true), arguments);
   }
   export function strict<Value, Key extends PropertyKey = PropertyKey>(
     items: ReadonlyArray<Value>,
-    fn: (item: Value) => Key
+    fn: (item: Value) => Key | undefined
   ): Out<Value, Key>;
 
   export function strict<Value, Key extends PropertyKey = PropertyKey>(
-    fn: (item: Value) => Key
+    fn: (item: Value) => Key | undefined
   ): (array: ReadonlyArray<Value>) => Out<Value, Key>;
 
   export function strict() {
@@ -102,10 +108,10 @@ export namespace groupBy {
   export namespace strict {
     export function indexed<Value, Key extends PropertyKey = PropertyKey>(
       array: ReadonlyArray<Value>,
-      fn: PredIndexed<Value, Key>
+      fn: PredIndexed<Value, Key | undefined>
     ): Out<Value, Key>;
     export function indexed<Value, Key extends PropertyKey = PropertyKey>(
-      fn: PredIndexed<Value, Key>
+      fn: PredIndexed<Value, Key | undefined>
     ): (array: ReadonlyArray<Value>) => Out<Value, Key>;
     export function indexed() {
       return purry(_groupBy(true), arguments);


### PR DESCRIPTION
Somtimes you want to run groupBy as a n-dimensional `filter`, but the nature of groupBy as its strictly defined doesn't allow you to also actually filter the items.

To also filter we have 3 options:
1. Using a pseudo group (like "none") and filter it after the groupBy, via `pick` or `exclude`. But this would mean that we build the whole array of items that we are going to discard just to discard it, and we build a new object from entries twice.
2. Filter first, then do the grouping. But this would mean running the grouper logic twice (or 2 similar grouper logics). If the grouper logic is expensive to run this is wasteful. And also results in code duplication. This also complicates typing because we need the type after the filter to refine the cases we filtered on.
3. To optimize on the previous 2 we can map over the array, pushing the grouping value into a new object together with the current item, then filter and group on these, and then map again to remove the grouper value from the items in the arrays. But we can't avoid creating a lot of throwaway objects and arrays throughout the whole thing, this might end up even less efficient, and the code is still not more readable).

When the array is small and the grouper function is trivial this doesn't matter; but if they are both long and expensive or we need to run this a lot of times, we will start to run into inefficiencies which can't be easily optimized.

To solve this we can support an undefined return value for the grouper to signal that the item shouldn't be grouped in any category, performing the whole operation we need in one sweep.

Because the grouper *has* to return a PropertyKey (which can't be undefined) the undefined return value is unambigously obvious as the filtering value, and it works well with filtering based on optional props of an object.

```ts
groupBy<{ name: string, type?: "cat" | "dog" }>(arr, prop("type"))
```

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
