### PR TITLE
feat(sort): strictm mode

### DIFF
--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -17,3 +17,65 @@ describe('data_last', () => {
     ).toEqual([2, 4, 5, 7]);
   });
 });
+
+describe('strict', () => {
+  it('on empty tuple', () => {
+    const array: [] = [];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on empty readonly tuple', () => {
+    const array: readonly [] = [];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on array', () => {
+    const array: Array<number> = [];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+  });
+
+  it('on readonly array', () => {
+    const array: ReadonlyArray<number> = [];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+  });
+
+  it('on tuple', () => {
+    const array: [1, 2, 3] = [1, 2, 3];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
+  });
+
+  it('on readonly tuple', () => {
+    const array: readonly [1, 2, 3] = [1, 2, 3];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
+  });
+
+  it('on tuple with rest tail', () => {
+    const array: [number, ...Array<number>] = [1];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+  });
+
+  it('on readonly tuple with rest tail', () => {
+    const array: readonly [number, ...Array<number>] = [1];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+  });
+
+  it('on tuple with rest head', () => {
+    const array: [...Array<number>, number] = [1];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+  });
+
+  it('on readonly tuple with rest head', () => {
+    const array: readonly [...Array<number>, number] = [1];
+    const result = sort.strict(array, (a, b) => a - b);
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+  });
+});

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -78,4 +78,16 @@ describe('strict', () => {
     const result = sort.strict(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
+
+  it('on mixed types tuple', () => {
+    const array: [number, string, boolean] = [1, 'hello', true];
+    const result = sort.strict(array, () => 1);
+    expectTypeOf(result).toEqualTypeOf<
+      [
+        number | string | boolean,
+        number | string | boolean,
+        number | string | boolean
+      ]
+    >();
+  });
 });

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,3 +1,4 @@
+import { IterableContainer } from './_types';
 import { purry } from './purry';
 
 /**
@@ -40,4 +41,23 @@ function _sort<T>(items: Array<T>, cmp: (a: T, b: T) => number) {
   const ret = [...items];
   ret.sort(cmp);
   return ret;
+}
+
+interface Strict {
+  <T extends IterableContainer>(
+    items: T,
+    cmp: (a: T[number], b: T[number]) => number
+  ): StrictOut<T>;
+
+  <T extends IterableContainer>(cmp: (a: T[number], b: T[number]) => number): (
+    items: T
+  ) => StrictOut<T>;
+}
+
+type StrictOut<T extends IterableContainer> = {
+  -readonly [P in keyof T]: T[number];
+};
+
+export namespace sort {
+  export const strict: Strict = sort;
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -47,14 +47,14 @@ interface Strict {
   <T extends IterableContainer>(
     items: T,
     cmp: (a: T[number], b: T[number]) => number
-  ): StrictOut<T>;
+  ): Sorted<T>;
 
   <T extends IterableContainer>(cmp: (a: T[number], b: T[number]) => number): (
     items: T
-  ) => StrictOut<T>;
+  ) => Sorted<T>;
 }
 
-type StrictOut<T extends IterableContainer> = {
+type Sorted<T extends IterableContainer> = {
   -readonly [P in keyof T]: T[number];
 };
 

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -1,3 +1,4 @@
+import { identity } from './identity';
 import { pipe } from './pipe';
 import { sortBy } from './sortBy';
 
@@ -133,5 +134,79 @@ describe('data last', () => {
       type T = (typeof objects)[number];
       assertType<Array<T>>(actual);
     });
+  });
+});
+
+describe('strict', () => {
+  it('on empty tuple', () => {
+    const array: [] = [];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on empty readonly tuple', () => {
+    const array: readonly [] = [];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on array', () => {
+    const array: Array<number> = [];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+  });
+
+  it('on readonly array', () => {
+    const array: ReadonlyArray<number> = [];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+  });
+
+  it('on tuple', () => {
+    const array: [1, 2, 3] = [1, 2, 3];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
+  });
+
+  it('on readonly tuple', () => {
+    const array: readonly [1, 2, 3] = [1, 2, 3];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
+  });
+
+  it('on tuple with rest tail', () => {
+    const array: [number, ...Array<number>] = [1];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+  });
+
+  it('on readonly tuple with rest tail', () => {
+    const array: readonly [number, ...Array<number>] = [1];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+  });
+
+  it('on tuple with rest head', () => {
+    const array: [...Array<number>, number] = [1];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+  });
+
+  it('on readonly tuple with rest head', () => {
+    const array: readonly [...Array<number>, number] = [1];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+  });
+
+  it('on mixed types tuple', () => {
+    const array: [number, string, boolean] = [1, 'hello', true];
+    const result = sortBy.strict(array, identity);
+    expectTypeOf(result).toEqualTypeOf<
+      [
+        number | string | boolean,
+        number | string | boolean,
+        number | string | boolean
+      ]
+    >();
   });
 });

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -1,3 +1,4 @@
+import { IterableContainer } from './_types';
 import { purry } from './purry';
 
 type Direction = 'asc' | 'desc';
@@ -115,4 +116,24 @@ function _sortBy<T>(array: Array<T>, sorts: Array<SortRule<T>>): Array<T> {
   };
   const copied = [...array];
   return copied.sort((a: T, b: T) => sort(a, b, sorts[0], sorts.slice(1)));
+}
+
+interface Strict {
+  <T extends IterableContainer>(
+    sort: SortRule<T[number]>,
+    ...sorts: Array<SortRule<T[number]>>
+  ): (data: T) => SortedBy<T>;
+
+  <T extends IterableContainer>(
+    data: T,
+    ...sorts: Array<SortRule<T[number]>>
+  ): SortedBy<T>;
+}
+
+type SortedBy<T extends IterableContainer> = {
+  -readonly [P in keyof T]: T[number];
+};
+
+export namespace sortBy {
+  export const strict: Strict = sortBy;
 }


### PR DESCRIPTION
I wanted to be able to sort a NonEmptyArray and keep it non empty (so that it could be used, for example, in a pipe with `first` to get the smallest item in a sort, maybe in a pipe with groupBy :wink:).

I made the types as generic as possible, so any sort of tuple combination would work, including mixed types.

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`
