### PR TITLE
Invert

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -39,6 +39,7 @@ documentation when migrating._
 | `isNil`            | `isNil`            | `isNil`             |
 | `join`             | `join`             | `join`              |
 | `indexBy`          | `keyBy`            | `indexBy`           |
+| `invert`           | `invert`           | `invertObj`         |
 | `intersection`     | `intersection`     | `intersection`      |
 | `intersectionWith` | `intersectionWith` | `innerJoin`         |
 | `last`             | `last`             | `last`              |

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export * from './identity';
 export * from './indexBy';
 export * from './intersection';
 export * from './intersectionWith';
+export * from './invert';
 export * from './isArray';
 export * from './isBoolean';
 export * from './isDate';

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -1,0 +1,55 @@
+import { invert } from './invert';
+import { pipe } from './pipe';
+
+describe('invert', function () {
+  describe('with parameter', () => {
+    test('empty object', () => {
+      expect(invert({})).toEqual({});
+    });
+
+    test('no duplicate values', () => {
+      expect(invert({ a: 'd', b: 'e', c: 'f' })).toEqual({
+        d: 'a',
+        e: 'b',
+        f: 'c',
+      });
+    });
+
+    test('duplicate values', () => {
+      expect(invert({ a: 'd', b: 'e', c: 'd' })).toEqual({ e: 'b', d: 'c' });
+    });
+
+    test('numeric values', () => {
+      expect(invert(['a', 'b', 'c'])).toEqual({ a: '0', b: '1', c: '2' });
+    });
+  });
+
+  describe('without parameter', () => {
+    test('empty object', () => {
+      expect(pipe({}, invert())).toEqual({});
+    });
+
+    test('no duplicate values', () => {
+      expect(pipe({ a: 'd', b: 'e', c: 'f' }, invert())).toEqual({
+        d: 'a',
+        e: 'b',
+        f: 'c',
+      });
+    });
+
+    test('duplicate values', () => {
+      expect(pipe({ a: 'd', b: 'e', c: 'd' }, invert())).toEqual({
+        e: 'b',
+        d: 'c',
+      });
+    });
+
+    test('numeric values', () => {
+      expect(pipe(['a', 'b', 'c'], invert())).toEqual({
+        a: '0',
+        b: '1',
+        c: '2',
+      });
+    });
+  });
+});

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -1,55 +1,53 @@
 import { invert } from './invert';
 import { pipe } from './pipe';
 
