### PR TITLE
feat: join utility

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -1,4 +1,4 @@
-### Mapping for Lodash and Ramda
+# Mapping for Lodash and Ramda
 
 _Remeda functions are not necessarily drop-in replacements for the
 listed Lodash and Ramda functions. Just as the Lodash function may behave
@@ -36,6 +36,7 @@ documentation when migrating._
 | `groupBy`        | `groupBy`        | `groupBy`           |
 | `identity`       | `identity`       | `identity`          |
 | `isNil`          | `isNil`          | `isNil`             |
+| `join`           | `join`           | `join`              |
 | `indexBy`        | `keyBy`          | `indexBy`           |
 | `intersection`   | `intersection`   | `intersection`      |
 | `last`           | `last`           | `last`              |
@@ -78,7 +79,7 @@ documentation when migrating._
 | `uniqWith`       | `uniqWith`       | `uniqWith`          |
 | `zipObj`         | `zipObj`         | `zipObj`            |
 
-### Helpful one-liners
+## Helpful one-liners
 
 Some lodash and ramda functions don't have a Remeda equivalent, but can be
 easily replaced with a one-liner in TypeScript. Some of the most common

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export * from './isObject';
 export * from './isPromise';
 export * from './isString';
 export * from './isTruthy';
+export * from './join';
 export * from './keys';
 export * from './last';
 export * from './map';

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -1,0 +1,133 @@
+import { join } from './join';
+
+describe('at runtime', () => {
+  describe('joins same-typed items', () => {
+    it('number', () => {
+      const array = [1, 2, 3, 4, 5];
+      const result = join(array, ',');
+      expect(result).toEqual('1,2,3,4,5');
+    });
+
+    it('string', () => {
+      const array = ['a', 'b', 'c', 'd', 'e'];
+      const result = join(array, ',');
+      expect(result).toEqual('a,b,c,d,e');
+    });
+
+    it('bigint', () => {
+      const array = [BigInt(1), BigInt(2), BigInt(3), BigInt(4), BigInt(5)];
+      const result = join(array, ',');
+      expect(result).toEqual('1,2,3,4,5');
+    });
+
+    it('boolean', () => {
+      const array = [true, false, true, false, true];
+      const result = join(array, ',');
+      expect(result).toEqual('true,false,true,false,true');
+    });
+
+    it('null', () => {
+      const array = [null, null, null, null, null];
+      const result = join(array, ',');
+      expect(result).toEqual(',,,,');
+    });
+
+    it('undefined', () => {
+      const array = [undefined, undefined, undefined, undefined, undefined];
+      const result = join(array, ',');
+      expect(result).toEqual(',,,,');
+    });
+  });
+
+  it('joins different-typed items', () => {
+    const array = [1, '2', BigInt(3), true, null, undefined];
+    const result = join(array, ',');
+    expect(result).toEqual('1,2,3,true,,');
+  });
+
+  describe('edge-cases', () => {
+    it('empty glue', () => {
+      const array = [1, 2, 3, 4, 5];
+      const result = join(array, '');
+      expect(result).toEqual('12345');
+    });
+
+    it('empty array', () => {
+      const array: Array<number> = [];
+      const result = join(array, ',');
+      expect(result).toEqual('');
+    });
+
+    it('doesnt add glue on single item', () => {
+      const array = [1];
+      const result = join(array, ',');
+      expect(result).toEqual('1');
+    });
+  });
+});
+
+describe('typing', () => {
+  it('empty tuple', () => {
+    const array: [] = [];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<''>();
+  });
+
+  it('empty readonly tuple', () => {
+    const array: readonly [] = [];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<''>();
+  });
+
+  it('array', () => {
+    const array: Array<number> = [];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<string>();
+  });
+
+  it('readonly array', () => {
+    const array: ReadonlyArray<number> = [];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<string>();
+  });
+
+  it('tuple', () => {
+    const array: ['a' | 'b', 'c' | 'd', 'e' | 'f'] = ['a', 'c', 'e'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${'a' | 'b'},${'c' | 'd'},${
+      | 'e'
+      | 'f'}`>();
+  });
+
+  it('readonly tuple', () => {
+    const array: readonly ['a' | 'b', 'c' | 'd', 'e' | 'f'] = ['a', 'c', 'e'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${'a' | 'b'},${'c' | 'd'},${
+      | 'e'
+      | 'f'}`>();
+  });
+
+  it('tuple with rest tail', () => {
+    const array: ['a' | 'b', ...Array<'c' | 'd'>] = ['a', 'c'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${'a' | 'b'},${string}`>();
+  });
+
+  it('readonly tuple with rest tail', () => {
+    const array: readonly ['a' | 'b', ...Array<'c' | 'd'>] = ['a', 'c'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${'a' | 'b'},${string}`>();
+  });
+
+  it('tuple with rest head', () => {
+    const array: [...Array<'a' | 'b'>, 'c' | 'd'] = ['a', 'c'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${string},${'c' | 'd'}`>();
+  });
+
+  it('readonly tuple with rest head', () => {
+    const array: readonly [...Array<'a' | 'b'>, 'c' | 'd'] = ['a', 'c'];
+    const result = join(array, ',');
+    expectTypeOf(result).toEqualTypeOf<`${string},${'c' | 'd'}`>();
+  });
+});

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -130,4 +130,48 @@ describe('typing', () => {
     const result = join(array, ',');
     expectTypeOf(result).toEqualTypeOf<`${string},${'c' | 'd'}`>();
   });
+
+  describe('tuple item types', () => {
+    it('number', () => {
+      const array: [number, number] = [1, 2];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${number},${number}`>();
+    });
+
+    it('string', () => {
+      const array: [string, string] = ['a', 'b'];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${string},${string}`>();
+    });
+
+    it('bigint', () => {
+      const array: [bigint, bigint] = [BigInt(1), BigInt(2)];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${bigint},${bigint}`>();
+    });
+
+    it('boolean', () => {
+      const array: [boolean, boolean] = [true, false];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${boolean},${boolean}`>();
+    });
+
+    it('null', () => {
+      const array: [null, null] = [null, null];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<','>();
+    });
+
+    it('undefined', () => {
+      const array: [undefined, undefined] = [undefined, undefined];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<','>();
+    });
+
+    it('mixed', () => {
+      const array: [number, undefined, string] = [1, undefined, 'a'];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${number},,${string}`>();
+    });
+  });
 });

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -173,5 +173,17 @@ describe('typing', () => {
       const result = join(array, ',');
       expectTypeOf(result).toEqualTypeOf<`${number},,${string}`>();
     });
+
+    it('nullish items', () => {
+      const array: [
+        'prefix' | undefined,
+        'midfix' | undefined,
+        'suffix' | undefined
+      ] = ['prefix', undefined, 'suffix'];
+      const result = join(array, ',');
+      expectTypeOf(result).toEqualTypeOf<`${'prefix' | ''},${'midfix' | ''},${
+        | 'suffix'
+        | ''}`>();
+    });
   });
 });

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,0 +1,44 @@
+import { IterableContainer } from './_types';
+import { purry } from './purry';
+
+type Joinable = bigint | boolean | number | string | null | undefined;
+
+type Joined<
+  T extends IterableContainer,
+  Glue extends string
+> = T[number] extends never
+  ? ''
+  : T extends readonly [infer Only]
+  ? JoinedValue<Only>
+  : T extends readonly [infer First, ...infer Tail]
+  ? `${JoinedValue<First>}${Glue}${Joined<Tail, Glue>}`
+  : T extends readonly [...infer Head, infer Last]
+  ? `${Joined<Head, Glue>}${Glue}${JoinedValue<Last>}`
+  : string;
+
+type JoinedValue<V> = undefined extends V
+  ? ''
+  : null extends V
+  ? ''
+  : V extends NonNullable<Joinable>
+  ? `${V}`
+  : never;
+
+export function join<
+  T extends ReadonlyArray<Joinable> | [],
+  Glue extends string
+>(data: T, glue: Glue): Joined<T, Glue>;
+
+export function join<
+  T extends ReadonlyArray<Joinable> | [],
+  Glue extends string
+>(glue: Glue): (data: T) => Joined<T, Glue>;
+
+export function join(): unknown {
+  return purry(joinImplementation, arguments);
+}
+
+const joinImplementation = (
+  data: ReadonlyArray<unknown>,
+  glue: string
+): string => data.join(glue);

