### PR TITLE
chore(prettier): Modernize config

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,11 +1,5 @@
 /** @type {import('prettier').Config} */
 module.exports = {
-  semi: true,
-  useTabs: false,
-  printWidth: 80,
-  tabWidth: 2,
   singleQuote: true,
-  trailingComma: 'es5',
-  jsxBracketSameLine: false,
   arrowParens: 'avoid',
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,24 +1,11 @@
 /** @type {import('prettier').Config} */
 module.exports = {
-  // write: true,
   semi: true,
-  useTabs: false, // Indent lines with tabs instead of spaces.
-  printWidth: 80, // Specify the length of line that the printer will wrap on.
-  tabWidth: 2, // Specify the number of spaces per indentation-level.
-  singleQuote: true, // Use single quotes instead of double quotes.
-  /**
-   * Print trailing commas wherever possible.
-   * Valid options:
-   *   - "none" - no trailing commas
-   *   - "es5" - trailing commas where valid in ES5 (objects, arrays, etc)
-   *   - "all" - trailing commas wherever possible (function arguments)
-   */
+  useTabs: false,
+  printWidth: 80,
+  tabWidth: 2,
+  singleQuote: true,
   trailingComma: 'es5',
-  /**
-   * Do not print spaces between brackets.
-   * If true, puts the > of a multi-line jsx element at the end of the last line instead of being
-   * alone on the next line
-   */
   jsxBracketSameLine: false,
   arrowParens: 'avoid',
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -19,12 +19,5 @@ module.exports = {
    * alone on the next line
    */
   jsxBracketSameLine: false,
-  /**
-   * Specify which parse to use.
-   * Valid options:
-   *   - "flow"
-   *   - "babylon"
-   */
-  parser: 'typescript',
   arrowParens: 'avoid',
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Config} */
 module.exports = {
   // write: true,
   semi: true,


### PR DESCRIPTION
* I initially started touching this file because of the parser config. It breaks using prettier for anything other than typescript and [is wrongly configured based on the prettier documentation](https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option)
> Never put the parser option at the top level of your configuration. Only use it inside overrides. Otherwise you effectively disable Prettier’s automatic file extension based parser inference. This forces Prettier to use the parser you specified for all types of files – even when it doesn’t make sense, such as trying to parse a CSS file as JavaScript.

* In addition I added typing for the config (similar to a json schema) which provides autocomplete, typechecking the values, and inline documentation. This allowed me to remove all the inline comments which were just copy pasted documentation.

* Lastly, I removed all settings which just used the default value, this would allow us to take prettier best practices as they are released.