-describe('invert', function () {
-  describe('with parameter', () => {
-    test('empty object', () => {
-      expect(invert({})).toEqual({});
-    });
+describe('data first', () => {
+  test('empty object', () => {
+    expect(invert({})).toEqual({});
+  });
 
-    test('no duplicate values', () => {
-      expect(invert({ a: 'd', b: 'e', c: 'f' })).toEqual({
-        d: 'a',
-        e: 'b',
-        f: 'c',
-      });
-    });
-
-    test('duplicate values', () => {
-      expect(invert({ a: 'd', b: 'e', c: 'd' })).toEqual({ e: 'b', d: 'c' });
-    });
-
-    test('numeric values', () => {
-      expect(invert(['a', 'b', 'c'])).toEqual({ a: '0', b: '1', c: '2' });
+  test('no duplicate values', () => {
+    expect(invert({ a: 'd', b: 'e', c: 'f' })).toEqual({
+      d: 'a',
+      e: 'b',
+      f: 'c',
     });
   });
 
-  describe('without parameter', () => {
-    test('empty object', () => {
-      expect(pipe({}, invert())).toEqual({});
-    });
+  test('duplicate values', () => {
+    expect(invert({ a: 'd', b: 'e', c: 'd' })).toEqual({ e: 'b', d: 'c' });
+  });
 
-    test('no duplicate values', () => {
-      expect(pipe({ a: 'd', b: 'e', c: 'f' }, invert())).toEqual({
-        d: 'a',
-        e: 'b',
-        f: 'c',
-      });
-    });
+  test('numeric values', () => {
+    expect(invert(['a', 'b', 'c'])).toEqual({ a: '0', b: '1', c: '2' });
+  });
+});
 
-    test('duplicate values', () => {
-      expect(pipe({ a: 'd', b: 'e', c: 'd' }, invert())).toEqual({
-        e: 'b',
-        d: 'c',
-      });
-    });
+describe('data last', () => {
+  test('empty object', () => {
+    expect(pipe({}, invert())).toEqual({});
+  });
 
-    test('numeric values', () => {
-      expect(pipe(['a', 'b', 'c'], invert())).toEqual({
-        a: '0',
-        b: '1',
-        c: '2',
-      });
+  test('no duplicate values', () => {
+    expect(pipe({ a: 'd', b: 'e', c: 'f' }, invert())).toEqual({
+      d: 'a',
+      e: 'b',
+      f: 'c',
+    });
+  });
+
+  test('duplicate values', () => {
+    expect(pipe({ a: 'd', b: 'e', c: 'd' }, invert())).toEqual({
+      e: 'b',
+      d: 'c',
+    });
+  });
+
+  test('numeric values', () => {
+    expect(pipe(['a', 'b', 'c'], invert())).toEqual({
+      a: '0',
+      b: '1',
+      c: '2',
     });
   });
 });

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -11,16 +11,24 @@ type Inverted = { [index: string]: string };
  *    R.invert(object)
  * @example
  *    R.invert({ a: "d", b: "e", c: "f" }) // => { d: "a", e: "b", f: "c" }
- *    R.invert({}) // => {}
- *    R.pipe(
- *      { a: "d", b: "e", c: "f" }
- *      R.invert()
- *    ); // => { d: "a", e: "b", f: "c" }
- *
+ * @data_first
  * @category object
  * @pipeable
  */
 export function invert<T>(object: Invertable): Inverted;
+
+/**
+ * Returns an object whose keys are values are swapped. If the object contains duplicate values,
+ * subsequent values will overwrite previous values.
+ * @param object the object
+ * @signature
+ *    R.invert()(object)
+ * @example
+ *    R.pipe({ a: "d", b: "e", c: "f" }, R.invert()); // => { d: "a", e: "b", f: "c" }
+ * @data_last
+ * @category object
+ * @pipeable
+ */
 export function invert<T>(): (object: Invertable) => Inverted;
 
 export function invert() {

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -36,14 +36,14 @@ export function invert() {
   return purry(_invert, arguments);
 }
 
-function _invert<T extends object>(object: T): Inverted<T> {
-  const result: Record<PropertyKey, keyof T> = {};
+function _invert(
+  object: Readonly<Record<PropertyKey, PropertyKey>>
+): Record<PropertyKey, PropertyKey> {
+  const result: Record<PropertyKey, PropertyKey> = {};
 
   for (const key in object) {
-    // @ts-expect-error We ensure that the value is a valid type in the definition of Invertable
-    // above.
     result[object[key]] = key;
   }
 
-  return result as Inverted<T>;
+  return result;
 }

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -1,7 +1,8 @@
 import { purry } from './purry';
 
-type Invertable = Record<PropertyKey, PropertyKey> | Array<PropertyKey>;
-type Inverted = Record<PropertyKey, PropertyKey>;
+type Inverted<T extends object> = T[keyof T] extends PropertyKey
+  ? Record<T[keyof T], keyof T>
+  : never;
 
 /**
  * Returns an object whose keys are values are swapped. If the object contains duplicate values,
@@ -15,7 +16,7 @@ type Inverted = Record<PropertyKey, PropertyKey>;
  * @category object
  * @pipeable
  */
-export function invert(object: Invertable): Inverted;
+export function invert<T extends object>(object: T): Inverted<T>;
 
 /**
  * Returns an object whose keys are values are swapped. If the object contains duplicate values,
@@ -29,18 +30,20 @@ export function invert(object: Invertable): Inverted;
  * @category object
  * @pipeable
  */
-export function invert(): (object: Invertable) => Inverted;
+export function invert<T extends object>(): (object: T) => Inverted<T>;
 
 export function invert() {
   return purry(_invert, arguments);
 }
 
-function _invert(object: Invertable): Inverted {
-  return Object.entries(object).reduce<Inverted>(
-    (accumulator, [key, value]) => {
-      accumulator[value] = key;
-      return accumulator;
-    },
-    {}
-  );
+function _invert<T extends object>(object: T): Inverted<T> {
+  const result: Record<PropertyKey, keyof T> = {};
+
+  for (const key in object) {
+    // @ts-expect-error We ensure that the value is a valid type in the definition of Invertable
+    // above.
+    result[object[key]] = key;
+  }
+
+  return result as Inverted<T>;
 }

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -1,0 +1,35 @@
+import { purry } from './purry';
+
+type Invertable = { [index: string]: string } | { [index: number]: string };
+type Inverted = { [index: string]: string };
+
+/**
+ * Returns an object whose keys are values are swapped. If the object contains duplicate values,
+ * subsequent values will overwrite previous values.
+ * @param object the object
+ * @signature
+ *    R.invert(object)
+ * @example
+ *    R.invert({ a: "d", b: "e", c: "f" }) // => { d: "a", e: "b", f: "c" }
+ *    R.invert({}) // => {}
+ *    R.pipe(
+ *      { a: "d", b: "e", c: "f" }
+ *      R.invert()
+ *    ); // => { d: "a", e: "b", f: "c" }
+ *
+ * @category object
+ * @pipeable
+ */
+export function invert<T>(object: Invertable): Inverted;
+export function invert<T>(): (object: Invertable) => Inverted;
+
+export function invert() {
+  return purry(_invert, arguments);
+}
+
+function _invert(object: Invertable): Inverted {
+  return Object.entries(object).reduce((accumulator, [key, value]) => {
+    accumulator[value] = key;
+    return accumulator;
+  }, {} as Inverted)
+}

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -1,7 +1,7 @@
 import { purry } from './purry';
 
-type Invertable = { [index: string]: string } | { [index: number]: string };
-type Inverted = { [index: string]: string };
+type Invertable = Record<PropertyKey, PropertyKey> | Array<PropertyKey>;
+type Inverted = Record<PropertyKey, PropertyKey>;
 
 /**
  * Returns an object whose keys are values are swapped. If the object contains duplicate values,
@@ -15,7 +15,7 @@ type Inverted = { [index: string]: string };
  * @category object
  * @pipeable
  */
-export function invert<T>(object: Invertable): Inverted;
+export function invert(object: Invertable): Inverted;
 
 /**
  * Returns an object whose keys are values are swapped. If the object contains duplicate values,
@@ -29,15 +29,18 @@ export function invert<T>(object: Invertable): Inverted;
  * @category object
  * @pipeable
  */
-export function invert<T>(): (object: Invertable) => Inverted;
+export function invert(): (object: Invertable) => Inverted;
 
 export function invert() {
   return purry(_invert, arguments);
 }
 
 function _invert(object: Invertable): Inverted {
-  return Object.entries(object).reduce((accumulator, [key, value]) => {
-    accumulator[value] = key;
-    return accumulator;
-  }, {} as Inverted)
+  return Object.entries(object).reduce<Inverted>(
+    (accumulator, [key, value]) => {
+      accumulator[value] = key;
+      return accumulator;
+    },
+    {}
+  );
 }


### PR DESCRIPTION
@TkDodo Sorry for the delayed response on #236. (I had a baby around that time, and this completely fell off my radar.) I've pushed up all of the changes you've suggested except for the more refined type. I wasn't sure if you saw my comment there, so I decided to reopen this.

I spent quite a while battling the compiler, but I couldn't find a way to make it happy with a generic type.

Here are the two main variations of the `Inverted<T>` type I spent time trying to get work. (I tried several other variants as well.) @texastoland Could you take a look at my branch and see if you can get either working?

``` typescript
type Inverted<T extends Invertable> = Record<Extract<T[keyof T], PropertyKey>, T[keyof T]>

type Inverted<Obj extends Record<PropertyKey, PropertyKey> | PropertyKey[]> = {
  [Value in Extract<Obj[keyof Obj], PropertyKey>]: keyof {
    [Key in keyof Obj as Obj[Key] extends Value ? Key : never]: never
  }
}
```

I also played with a few different implementations of `_inverted`, but all failed with a similar error when running `tsc`.

``` typescript
function _invert<T extends Invertable>(object: T): Inverted<T> {
  return Object.entries(object).reduce((accumulator, [key, value]) => {
    accumulator[value] = key;
    return accumulator;
  }, {} as Inverted<T>);
}
```

``` typescript
src/invert.ts:46:5 - error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Inverted<T>'.

46     accumulator[value] = key;
       ~~~~~~~~~~~~~~~~~~
```

Do you have any other suggestions or improvements? I promise not to take 5 months to implement them this time. 😬 