--- a/src/join.ts
+++ b/src/join.ts
@@ -3,26 +3,33 @@ import { purry } from './purry';
 
 type Joinable = bigint | boolean | number | string | null | undefined;
 
-type Joined<
-  T extends IterableContainer,
-  Glue extends string
-> = T[number] extends never
-  ? ''
-  : T extends readonly [infer Only]
-  ? JoinedValue<Only>
-  : T extends readonly [infer First, ...infer Tail]
-  ? `${JoinedValue<First>}${Glue}${Joined<Tail, Glue>}`
-  : T extends readonly [...infer Head, infer Last]
-  ? `${Joined<Head, Glue>}${Glue}${JoinedValue<Last>}`
-  : string;
+type Joined<T extends IterableContainer, Glue extends string> =
+  // Empty tuple
+  T[number] extends never
+    ? ''
+    : // Single Item tuple
+    T extends readonly [infer Only]
+    ? JoinedValue<Only>
+    : // Tuple with non-rest element (head)
+    T extends readonly [infer First, ...infer Tail]
+    ? `${JoinedValue<First>}${Glue}${Joined<Tail, Glue>}`
+    : // Tuple with non-rest element (tail)
+    T extends readonly [...infer Head, infer Last]
+    ? `${Joined<Head, Glue>}${Glue}${JoinedValue<Last>}`
+    : // Arrays and tuple rest-elements, we can't say anything about the output
+      string;
 
