### PR TITLE
fix(chunk): Simplify general case

### DIFF
--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -35,41 +35,75 @@ describe('data last', () => {
 });
 
 describe('strict typing', () => {
+  test('empty tuple', () => {
+    const input: [] = [];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  test('readonly empty tuple', () => {
+    const input = [] as const;
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
   test('array', () => {
     const input: Array<number> = [];
     const result = chunk(input, 2);
-    const [first, ...rest] = result;
-    expectTypeOf(result).toEqualTypeOf<
-      [] | NonEmptyArray<NonEmptyArray<number>>
-    >();
-    expectTypeOf(first).toEqualTypeOf<NonEmptyArray<number> | undefined>();
-    expectTypeOf(rest).toEqualTypeOf<Array<NonEmptyArray<number>>>();
-    expect(result).toEqual([]);
+    expectTypeOf(result).toEqualTypeOf<Array<NonEmptyArray<number>>>();
   });
 
-  test('non empty start array', () => {
-    const input: [number, ...Array<number>] = [1];
+  test('readonly array', () => {
+    const input: ReadonlyArray<number> = [];
     const result = chunk(input, 2);
-    const [first, ...rest] = result;
-    const [firstValue, ...otherValues] = first;
-    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
-    expectTypeOf(first).toEqualTypeOf<NonEmptyArray<number>>();
-    expectTypeOf(rest).toEqualTypeOf<Array<NonEmptyArray<number>>>();
-    expectTypeOf(firstValue).toEqualTypeOf<number>();
-    expectTypeOf(otherValues).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([[1]]);
+    expectTypeOf(result).toEqualTypeOf<Array<NonEmptyArray<number>>>();
   });
 
-  test('non empty end array', () => {
-    const input: [...Array<number>, number] = [1];
+  test('tuple', () => {
+    const input: [number, number, number] = [123, 456, 789];
     const result = chunk(input, 2);
-    const [first, ...rest] = result;
-    const [firstValue, ...otherValues] = first;
     expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
-    expectTypeOf(first).toEqualTypeOf<NonEmptyArray<number>>();
-    expectTypeOf(rest).toEqualTypeOf<Array<NonEmptyArray<number>>>();
-    expectTypeOf(firstValue).toEqualTypeOf<number>();
-    expectTypeOf(otherValues).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([[1]]);
+  });
+
+  test('readonly tuple', () => {
+    const input: readonly [number, number, number] = [123, 456, 789];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('tuple with rest tail', () => {
+    const input: [number, ...Array<number>] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('readonly tuple with rest tail', () => {
+    const input: readonly [number, ...Array<number>] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('tuple with rest middle', () => {
+    const input: [number, ...Array<number>, number] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('readonly tuple with rest middle', () => {
+    const input: readonly [number, ...Array<number>, number] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('tuple with rest head', () => {
+    const input: [...Array<number>, number] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
+  });
+
+  test('readonly tuple with rest head', () => {
+    const input: readonly [...Array<number>, number] = [123, 456];
+    const result = chunk(input, 2);
+    expectTypeOf(result).toEqualTypeOf<NonEmptyArray<NonEmptyArray<number>>>();
   });
 });

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,13 +1,13 @@
 import { IterableContainer, NonEmptyArray } from './_types';
 import { purry } from './purry';
 
-type Chunked<T extends IterableContainer> =
-  | (T extends
+type Chunked<T extends IterableContainer> = T[number] extends never
+  ? []
+  : T extends
       | readonly [unknown, ...Array<unknown>]
       | readonly [...Array<unknown>, unknown]
-      ? never
-      : [])
-  | NonEmptyArray<NonEmptyArray<T[number]>>;
+  ? NonEmptyArray<NonEmptyArray<T[number]>>
+  : Array<NonEmptyArray<T[number]>>;
 
 /**
  * Split an array into groups the length of `size`. If `array` can't be split evenly, the final chunk will be the remaining elements.


### PR DESCRIPTION
The previous Chunked definition wasn't good for regular plain arrays as it's output wasn't a simple array (it was the union  `[] | NonEmptyArray<...>`). 

Typescript didn't handle this correctly when the Chunked result was needed in a function that took a simple array.

This typing results in a simpler output.

I also rewrote the tests to cover more cases and be pure type testing, without runtime checks