### PR TITLE
fix(build): Refine build directory

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
Including extra files from the parent directory in tsconfig means that tsc will build everything under the folder it lives in. By only taking files from `src` tsc considers it the root directory and doesn't create it as a subdir.
