### PR TITLE
chore: IterableContainer

### DIFF
--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,7 +1,7 @@
+import { IterableContainer, NonEmptyArray } from './_types';
 import { purry } from './purry';
-import { NonEmptyArray } from './_types';
 
-type Chunked<T extends ReadonlyArray<unknown> | []> =
+type Chunked<T extends IterableContainer> =
   | (T extends
       | readonly [unknown, ...Array<unknown>]
       | readonly [...Array<unknown>, unknown]
@@ -21,7 +21,7 @@ type Chunked<T extends ReadonlyArray<unknown> | []> =
  * @data_first
  * @category Array
  */
-export function chunk<T extends ReadonlyArray<unknown> | []>(
+export function chunk<T extends IterableContainer>(
   array: T,
   size: number
 ): Chunked<T>;
@@ -37,7 +37,7 @@ export function chunk<T extends ReadonlyArray<unknown> | []>(
  * @data_last
  * @category Array
  */
-export function chunk<T extends ReadonlyArray<unknown> | []>(
+export function chunk<T extends IterableContainer>(
   size: number
 ): (array: T) => Chunked<T>;
 

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,6 +1,7 @@
+import { IterableContainer } from './_types';
 import { purry } from './purry';
 
-type FirstOut<T extends ReadonlyArray<unknown> | []> = T extends []
+type FirstOut<T extends IterableContainer> = T extends []
   ? undefined
   : T extends readonly [unknown, ...Array<unknown>]
   ? T[0]
@@ -27,10 +28,10 @@ type FirstOut<T extends ReadonlyArray<unknown> | []> = T extends []
  * @category array
  * @pipeable
  */
-export function first<T extends ReadonlyArray<unknown> | []>(
+export function first<T extends IterableContainer>(
   array: Readonly<T>
 ): FirstOut<T>;
-export function first<T extends ReadonlyArray<unknown> | []>(): (
+export function first<T extends IterableContainer>(): (
   array: Readonly<T>
 ) => FirstOut<T>;
 


### PR DESCRIPTION
Just using the IterableContainer type that was defined in one of the recent PRs to the rest of the utilities that used it.