### PR TITLE
chore: Compile to es2015

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,11 +17,9 @@
     "noEmit": true,
 
     // LANGUAGE and ENVIRONMENT
-    "lib": ["ES6", "ES2017.Object"],
-    // TODO: The recommended target is ES2015 (ES6). Node10 supports es2018 and
-    // the vast majority of browsers are probably above that too already. It's
-    // most likely safe to up this value, and it would probably result in a
-    // smaller package size.
-    "target": "ES5"
+    "lib": ["ES2015", "ES2017.Object"],
+    // TODO: If we already assume we use parts of ES2017 in the lib, it makes
+    // sense to simply use that as the baseline target for everything.
+    "target": "ES2015"
   }
 }


### PR DESCRIPTION
Our minimum typescript version is 4.2 which came out on February 2021. Afaik node has supported es2015 since at least version 10, most likely earlier. Approximately 98% of browsers nowadays support it too. Moving to es2015 creates output files which are about 17% smaller, and allow us to use iterators (for...each loops) which make for safer code.

Overall I think we should make the move.

I don't think this requiring bumping the major version to 2, as the APIs we provide don't change, but I can also see how this is a breaking change for some users. I think at the current level of adoption of remeda a bump in major isn't that bad either, but if we already do that, we might as well bump the es version to es2020 or more, and drop support for typescript below 4.9 or 4.8. Finally, If we do bump a major, i think we should swap the "strict" and "nonstrict" versions of our methods so that the default provides stronger typing, and allow people to migrate slowly away from the nonstrict ones via a "legacy" variant.

Let's discuss over this PR.