### PR TITLE
fix(prop): strict key names

### DIFF
--- a/src/prop.test.ts
+++ b/src/prop.test.ts
@@ -7,27 +7,6 @@ test('prop', () => {
   expect(result).toEqual('bar');
 });
 
-test('type for curried form', () => {
-  const propFoo = prop('foo');
-
-  const result = propFoo({ foo: 1, bar: 'potato' });
-
-  expectTypeOf(result).toEqualTypeOf<number>();
-
-  expect(result).toBe(1);
-
-  // without the key
-  const r2 = propFoo({ bar: 'potato' });
-  expect(r2).toBe(undefined);
-
-  // can specify the target object type at creation
-  const propBar = prop('bar')<{ bar: number; baz: boolean }>;
-
-  expectTypeOf(
-    true as any as ReturnType<typeof propBar>
-  ).toEqualTypeOf<number>();
-});
-
 test('prop typing', () => {
   const input = [{ a: 1 }];
 

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -1,17 +1,13 @@
 /**
  * Gets the value of the given property.
- * @param prop the property name
+ * @param propName the property name
  * @signature R.prop(prop)(object)
  * @example
  *    R.pipe({foo: 'bar'}, R.prop('foo')) // => 'bar'
  * @data_last
  * @category Object
  */
-export function prop<T, K extends keyof T>(prop: K): (data: T) => T[K];
-export function prop<K extends PropertyKey>(
-  prop: K
-): <T>(data: T) => K extends keyof T ? T[K] : undefined;
-
-export function prop<T, K extends keyof T>(prop: K): (data: T) => unknown {
-  return data => data[prop];
-}
+export const prop =
+  <T, K extends keyof T>(propName: K): ((data: T) => T[K]) =>
+  ({ [propName]: value }) =>
+    value;

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -8,6 +8,6 @@
  * @category Object
  */
 export const prop =
-  <T, K extends keyof T>(propName: K): ((data: T) => T[K]) =>
-  ({ [propName]: value }) =>
+  <T, K extends keyof T>(propName: K) =>
+  ({ [propName]: value }: T) =>
     value;


### PR DESCRIPTION
I've encountered issues at work were prop didn't detect the object's props and didn't offer typehints, allowing entering any propName, and resulting in `any` in the pipe instead of a strict type.

I don't fully understand when this happens and when it doesn't, as it doesn't repro in all pipes (as can be seen by the test), but generally, if the prop function right now doesn't provide us a strong type-safety at compile time to prevent people from accessing a non-existent prop then it isn't useful.

Reverting to the typing before #238