### PR TITLE
type(isEmpty): accept undefined for strings

### DIFF
--- a/src/isEmpty.test.ts
+++ b/src/isEmpty.test.ts
@@ -34,7 +34,95 @@ describe('isEmpty', () => {
     // @ts-expect-error null is not a valid input type
     isEmpty(null);
 
-    // @ts-expect-error undefined is not a valid input type
-    isEmpty(undefined);
+    // @ts-expect-error [ts2769] undefined is only allowed with strings
+    isEmpty([] as ReadonlyArray<string> | undefined);
+  });
+});
+
+describe('strings are narrowed correctly', () => {
+  test('just undefined', () => {
+    const data = undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<undefined>();
+    }
+  });
+
+  test('just string', () => {
+    const data = '' as string;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<''>();
+    }
+  });
+
+  test('just EMPTY string', () => {
+    const data = '' as const;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<''>();
+    }
+  });
+
+  test('string or undefined', () => {
+    const data = undefined as string | undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<'' | undefined>();
+    }
+  });
+
+  test('string literals that CANT be empty or undefined', () => {
+    const data = 'cat' as 'cat' | 'dog';
+    if (isEmpty(data)) {
+      // unreachable
+      expectTypeOf(data).toEqualTypeOf<never>();
+    }
+  });
+
+  test('string literals that CAN be empty', () => {
+    const data = 'cat' as 'cat' | 'dog' | '';
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<''>();
+    }
+  });
+
+  test('string literals that CAN be undefined', () => {
+    const data = 'cat' as 'cat' | 'dog' | undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<undefined>();
+    }
+  });
+
+  test('string literals that CAN be undefined or empty', () => {
+    const data = 'cat' as 'cat' | 'dog' | '' | undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<'' | undefined>();
+    }
+  });
+
+  test('string templates that CANT be empty or undefined', () => {
+    const data = 'prefix_0' as `prefix_${number}`;
+    if (isEmpty(data)) {
+      // unreachable
+      expectTypeOf(data).toEqualTypeOf<never>();
+    }
+  });
+
+  test('string templates that CAN be empty', () => {
+    const data = '' as `prefix_${number}` | '';
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<''>();
+    }
+  });
+
+  test('string templates that CAN be undefined', () => {
+    const data = 'prefix_0' as `prefix_${number}` | undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<undefined>();
+    }
+  });
+
+  test('string templates that CAN be undefined or empty', () => {
+    const data = 'prefix_0' as `prefix_${number}` | '' | undefined;
+    if (isEmpty(data)) {
+      expectTypeOf(data).toEqualTypeOf<'' | undefined>();
+    }
   });
 });

--- a/src/isEmpty.test.ts
+++ b/src/isEmpty.test.ts
@@ -24,18 +24,25 @@ describe('isEmpty', () => {
     expect(isEmpty({ length: 0 })).toBe(false);
   });
 
+  test('returns true for undefined', () => {
+    expect(isEmpty(undefined)).toBe(true);
+  });
+
   test('does not accept invalid input types', () => {
-    // @ts-expect-error number is not a valid input type
+    // @ts-expect-error [ts2769] number is not a valid input type
     isEmpty(2);
 
-    // @ts-expect-error boolean is not a valid input type
+    // @ts-expect-error [ts2769] boolean is not a valid input type
     isEmpty(false);
 
-    // @ts-expect-error null is not a valid input type
+    // @ts-expect-error [ts2769] null is not a valid input type
     isEmpty(null);
 
     // @ts-expect-error [ts2769] undefined is only allowed with strings
     isEmpty([] as ReadonlyArray<string> | undefined);
+
+    // @ts-expect-error [ts2769] undefined is only allowed with strings
+    isEmpty({} as Record<string, string> | undefined);
   });
 });
 

--- a/src/isEmpty.ts
+++ b/src/isEmpty.ts
@@ -3,12 +3,17 @@ import { isObject } from './isObject';
 import { isString } from './isString';
 
 /**
- * A function that checks if the passed parameter is empty
+ * A function that checks if the passed parameter is empty.
+ *
+ * `undefined` is also considered empty, but only when it's in a union with a
+ * `string` or string-like type.
+ *
  * @param data the variable to check
  * @signature
  *    R.isEmpty(data)
  * @returns true if the passed input is empty, false otherwise
  * @example
+ *    R.isEmpty(undefined) //=>true
  *    R.isEmpty('') //=> true
  *    R.isEmpty([]) //=> true
  *    R.isEmpty({}) //=> true
@@ -17,12 +22,20 @@ import { isString } from './isString';
  *    R.isEmpty({ length: 0 }) //=> false
  * @category Function
  */
-export function isEmpty(data: string): data is '';
+export function isEmpty<T extends string | undefined>(
+  data: T
+): data is
+  | ('' extends T ? '' : never)
+  | (undefined extends T ? undefined : never);
 export function isEmpty(data: ReadonlyArray<unknown> | []): data is [];
 export function isEmpty<T extends Readonly<Record<PropertyKey, unknown>>>(
   data: T
 ): data is Record<keyof T, never>;
 export function isEmpty(data: unknown): boolean {
+  if (data === undefined) {
+    return true;
+  }
+
   if (isArray(data) || isString(data)) {
     return data.length === 0;
   }


### PR DESCRIPTION
Adds support for undefined for strings (but not for arrays and objects).

Closes #369 

---

Make sure that you:

- [X] Typedoc added for new methods and updated for changed
- [X] Tests added for new methods and updated for changed

