### PR TITLE
chore: Use strictest typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "sideEffects": false,
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",
+    "@types/eslint": "^8.21.3",
+    "@types/prettier": "^2.7.2",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "@vitest/coverage-c8": "^0.27.2",

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -33,12 +33,13 @@ export function _reduceLazy<T, K>(
   // We intentionally use a for loop here instead of reduce for performance reasons. See https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/ for more info
   for (const item of array) {
     const result = indexed ? lazy(item, index, array) : lazy(item);
+    index += 1;
+
     if (result.hasMany === true) {
       newArray.push(...result.next);
     } else if (result.hasNext) {
       newArray.push(result.next);
     }
-    index += 1;
   }
   return newArray;
 }

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -27,15 +27,18 @@ export function _reduceLazy<T, K>(
   indexed?: boolean
 ): Array<K> {
   const newArray: Array<K> = [];
+  // TODO: If we use ES2015 (i think) we can use `Array.entries()` to iterate
+  // using for...of loops on both the item and the index.
+  let index = 0;
   // We intentionally use a for loop here instead of reduce for performance reasons. See https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/ for more info
-  for (let index = 0; index < array.length; index++) {
-    const item = array[index];
+  for (const item of array) {
     const result = indexed ? lazy(item, index, array) : lazy(item);
     if (result.hasMany === true) {
       newArray.push(...result.next);
     } else if (result.hasNext) {
       newArray.push(result.next);
     }
+    index += 1;
   }
   return newArray;
 }

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -1,5 +1,5 @@
+import type { NonEmptyArray } from './_types';
 import { chunk } from './chunk';
-import { NonEmptyArray } from './_types';
 
 describe('data first', () => {
   test('equal size', () => {

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,4 +1,4 @@
-import { IterableContainer, NonEmptyArray } from './_types';
+import type { IterableContainer, NonEmptyArray } from './_types';
 import { purry } from './purry';
 
 type Chunked<T extends IterableContainer> =

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -116,8 +116,9 @@ describe('deep clone functions', () => {
 
     const cloned = clone(list);
 
-    eq(cloned[0].a(10), 20);
-    eq(list[0].a, cloned[0].a);
+    expect(cloned).length.greaterThanOrEqual(1);
+    eq(cloned[0]?.a(10), 20);
+    eq(list[0]?.a, cloned[0]?.a);
   });
 });
 
@@ -157,6 +158,7 @@ describe('deep clone deep nested mixed objects', () => {
   it('clones array with arrays', () => {
     const list: Array<Array<any>> = [[1], [[3]]];
     const cloned = clone(list);
+    // @ts-expect-error (ts2532) - We know this is safe
     list[1][0] = null;
     eq(cloned, [[1], [[3]]]);
   });
@@ -166,17 +168,18 @@ describe('deep clone deep nested mixed objects', () => {
     const list = [{ b: obj }, { b: obj }];
     const cloned = clone(list);
 
-    assert.strictEqual(list[0].b, list[1].b);
-    assert.strictEqual(cloned[0].b, cloned[1].b);
-    assert.notStrictEqual(cloned[0].b, list[0].b);
-    assert.notStrictEqual(cloned[1].b, list[1].b);
+    expect(cloned).length.greaterThanOrEqual(2);
+    assert.strictEqual(list[0]?.b, list[1]?.b);
+    assert.strictEqual(cloned[0]?.b, cloned[1]?.b);
+    assert.notStrictEqual(cloned[0]?.b, list[0]?.b);
+    assert.notStrictEqual(cloned[1]?.b, list[1]?.b);
 
-    eq(cloned[0].b, { a: 1 });
-    eq(cloned[1].b, { a: 1 });
+    eq(cloned[0]?.b, { a: 1 });
+    eq(cloned[1]?.b, { a: 1 });
 
     obj.a = 2;
-    eq(cloned[0].b, { a: 1 });
-    eq(cloned[1].b, { a: 1 });
+    eq(cloned[0]?.b, { a: 1 });
+    eq(cloned[1]?.b, { a: 1 });
   });
 });
 

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { Pred, PredIndexed, PredIndexedOptional } from './_types';
+import type { Pred, PredIndexed, PredIndexedOptional } from './_types';
 
 const _countBy =
   (indexed: boolean) =>

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -50,7 +50,6 @@ function _equals(a: any, b: any) {
     const arrB = isArray(b);
     let i;
     let length;
-    let key;
 
     if (arrA && arrB) {
       length = a.length;
@@ -94,14 +93,13 @@ function _equals(a: any, b: any) {
       return false;
     }
 
-    for (i = length; i-- !== 0; ) {
-      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) {
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) {
         return false;
       }
     }
 
-    for (i = length; i-- !== 0; ) {
-      key = keys[i];
+    for (const key of keys) {
       if (!equals(a[key], b[key])) {
         return false;
       }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,6 @@
 import { purry } from './purry';
 import { _reduceLazy, LazyResult } from './_reduceLazy';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 
 /**

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 import { _toSingle } from './_toSingle';
 

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 import { _toSingle } from './_toSingle';
 

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -55,6 +55,8 @@ const _findLast =
   (indexed: boolean) =>
   <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
+      // @ts-expect-error [ts2345] - This is safe, we are simply iterating over
+      // indexes of the array
       if (indexed ? fn(array[i], i, array) : fn(array[i])) {
         return array[i];
       }

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -59,6 +59,7 @@ const _findLast =
         return array[i];
       }
     }
+    return undefined;
   };
 
 export namespace findLast {

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Returns the value of the last element in the array where predicate is true, and undefined

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Returns the index of the last element in the array where predicate is true, and -1 otherwise.

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -54,6 +54,8 @@ const _findLastIndex =
   (indexed: boolean) =>
   <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
+      // @ts-expect-error [ts2345] - This is safe, we are simply iterating over
+      // indexes of the array
       if (indexed ? fn(array[i], i, array) : fn(array[i])) {
         return i;
       }

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from './_types';
+import type { IterableContainer } from './_types';
 import { purry } from './purry';
 
 type FirstOut<T extends IterableContainer> = T extends []

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -1,4 +1,4 @@
-import { PredIndexedOptional } from './_types';
+import type { PredIndexedOptional } from './_types';
 import { purry } from './purry';
 
 /**

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -1,7 +1,7 @@
 import { purry } from './purry';
 import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { _toLazyIndexed } from './_toLazyIndexed';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Iterate an array using a defined callback function. The original array is returned instead of `void`.

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,6 +1,6 @@
+import type { NonEmptyArray } from './_types';
 import { groupBy } from './groupBy';
 import { pipe } from './pipe';
-import type { NonEmptyArray } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -87,7 +87,7 @@ describe('Filtering on undefined grouper result', () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty('even');
-    expect(result.even).toEqual([0, 2, 4, 6, 8]);
+    expect(result['even']).toEqual([0, 2, 4, 6, 8]);
   });
 
   test('regular indexed', () => {
@@ -97,7 +97,7 @@ describe('Filtering on undefined grouper result', () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty('even');
-    expect(result.even).toEqual(['a', 'c', 'e', 'g', 'i']);
+    expect(result['even']).toEqual(['a', 'c', 'e', 'g', 'i']);
   });
 
   test('strict', () => {

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,6 +1,6 @@
 import { groupBy } from './groupBy';
 import { pipe } from './pipe';
-import { NonEmptyArray } from './_types';
+import type { NonEmptyArray } from './_types';
 
 const array = [
   { a: 1, b: 1 },

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
+import type { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -53,10 +53,12 @@ const _groupBy =
       const key = indexed ? fn(item, index, array) : fn(item);
       if (key !== undefined) {
         const actualKey = String(key);
-        if (!ret[actualKey]) {
-          ret[actualKey] = [];
+        let group = ret[actualKey];
+        if (group === undefined) {
+          group = [];
+          ret[actualKey] = group;
         }
-        ret[actualKey].push(item);
+        group.push(item);
       }
     });
     return ret;

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexedOptional, PredIndexed } from './_types';
+import type { PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Converts a list of objects into an object indexing the objects by the given key.

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -1,6 +1,6 @@
 import { last } from './last';
 import { pipe } from './pipe';
-import { NonEmptyArray } from './_types';
+import type { NonEmptyArray } from './_types';
 
 describe('last', () => {
   describe('data first', () => {

--- a/src/last.ts
+++ b/src/last.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from './_types';
+import type { NonEmptyArray } from './_types';
 import { purry } from './purry';
 
 /**

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -10,7 +10,7 @@ describe('data_first', () => {
     expect(result).toEqual([2, 4, 6]);
   });
   it('map.indexed', () => {
-    const result = map.indexed([0, 0, 0] as const, (x, i) => i);
+    const result = map.indexed([0, 0, 0] as const, (_, i) => i);
     expect(result).toEqual([0, 1, 2]);
   });
 });
@@ -26,7 +26,7 @@ describe('data_last', () => {
   it('map.indexed', () => {
     const result = pipe(
       [0, 0, 0] as const,
-      map.indexed((x, i) => i)
+      map.indexed((_, i) => i)
     );
     expect(result).toEqual([0, 1, 2]);
   });
@@ -51,7 +51,7 @@ describe('pipe', () => {
     const count = vi.fn();
     const result = pipe(
       [0, 0, 0] as const,
-      map.indexed((x, i) => {
+      map.indexed((_, i) => {
         count();
         return i;
       }),

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,7 +1,7 @@
 import { purry } from './purry';
 import { LazyResult, _reduceLazy } from './_reduceLazy';
 import { _toLazyIndexed } from './_toLazyIndexed';
-import {
+import type {
   IterableContainer,
   Pred,
   PredIndexed,

--- a/src/mapToObj.test.ts
+++ b/src/mapToObj.test.ts
@@ -7,7 +7,7 @@ describe('data_first', () => {
     expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
   });
   it('mapToObj.indexed', () => {
-    const result = mapToObj.indexed([0, 0, 0] as const, (x, i) => [i, i]);
+    const result = mapToObj.indexed([0, 0, 0] as const, (_, i) => [i, i]);
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });
@@ -23,7 +23,7 @@ describe('data_last', () => {
   it('mapToObj.indexed', () => {
     const result = pipe(
       [0, 0, 0] as const,
-      mapToObj.indexed((x, i) => [i, i])
+      mapToObj.indexed((_, i) => [i, i])
     );
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -1,4 +1,4 @@
-import { PredIndexedOptional } from './_types';
+import type { PredIndexedOptional } from './_types';
 import { purry } from './purry';
 
 /**

--- a/src/maxBy.ts
+++ b/src/maxBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexed, PredIndexedOptional } from './_types';
+import type { PredIndexed, PredIndexedOptional } from './_types';
 
 const _maxBy =
   (indexed: boolean) =>

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexed, PredIndexedOptional } from './_types';
+import type { PredIndexed, PredIndexedOptional } from './_types';
 
 const _meanBy =
   (indexed: boolean) =>

--- a/src/minBy.ts
+++ b/src/minBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexed, PredIndexedOptional } from './_types';
+import type { PredIndexed, PredIndexedOptional } from './_types';
 
 const _minBy =
   (indexed: boolean) =>

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -5,7 +5,7 @@ describe('data first', () => {
   test('it should omit props', () => {
     const result = omitBy(
       { a: 1, b: 2, A: 3, B: 4 },
-      (val, key) => key.toUpperCase() === key
+      (_, key) => key.toUpperCase() === key
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
@@ -13,7 +13,7 @@ describe('data first', () => {
   test('allow partial type', () => {
     const result = omitBy(
       {} as Partial<{ a: string; b: number }>,
-      (val, key) => key === 'a'
+      (_, key) => key === 'a'
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
@@ -24,7 +24,7 @@ describe('data last', () => {
   test('it should omit props', () => {
     const result = pipe(
       { a: 1, b: 2, A: 3, B: 4 },
-      omitBy((val, key) => key.toUpperCase() === key)
+      omitBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
@@ -32,7 +32,7 @@ describe('data last', () => {
   test('allow partial type', () => {
     const result = pipe(
       {} as Partial<{ a: string; b: number }>,
-      omitBy((val, key) => key.toUpperCase() === key)
+      omitBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexedOptional, PredIndexed } from './_types';
+import type { PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Splits a collection into two groups, the first of which contains elements the `predicate` type guard passes, and the second one containing the rest.

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -5,19 +5,19 @@ describe('data first', () => {
   test('it should pick props', () => {
     const result = pickBy(
       { a: 1, b: 2, A: 3, B: 4 },
-      (val, key) => key.toUpperCase() === key
+      (_, key) => key.toUpperCase() === key
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
   });
   test('allow undefined or null', () => {
-    expect(pickBy(undefined as any, (val, key) => key === 'foo')).toEqual({});
-    expect(pickBy(null as any, (val, key) => key === 'foo')).toEqual({});
+    expect(pickBy(undefined as any, (_, key) => key === 'foo')).toEqual({});
+    expect(pickBy(null as any, (_, key) => key === 'foo')).toEqual({});
   });
   test('allow partial type', () => {
     const result = pickBy(
       {} as { a?: string; b?: number },
-      (val, key) => key === 'a'
+      (_, key) => key === 'a'
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
@@ -28,7 +28,7 @@ describe('data last', () => {
   test('it should pick props', () => {
     const result = pipe(
       { a: 1, b: 2, A: 3, B: 4 },
-      pickBy((val, key) => key.toUpperCase() === key)
+      pickBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
@@ -36,7 +36,7 @@ describe('data last', () => {
   test('allow partial type', () => {
     const result = pipe(
       {} as { a?: string; b?: number },
-      pickBy((val, key) => key.toUpperCase() === key)
+      pickBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -214,6 +214,8 @@ export function pipe(
     const op = operations[opIdx];
     const lazyOp = lazyOps[opIdx];
     if (!lazyOp) {
+      // @ts-expect-error [ts2722] - opIdx is within range of operations so we
+      // know this is safe...
       ret = op(ret);
       opIdx++;
       continue;

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -1,4 +1,4 @@
-import { LazyResult } from './_reduceLazy';
+import type { LazyResult } from './_reduceLazy';
 
 /**
  * Perform left-to-right function composition.

--- a/src/randomString.ts
+++ b/src/randomString.ts
@@ -11,8 +11,9 @@ import { range } from './range';
 export function randomString(length: number) {
   const characterSet =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const randomChar = () =>
+  const randomChar = (): string =>
+    // @ts-expect-error [ts2322] - We know the index will be in-range
     characterSet[Math.floor(Math.random() * characterSet.length)];
 
-  return range(0, length).reduce(text => `${text}${randomChar() ?? ''}`, '');
+  return range(0, length).reduce(text => text + randomChar(), '');
 }

--- a/src/randomString.ts
+++ b/src/randomString.ts
@@ -14,5 +14,5 @@ export function randomString(length: number) {
   const randomChar = () =>
     characterSet[Math.floor(Math.random() * characterSet.length)];
 
-  return range(0, length).reduce(text => text + randomChar(), '');
+  return range(0, length).reduce(text => `${text}${randomChar() ?? ''}`, '');
 }

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -1,6 +1,6 @@
 import { purry } from './purry';
 import { _reduceLazy, LazyResult } from './_reduceLazy';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
+import type { Pred, PredIndexedOptional, PredIndexed } from './_types';
 import { _toLazyIndexed } from './_toLazyIndexed';
 
 /**

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { NonEmptyArray } from './_types';
+import type { NonEmptyArray } from './_types';
 
 type Direction = 'asc' | 'desc';
 type SortProjection<T> = (x: T) => Comparable;

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -37,7 +37,13 @@ export function splitWhen() {
 
 function _splitWhen<T>(array: Array<T>, fn: (item: T) => boolean) {
   for (let i = 0; i < array.length; i++) {
-    if (fn(array[i])) {
+    if (
+      fn(
+        // @ts-expect-error [ts2345] - We are iterating over the array so we know
+        // this is safe.
+        array[i]
+      )
+    ) {
       return splitAt(array, i);
     }
   }

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -1,5 +1,5 @@
-import { splitAt } from './splitAt';
 import { purry } from './purry';
+import { splitAt } from './splitAt';
 
 /**
  * Splits a given array at the first index where the given predicate returns true.
@@ -36,16 +36,6 @@ export function splitWhen() {
 }
 
 function _splitWhen<T>(array: Array<T>, fn: (item: T) => boolean) {
-  for (let i = 0; i < array.length; i++) {
-    if (
-      fn(
-        // @ts-expect-error [ts2345] - We are iterating over the array so we know
-        // this is safe.
-        array[i]
-      )
-    ) {
-      return splitAt(array, i);
-    }
-  }
-  return [array, []];
+  const index = array.findIndex(fn);
+  return index >= 0 ? splitAt(array, index) : [array, []];
 }

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -1,5 +1,5 @@
 import { purry } from './purry';
-import { PredIndexed, PredIndexedOptional } from './_types';
+import type { PredIndexed, PredIndexedOptional } from './_types';
 
 const _sumBy =
   (indexed: boolean) =>

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -39,14 +39,21 @@ export function zipObj() {
 }
 
 function _zipObj(
-  first: Array<string | number | symbol>,
-  second: Array<unknown>
+  keys: ReadonlyArray<string | number | symbol>,
+  values: ReadonlyArray<unknown>
 ) {
-  const resultLength =
-    first.length > second.length ? second.length : first.length;
   const result: Record<string | number | symbol, unknown> = {};
-  for (let i = 0; i < resultLength; i++) {
-    result[first[i]] = second[i];
+
+  let index = 0;
+  for (const key of keys) {
+    if (index >= values.length) {
+      break;
+    }
+
+    const value = values[index];
+    index += 1;
+
+    result[key] = value;
   }
 
   return result;

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -44,7 +44,10 @@ function _zipObj(
 ) {
   const result: Record<string | number | symbol, unknown> = {};
 
+  // TODO: If we use ES2015 (i think) we can use `Array.entries()` to iterate
+  // using for...of loops on both the item and the index.
   let index = 0;
+
   for (const key of keys) {
     if (index >= values.length) {
       break;

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -66,6 +66,8 @@ export function zipWith() {
   if (args.length === 3) {
     return _zipWith(args[0], args[1], args[2]);
   }
+
+  throw new TypeError('Unsupported invocation params');
 }
 
 function _zipWith<F, S, R>(

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -75,11 +75,16 @@ function _zipWith<F, S, R>(
   second: Array<S>,
   fn: (f: F, s: S) => R
 ) {
-  const resultLength =
-    first.length > second.length ? second.length : first.length;
-  const result = [];
-  for (let i = 0; i < resultLength; i++) {
-    result.push(fn(first[i], second[i]));
+  const result: Array<R> = Array.from({
+    length: Math.min(first.length, second.length),
+  });
+  for (let i = 0; i < result.length; i++) {
+    result[i] = fn(
+      // @ts-expect-error [ts2345] - our index will only ever iterate over the
+      // shortest array, so these are always defined...
+      first[i],
+      second[i]
+    );
   }
 
   return result;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     // MODULES
     "types": ["vitest/globals"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
+    "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,10 +35,5 @@
     // most likely safe to up this value, and it would probably result in a
     // smaller package size.
     "target": "ES5"
-
-    // "strict": true,
-    // "esModuleInterop": true,
-    // "skipLibCheck": true,
-    // "forceConsistentCasingInFileNames": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "importsNotUsedAsValues": "error",
     "noEmit": true,
 
+    // Javascript Support
+    "checkJs": true,
+
     // LANGUAGE and ENVIRONMENT
     "lib": ["ES6", "ES2017.Object"],
     // TODO: The recommended target is ES2015 (ES6). Node10 supports es2018 and

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,12 @@
 
   "compilerOptions": {
     // TYPE CHECKING
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
 
     // MODULES
@@ -23,5 +28,10 @@
     // most likely safe to up this value, and it would probably result in a
     // smaller package size.
     "target": "ES5"
+
+    // "strict": true,
+    // "esModuleInterop": true,
+    // "skipLibCheck": true,
+    // "forceConsistentCasingInFileNames": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
 
     // MODULES

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "types": ["vitest/globals"],
 
     // EMIT
+    "importsNotUsedAsValues": "error",
     "noEmit": true,
 
     // LANGUAGE and ENVIRONMENT

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,19 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
   integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
 
+"@types/eslint@^8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.21.3.tgz#5794b3911f0f19e34e3a272c49cbdf48d6f543f2"
+  integrity sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+
 "@types/fs-extra@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.1.tgz#cd856fbbdd6af2c11f26f8928fd8644c9e9616c9"
@@ -247,7 +260,7 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
   integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
 
-"@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -276,6 +289,11 @@
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+
+"@types/prettier@^2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
+  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
 "@types/semver@^7.3.12":
   version "7.3.13"


### PR DESCRIPTION
Using [the strictest tsconfig base](https://github.com/tsconfig/bases/blob/main/bases/strictest.json) as a reference, I turned on extra typechecking flags in our tsconfig and followed up with the changes they required in our code. Where it was easy and obvious I also reimplemented logic to better fit with modern typescript. For example, usage of for...of loops instead of indexes. This is currently being backported as regular for loops by typescript in our emitted code, but could be kept natively once we move to es2015. In most other places I simply suppressed the new error for now...

Each commit handles one flag, to make it easier to break down the review.

For easier reviewing, the only files with non-trivial changes are:
- [ ] equals
- [ ] groupBy
- [ ] sortBy
- [ ] zipWith
- [ ] _reduceLazy
- [ ] splitWhen

And the test file:
- [ ] clone.test
