### PR TITLE
Update documentation for times.ts

### DIFF
--- a/src/times.ts
+++ b/src/times.ts
@@ -10,7 +10,7 @@ import { purry } from './purry';
  * @param {Number} count A value between `0` and `n - 1`. Increments after each function call.
  * @param {Function} fn The function to invoke. Passed one argument, the current value of `n`.
  * @return {Array} An array containing the return values of all calls to `fn`.
- * @example times(identity, 5); //=> [0, 1, 2, 3, 4]
+ * @example times(5, identity); //=> [0, 1, 2, 3, 4]
  * @data_first
  */
 export function times<T>(count: number, fn: (n: number) => T): Array<T>;

--- a/src/times.ts
+++ b/src/times.ts
@@ -25,7 +25,7 @@ export function times<T>(count: number, fn: (n: number) => T): Array<T>;
  * @param {Function} fn The function to invoke. Passed one argument, the current value of `n`.
  * @param {Number} count A value between `0` and `n - 1`. Increments after each function call.
  * @return {Array} An array containing the return values of all calls to `fn`.
- * @example times(5)(identity); //=> [0, 1, 2, 3, 4]
+ * @example times(identity)(5); //=> [0, 1, 2, 3, 4]
  * @data_last
  */
 export function times<T>(fn: (n: number) => T): (count: number) => Array<T>;


### PR DESCRIPTION
The examples for `times` passes the function arguments in the wrong order.

> The example in the the docs lists the parameters as `times(identity, 5)` (function before count). However, the code itself expects `times(5, identity)` (count before function). This change updates the example to match the code. This PR also changes the docs for the data-first version of times.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