-type JoinedValue<V> = undefined extends V
-  ? ''
-  : null extends V
-  ? ''
-  : V extends NonNullable<Joinable>
-  ? `${V}`
-  : never;
+type JoinedValue<V> =
+  // `undefined` and `null` are special-cased by join, a regular cast to string
+  // would result in the strings 'undefined' and 'null', but join returns an
+  // empty strings instead.
+  undefined extends V
+    ? ''
+    : null extends V
+    ? ''
+    : V extends NonNullable<Joinable>
+    ? `${V}`
+    : "ERROR: Trying to join a value type that isn't castable to string";
 
 export function join<
   T extends ReadonlyArray<Joinable> | [],

--- a/src/join.ts
+++ b/src/join.ts
@@ -31,11 +31,49 @@ type JoinedValue<V> =
     ? `${V}`
     : "ERROR: Trying to join a value type that isn't castable to string";
 
+/**
+ * Joins the elements of the array by: casting them to a string and
+ * concatenating them one to the other, with the provided glue string in between
+ * every two elements.
+ *
+ * When called on a tuple and with stricter item types (union of literal values,
+ * the result is strictly typed to the tuples shape and it's item types).
+ *
+ * @param data The array to join
+ * @param glue The string to put in between every two elements
+ * @signature
+ *    R.join(data, glue)
+ * @example
+ *    R.join([1,2,3], ",") // => "1,2,3" (typed `string`)
+ *    R.join(['a','b','c'], "") // => "abc" (typed `string`)
+ *    R.join(['hello', 'world'] as const, " ") // => "hello world" (typed `hello world`)
+ * @data_first
+ * @category Array
+ */
 export function join<
   T extends ReadonlyArray<Joinable> | [],
   Glue extends string
 >(data: T, glue: Glue): Joined<T, Glue>;
 
+/**
+ * Joins the elements of the array by: casting them to a string and
+ * concatenating them one to the other, with the provided glue string in between
+ * every two elements.
+ *
+ * When called on a tuple and with stricter item types (union of literal values,
+ * the result is strictly typed to the tuples shape and it's item types).
+ *
+ * @param data The array to join
+ * @param glue The string to put in between every two elements
+ * @signature
+ *    R.join(glue)(data)
+ * @example
+ *    R.pipe([1,2,3], R.join(",")) // => "1,2,3" (typed `string`)
+ *    R.pipe(['a','b','c'], R.join("")) // => "abc" (typed `string`)
+ *    R.pipe(['hello', 'world'] as const, R.join(" ")) // => "hello world" (typed `hello world`)
+ * @data_last
+ * @category Array
+ */
 export function join<
   T extends ReadonlyArray<Joinable> | [],
   Glue extends string

--- a/src/join.ts
+++ b/src/join.ts
@@ -11,10 +11,10 @@ type Joined<T extends IterableContainer, Glue extends string> =
     T extends readonly [Joinable?]
     ? `${NullishCoalesce<T[0], ''>}`
     : // Tuple with non-rest element (head)
-    T extends readonly [infer First extends Joinable, ...infer Tail]
+    T extends readonly [infer First, ...infer Tail]
     ? `${NullishCoalesce<First, ''>}${Glue}${Joined<Tail, Glue>}`
     : // Tuple with non-rest element (tail)
-    T extends readonly [...infer Head, infer Last extends Joinable]
+    T extends readonly [...infer Head, infer Last]
     ? `${Joined<Head, Glue>}${Glue}${NullishCoalesce<Last, ''>}`
     : // Arrays and tuple rest-elements, we can't say anything about the output
       string;
@@ -23,9 +23,11 @@ type Joined<T extends IterableContainer, Glue extends string> =
 // `${undefined}` === 'undefined' (and similarly for null), but specifically in
 // the builtin `join` method, they should result in an empty string!
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join#description
-type NullishCoalesce<T, Fallback> = T extends undefined | null
-  ? NonNullable<T> | Fallback
-  : T;
+type NullishCoalesce<T, Fallback> = T extends Joinable
+  ? T extends undefined | null
+    ? NonNullable<T> | Fallback
+    : T
+  : never;
 
 /**
  * Joins the elements of the array by: casting them to a string and


### PR DESCRIPTION
Adding a better typed wrapper around the builtin Array.prototype.join, with data-first and data-last signatures.

Similar to https://github.com/sindresorhus/type-fest/blob/main/source/join.d.ts

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
