### PR TITLE
ci(docs): modernize docs release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,24 +1,52 @@
 name: GH pages
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+
+      - name: Download deps
+        uses: bahmutov/npm-install@v1
+
       - name: Build docs
         run: yarn docs:build
-      - name: Deploy pages
-        uses: JamesIves/github-pages-deploy-action@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          folder: docs/dist
+          path: './docs/dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
I recently created a project deployed to github pages and followed their guide. I ported those recommendations here too.

Also changed the trigger to relases so that our docs don't reflect changes that aren't part of the library yet (for the rare cases where we ship something to the `master` branch but don't relase a version soon after.

