### PR TITLE
improve on the type of prop

### DIFF
--- a/src/prop.test.ts
+++ b/src/prop.test.ts
@@ -1,5 +1,6 @@
 import { pipe } from './pipe';
 import { prop } from './prop';
+import { sortBy } from './sortBy';
 
 test('prop', () => {
   const result = pipe({ foo: 'bar' }, prop('foo'));
@@ -25,4 +26,14 @@ test('type for curried form', () => {
   expectTypeOf(
     true as any as ReturnType<typeof propBar>
   ).toEqualTypeOf<number>();
+});
+
+test('prop typing', () => {
+  const input = [{ a: 1 }];
+
+  const works = sortBy(input, prop('a'));
+  expectTypeOf(works).toEqualTypeOf<typeof input>();
+
+  const doesntWork = pipe(input, sortBy(prop('a')));
+  expectTypeOf(doesntWork).toEqualTypeOf<typeof input>();
 });

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -7,6 +7,13 @@
  * @data_last
  * @category Object
  */
-export function prop<K extends string = string>(name: K) {
-  return <T extends Record<any, any>>(obj: T) => obj[name];
+
+interface PropInterface {
+  <T, K extends keyof T>(name: K): (obj: T) => T[K];
+  <K extends string = string>(name: K): <T extends Record<any, any>>(
+    obj: T
+  ) => T[K];
 }
+
+export const prop: PropInterface = (name: string) => (obj: Record<any, any>) =>
+  obj[name];

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -1,19 +1,17 @@
 /**
  * Gets the value of the given property.
- * @param name the property name
+ * @param propName the property name
  * @signature R.prop(prop)(object)
  * @example
  *    R.pipe({foo: 'bar'}, R.prop('foo')) // => 'bar'
  * @data_last
  * @category Object
  */
+export function prop<T, K extends keyof T>(propName: K): (data: T) => T[K];
+export function prop<K extends string = string>(
+  propName: K
+): <T>(data: T) => K extends keyof T ? T[K] : undefined;
 
-interface PropInterface {
-  <T, K extends keyof T>(name: K): (obj: T) => T[K];
-  <K extends string = string>(name: K): <T extends Record<any, any>>(
-    obj: T
-  ) => T[K];
+export function prop<T, K extends keyof T>(propName: K): (data: T) => unknown {
+  return data => data[propName];
 }
-
-export const prop: PropInterface = (name: string) => (obj: Record<any, any>) =>
-  obj[name];

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -1,17 +1,17 @@
 /**
  * Gets the value of the given property.
- * @param propName the property name
+ * @param prop the property name
  * @signature R.prop(prop)(object)
  * @example
  *    R.pipe({foo: 'bar'}, R.prop('foo')) // => 'bar'
  * @data_last
  * @category Object
  */
-export function prop<T, K extends keyof T>(propName: K): (data: T) => T[K];
-export function prop<K extends string = string>(
-  propName: K
+export function prop<T, K extends keyof T>(prop: K): (data: T) => T[K];
+export function prop<K extends PropertyKey>(
+  prop: K
 ): <T>(data: T) => K extends keyof T ? T[K] : undefined;
 
-export function prop<T, K extends keyof T>(propName: K): (data: T) => unknown {
-  return data => data[propName];
+export function prop<T, K extends keyof T>(prop: K): (data: T) => unknown {
+  return data => data[prop];
 }


### PR DESCRIPTION
change the type to be able to deal with the standalone form (where we don't know the source object type at all) and the form used in `pipe` (where we have an inference of the source).

For #320 