### PR TITLE
docs(gh-pages): pass router base name

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Build docs
         run: yarn docs:build
         env:
-          ROUTER_BASE_NAME: ${{ github.event.repository.name }}
+          # The loops i'd go through to make this generic... :(
+          # We define the base name as '/remeda/', but this makes it more
+          # generic so it's future-proof if the project ever changes it's name
+          ROUTER_BASE_NAME: ${{ format('/{0}/', github.event.repository.name) }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build docs
         run: yarn docs:build
+        env:
+          ROUTER_BASE_NAME: ${{ github.event.repository.name }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -12,7 +12,7 @@ export class App extends React.PureComponent {
   }
   render() {
     return (
-      <Router>
+      <Router basename={process.env.ROUTER_BASE_NAME}>
         <div className="wrapper">
           <Header />
           <Route exact path="/" component={Home} />


### PR DESCRIPTION
github pages are always located at `<ORGNAME>.github.io/<REPONAME>`. React router assumes the `/` route is always at the base of the URL. That's why it needs the base name to be defined for it to work if the root isn't at the URL root.

Here we use the fact that parcel inlines enviroment varialbes on build: https://parceljs.org/features/node-emulation/#environment-variables. We also assume that `${{ github.event.repository.name }}` would resolve to the current repo name ("remeda"). Finally, we assume that if the env variable is missing parcel would use undefined for the value, allowing us to fallback to the default root base name for the netlify deployment
