### PR TITLE
fix(first): better typing

### DIFF
--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -133,6 +133,20 @@ describe('strict typing', () => {
     expect(result).toEqual(undefined);
   });
 
+  test('array with last', () => {
+    const arr: [...Array<number>, number] = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('tuple with last', () => {
+    const arr: [...Array<string>, number] = ['a', 1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number>();
+    expect(result).toEqual('a');
+  });
+
   test('simple empty readonly array', () => {
     const arr: ReadonlyArray<number> = [];
     const result = first(arr);
@@ -173,5 +187,19 @@ describe('strict typing', () => {
     const result = first(arr);
     expectTypeOf(result).toEqualTypeOf(undefined);
     expect(result).toEqual(undefined);
+  });
+
+  test('readonly array with last', () => {
+    const arr: readonly [...Array<number>, number] = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('readonly tuple with last', () => {
+    const arr: readonly [...Array<string>, number] = ['a', 1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number>();
+    expect(result).toEqual('a');
   });
 });

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -89,3 +89,89 @@ describe('pipe', () => {
     expect(result).toEqual(5);
   });
 });
+
+describe('strict typing', () => {
+  test('simple empty array', () => {
+    const arr: Array<number> = [];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple array', () => {
+    const arr: Array<number> = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple non-empty array', () => {
+    const arr: [number, ...Array<number>] = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple tuple', () => {
+    const arr: [number, string] = [1, 'a'];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('array with more than one item', () => {
+    const arr: [number, number, ...Array<number>] = [1, 2];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('trivial empty array', () => {
+    const arr: [] = [];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf(undefined);
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple empty readonly array', () => {
+    const arr: ReadonlyArray<number> = [];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple readonly array', () => {
+    const arr: ReadonlyArray<number> = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple non-empty readonly array', () => {
+    const arr: readonly [number, ...Array<number>] = [1];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple readonly tuple', () => {
+    const arr: readonly [number, string] = [1, 'a'];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('readonly array with more than one item', () => {
+    const arr: readonly [number, number, ...Array<number>] = [1, 2];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
+
+  test('readonly trivial empty array', () => {
+    const arr: readonly [] = [];
+    const result = first(arr);
+    expectTypeOf(result).toEqualTypeOf(undefined);
+    expect(result).toEqual(undefined);
+  });
+});

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,8 +1,12 @@
 import { purry } from './purry';
-import { NonEmptyArray } from './_types';
 
-type FirstOut<T extends ReadonlyArray<unknown> | []> =
-  T extends Readonly<NonEmptyArray<unknown>> ? T[0] : T[0] | undefined;
+type FirstOut<T extends ReadonlyArray<unknown> | []> = T extends []
+  ? undefined
+  : T extends readonly [unknown, ...Array<unknown>]
+  ? T[0]
+  : T extends readonly [...infer Pre, infer Last]
+  ? Pre[0] | Last
+  : T[0] | undefined;
 
 /**
  * Gets the first element of `array`.

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,4 +1,8 @@
 import { purry } from './purry';
+import { NonEmptyArray } from './_types';
+
+type FirstOut<T extends ReadonlyArray<unknown> | []> =
+  T extends Readonly<NonEmptyArray<unknown>> ? T[0] : T[0] | undefined;
 
 /**
  * Gets the first element of `array`.
@@ -19,15 +23,19 @@ import { purry } from './purry';
  * @category array
  * @pipeable
  */
-export function first<T>(array: ReadonlyArray<T>): T | undefined;
-export function first<T>(): (array: ReadonlyArray<T>) => T | undefined;
+export function first<T extends ReadonlyArray<unknown> | []>(
+  array: Readonly<T>
+): FirstOut<T>;
+export function first<T extends ReadonlyArray<unknown> | []>(): (
+  array: Readonly<T>
+) => FirstOut<T>;
 
 export function first() {
   return purry(_first, arguments, first.lazy);
 }
 
-function _first<T>(array: Array<T>) {
-  return array[0];
+function _first<T>([first]: ReadonlyArray<T>) {
+  return first;
 }
 
 export namespace first {


### PR DESCRIPTION
There are several situations were the type of the first value could be inferred more precisely than just `T[0] | undefined`; when the array is not empty, and when taking into consideration arrays used as tuples too.

---

- [x] Tests added for new methods and updated for changed
