### PR TITLE
fix(prop): Partially Revert #238

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -7,6 +7,6 @@
  * @data_last
  * @category Object
  */
-export function prop<K extends string = string>(name: K) {
-  return <T extends Record<any, any>>(obj: T) => obj[name];
+export function prop<T, K extends keyof T>(propName: K) {
+  return (obj: T) => obj[propName];
 }


### PR DESCRIPTION
`prop` is broken when used inside a pipe, typescript can't infer the internal types:

```ts
const input = [{ a: 1 }];
const works = R.sortBy(input, R.prop('a')); // typed typeof input;
const doesntWork = R.pipe(input, R.sortBy(R.prop('a'))) // typed Record<any, any>;
```

// 