### PR TITLE
docs: fix typo in groupBy example

### DIFF
--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -11,7 +11,7 @@ import { NonEmptyArray, PredIndexedOptional, PredIndexed } from './_types';
  *    R.groupBy.strict(array, fn)
  * @example
  *    R.groupBy(['one', 'two', 'three'], x => x.length) // => {3: ['one', 'two'], 5: ['three']}
- *    R.groupBy.strict([{a: 'cat'}, {b: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *    R.groupBy.strict([{a: 'cat'}, {a: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
  *    R.groupBy([0, 1], x => x % 2 === 0 ? 'even' : undefined) // => {even: [0]}
  * @data_first
  * @indexed


### PR DESCRIPTION
Fix typo in groupBy example
---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`
