### PR TITLE
chore(omit): Optimized for optional keys

### DIFF
--- a/src/omit.test.ts
+++ b/src/omit.test.ts
@@ -7,12 +7,6 @@ describe('data first', () => {
     expect(result).toEqual({ b: 2, c: 3 });
   });
 
-  test('identity on unchanged results', () => {
-    const obj: { a?: number } = {};
-    const result = omit(obj, ['a']);
-    expect(result).toBe(obj);
-  });
-
   test('single removed prop works', () => {
     const obj: { a: number } = { a: 1 };
     const result = omit(obj, ['a']);

--- a/src/omit.test.ts
+++ b/src/omit.test.ts
@@ -6,6 +6,18 @@ describe('data first', () => {
     const result = omit({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd'] as const);
     expect(result).toEqual({ b: 2, c: 3 });
   });
+
+  test('identity on unchanged results', () => {
+    const obj: { a?: number } = {};
+    const result = omit(obj, ['a']);
+    expect(result).toBe(obj);
+  });
+
+  test('single removed prop works', () => {
+    const obj: { a: number } = { a: 1 };
+    const result = omit(obj, ['a']);
+    expect(result).toEqual({});
+  });
 });
 
 describe('data last', () => {

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -40,6 +40,10 @@ function _omit<T extends object, K extends keyof T>(
   data: T,
   propNames: ReadonlyArray<K>
 ): Omit<T, K> {
+  if (propNames.length === 0) {
+    return { ...data };
+  }
+
   if (!propNames.some(propName => propName in data)) {
     return { ...data };
   }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -2,34 +2,52 @@ import { purry } from './purry';
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- * @param object the object
- * @param names the property names
+ * 
+ * If the properties are optional and they don't exist in the input object then
+ * the same object is returned (unlike when using destructuring, which returns a
+ * new clone of the object).
+
+ * @param data the object
+ * @param propNames the property names
  * @signature
  *    R.omit(obj, names);
  * @example
  *    R.omit({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd']) // => { b: 2, c: 3 }
+ * 
+ *    const obj: { a?: number, b: number } = { b: 2 };
+ *    const result = R.omit(obj, ['a']);
+ *    result === obj // => true
  * @data_first
  * @category Object
  */
-export function omit<T extends Record<PropertyKey, any>, K extends keyof T>(
-  object: T,
-  names: ReadonlyArray<K>
+export function omit<T, K extends keyof T>(
+  data: T,
+  propNames: ReadonlyArray<K>
 ): Omit<T, K>;
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- * @param object the object
- * @param names the property names
+ *
+ * If the properties are optional and they don't exist in the input object then
+ * the same object is returned (unlike when using destructuring, which returns a
+ * new clone of the object).
+ *
+ * @param data the object
+ * @param propNames the property names
  * @signature
  *    R.omit(names)(obj);
  * @example
  *    R.pipe({ a: 1, b: 2, c: 3, d: 4 }, R.omit(['a', 'd'])) // => { b: 2, c: 3 }
+ *
+ *    const obj: { a?: number, b: number } = { b: 2 };
+ *    const result = R.pipe(obj, R.omit(['a']));
+ *    result === obj // => true
  * @data_last
  * @category Object
  */
 export function omit<K extends PropertyKey>(
-  names: ReadonlyArray<K>
-): <T extends Record<PropertyKey, any>>(object: T) => Omit<T, K>;
+  propNames: ReadonlyArray<K>
+): <T>(data: T) => Omit<T, K>;
 
 export function omit() {
   return purry(_omit, arguments);
@@ -37,9 +55,24 @@ export function omit() {
 
 function _omit<T extends Record<PropertyKey, any>, K extends keyof T>(
   object: T,
-  names: Array<K>
+  propNames: Array<K>
 ): Omit<T, K> {
-  const set = new Set(names as Array<string>);
+  if (!propNames.some(propName => propName in object)) {
+    // Avoid creating a clone of the input object when the output is unchanged.
+    return object;
+  }
+
+  if (propNames.length === 1) {
+    const [propName] = propNames;
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- use destructuring to remove a single key, letting JS optimize here...
+      [propName]: omitted,
+      ...remaining
+    } = object;
+    return remaining;
+  }
+
+  const set = new Set(propNames as Array<string>);
   return Object.entries(object).reduce<any>((acc, [name, value]) => {
     if (!set.has(name)) {
       acc[name] = value;

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,3 +1,4 @@
+import { fromPairs } from './fromPairs';
 import { purry } from './purry';
 
 /**
@@ -53,7 +54,7 @@ export function omit() {
   return purry(_omit, arguments);
 }
 
-function _omit<T extends object, K extends Extract<keyof T, string>>(
+function _omit<T extends object, K extends keyof T>(
   data: T,
   propNames: ReadonlyArray<K>
 ): Omit<T, K> {
@@ -72,12 +73,8 @@ function _omit<T extends object, K extends Extract<keyof T, string>>(
     return remaining;
   }
 
-  const clone: Partial<T> = {};
-  for (const key in data) {
-    if (propNames.includes(key as K)) {
-      continue;
-    }
-    clone[key as K] = data[key as K];
-  }
-  return clone as Omit<T, K>;
+  const asSet = new Set(propNames);
+  return fromPairs(
+    Object.entries(data).filter(([key]) => !asSet.has(key as K))
+  ) as Omit<T, K>;
 }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -44,10 +44,6 @@ function _omit<T extends object, K extends keyof T>(
     return { ...data };
   }
 
-  if (!propNames.some(propName => propName in data)) {
-    return { ...data };
-  }
-
   if (propNames.length === 1) {
     const [propName] = propNames;
     const {
@@ -56,6 +52,10 @@ function _omit<T extends object, K extends keyof T>(
       ...remaining
     } = data;
     return remaining;
+  }
+
+  if (!propNames.some(propName => propName in data)) {
+    return { ...data };
   }
 
   const asSet = new Set(propNames);

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -3,17 +3,12 @@ import { purry } from './purry';
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- *
  * @param data the object
  * @param propNames the property names
  * @signature
  *    R.omit(obj, names);
  * @example
  *    R.omit({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd']) // => { b: 2, c: 3 }
- *
- *    const obj: { a?: number, b: number } = { b: 2 };
- *    const result = R.omit(obj, ['a']);
- *    result === obj // => true
  * @data_first
  * @category Object
  */
@@ -24,17 +19,12 @@ export function omit<T extends object, K extends keyof T>(
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- *
  * @param data the object
  * @param propNames the property names
  * @signature
  *    R.omit(names)(obj);
  * @example
  *    R.pipe({ a: 1, b: 2, c: 3, d: 4 }, R.omit(['a', 'd'])) // => { b: 2, c: 3 }
- *
- *    const obj: { a?: number, b: number } = { b: 2 };
- *    const result = R.pipe(obj, R.omit(['a']));
- *    result === obj // => true
  * @data_last
  * @category Object
  */

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -59,8 +59,7 @@ function _omit<T extends object, K extends keyof T>(
   propNames: ReadonlyArray<K>
 ): Omit<T, K> {
   if (!propNames.some(propName => propName in data)) {
-    // Avoid creating a clone of the input object when the output is unchanged.
-    return data;
+    return { ...data };
   }
 
   if (propNames.length === 1) {

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -3,18 +3,14 @@ import { purry } from './purry';
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- * 
- * If the properties are optional and they don't exist in the input object then
- * the same object is returned (unlike when using destructuring, which returns a
- * new clone of the object).
-
+ *
  * @param data the object
  * @param propNames the property names
  * @signature
  *    R.omit(obj, names);
  * @example
  *    R.omit({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd']) // => { b: 2, c: 3 }
- * 
+ *
  *    const obj: { a?: number, b: number } = { b: 2 };
  *    const result = R.omit(obj, ['a']);
  *    result === obj // => true
@@ -28,10 +24,6 @@ export function omit<T extends object, K extends keyof T>(
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
- *
- * If the properties are optional and they don't exist in the input object then
- * the same object is returned (unlike when using destructuring, which returns a
- * new clone of the object).
  *
  * @param data the object
  * @param propNames the property names

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -21,7 +21,7 @@ import { purry } from './purry';
  * @data_first
  * @category Object
  */
-export function omit<T extends object, K extends Extract<keyof T, string>>(
+export function omit<T extends object, K extends keyof T>(
   data: T,
   propNames: ReadonlyArray<K>
 ): Omit<T, K>;


### PR DESCRIPTION
In hot paths where the omit is used to filter out props which are rare (like normalization paths) the current impl creates too many redundant objects both while computing the omit (the set and the new object) and for the output.

In this implementation the object is only created if needed.

We also optimize the case of a single prop to remove to use spread so that the effort of creating the new object is left to the engine, instead of our impl.

Finally, we implement the the omit via built-ins so that we don't need to deal with our own loops. This might be optimized by the engine (at least when we move to more modern es versions)