### PR TITLE
ci: lint PR titles for conventional syntax

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,27 @@ Make sure that you:
 - [ ] Tests added for new methods and updated for changed
 - [ ] New methods added to `src/index.ts`
 - [ ] New methods added to `mapping.md`
+
+---
+
+<details><summary>We use semantic PR titles to automate the release process!</summary>
+
+https://conventionalcommits.org
+
+PRs should be titled following using the format: `< TYPE >(< scope >)?: description`
+
+### Available Types:
+
+- `feat`: new functions!
+- `fix`: changes to function implementations that fix a bug where a function produces the wrong _runtime_ results.
+- `type`: type-only changes (params, overloading, return types, etc...)
+- `perf`: changes to function implementations that improve a functions _runtime_ performance.
+- `refactor`: changes to function implementations that are neither `fix` nor `perf`
+- `test`: tests-only changes (transparent to users of the function).
+- `docs`: changes to the documentation of a function **or the documentation site**.
+- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.
+
+For scope put the name of the function you are working on (either new or
+existing).
+
+</details>

--- a/.github/workflows/pr_titles.yml
+++ b/.github/workflows/pr_titles.yml
@@ -1,0 +1,20 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_titles.yml
+++ b/.github/workflows/pr_titles.yml
@@ -16,5 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        with:
+          # We use the default types (as defined in:
+          # https://github.com/commitizen/conventional-commit-types), but we
+          # add "type" to categorize changes that only affect the type system,
+          # and not the runtime behaviour (function signatures, return types,
+          # etc...)
+          types: |
+            feat
+            fix
+            type
+            perf
+            refactor
+            test
+            docs
+            build
+            ci
+            style
+            chore
+            revert
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We rely on PR titles for our release process, we usually need to rename PRs manually to make them fit, and we often make mistakes.

This should prevent all that
