### PR TITLE
docs(swapProps): Missing description for data_first version + category

### DIFF
--- a/src/swapProps.ts
+++ b/src/swapProps.ts
@@ -5,6 +5,8 @@ type SwappedProps<T, K1 extends keyof T, K2 extends keyof T> = {
 };
 
 /**
+ * Swaps the positions of two properties in an object based on the provided keys.
+ *
  * @param data the object to be manipulated
  * @param key1 the first property key
  * @param key2 the second property key
@@ -17,6 +19,8 @@ type SwappedProps<T, K1 extends keyof T, K2 extends keyof T> = {
  * @example
  *   swap({a: 1, b: 2, c: 3}, 'a', 'b') // => {a: 2, b: 1, c: 3}
  *
+ * @category Object
+ *
  * @data_first
  */
 export function swapProps<
@@ -27,6 +31,7 @@ export function swapProps<
 
 /**
  * Swaps the positions of two properties in an object based on the provided keys.
+ *
  * @param key1 the first property key
  * @param key2 the second property key
  *
@@ -37,6 +42,8 @@ export function swapProps<
  *   swap('a', 'b')({a: 1, b: 2, c: 3}) // => {a: 2, b: 1, c: 3}
  *
  * @returns Returns the manipulated object.
+ *
+ * @category Object
  *
  * @data_last
  */


### PR DESCRIPTION
> Fixed missing description for `swapProps`

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
Hello, I noticed that the description for `swapProps` was hot showing up in the docs (https://remedajs.com/docs#swapProps):

![remedajs com_docs](https://github.com/remeda/remeda/assets/6861911/49a92833-042c-4cd3-88da-237796299e62)

I fixed it and added the "Object"-tag:

![localhost_3000_docs](https://github.com/remeda/remeda/assets/6861911/54ef8e77-a7f6-4cd7-8b4c-3af4069657c2)

Cheers