### PR TITLE
fix(dropLast): Handle non-positive lengths

### DIFF
--- a/src/drop.test.ts
+++ b/src/drop.test.ts
@@ -7,8 +7,19 @@ const array = [1, 2, 3, 4, 5] as const;
 const expected = [3, 4, 5];
 
 describe('data first', () => {
-  test('should drop last', () => {
+  test('should drop', () => {
     expect(drop(array, 2)).toEqual(expected);
+  });
+
+  test('should not drop', () => {
+    expect(drop(array, 0)).toEqual(array);
+    expect(drop(array, -0)).toEqual(array);
+    expect(drop(array, -1)).toEqual(array);
+    expect(drop(array, NaN)).toEqual(array);
+  });
+
+  test('should return a new array even if there was no drop', () => {
+    expect(drop(array, 0)).not.toBe(array);
   });
 });
 

--- a/src/dropLast.test.ts
+++ b/src/dropLast.test.ts
@@ -9,4 +9,10 @@ test('should drop last', () => {
 test('should not drop last', () => {
   expect(dropLast(arr, 0)).toEqual(arr);
   expect(dropLast(arr, -0)).toEqual(arr);
+  expect(dropLast(arr, -1)).toEqual(arr);
+  expect(dropLast(arr, NaN)).toEqual(arr);
+});
+
+test('should return a new array even if there was no drop', () => {
+  expect(dropLast(arr, 0)).not.toBe(arr);
 });

--- a/src/dropLast.ts
+++ b/src/dropLast.ts
@@ -32,7 +32,7 @@ export function dropLast() {
 
 function _dropLast<T>(array: Array<T>, n: number) {
   const copy = [...array];
-  if (n !== 0) {
+  if (n > 0) {
     copy.splice(-n);
   }
   return copy;


### PR DESCRIPTION
Closed https://github.com/remeda/remeda/issues/350
Added a pinch of tests.
Also this change fixed the work with `NaN` as `N`. 