### PR TITLE
feat(zip): strict tuples

### DIFF
--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -143,7 +143,7 @@ describe('strict typings', () => {
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
     const result = zip.strict(firstVariadic, secondVariadic);
     expectTypeOf(result).toEqualTypeOf<
-      Array<[string | number, string | number]>
+      [[number, string], ...Array<[string, number]>]
     >;
   });
 });

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -6,7 +6,7 @@ const second = ['a', 'b', 'c'];
 const shorterFirst = [1, 2];
 const shorterSecond = ['a', 'b'];
 
-describe('data first', () => {
+describe('dataFirst', () => {
   test('should zip', () => {
     expect(zip(first, second)).toEqual([
       [1, 'a'],
@@ -85,52 +85,52 @@ describe('dataLast typings', () => {
 });
 
 describe('strict dataFirst typings', () => {
-  it('on empty tuples', () => {
+  test('on empty tuples', () => {
     const array: [] = [];
     const result = zip.strict(array, array);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it('on empty readonly tuples', () => {
+  test('on empty readonly tuples', () => {
     const array: readonly [] = [];
     const result = zip.strict(array, array);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it('on arrays', () => {
+  test('on arrays', () => {
     const array: Array<number> = [];
     const result = zip.strict(array, array);
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
-  it('on mixed typeds array', () => {
+  test('on mixed typeds array', () => {
     const array1: Array<number> = [];
     const array2: Array<string> = [];
     const result = zip.strict(array1, array2);
     expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
   });
 
-  it('on readonly arrays', () => {
+  test('on readonly arrays', () => {
     const array: ReadonlyArray<number> = [];
     const result = zip.strict(array, array);
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
-  it('on tuples', () => {
+  test('on tuples', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5, 6] = [4, 5, 6];
     const result = zip.strict(array1, array2);
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
-  it('on readonly tuples', () => {
+  test('on readonly tuples', () => {
     const array1: readonly [1, 2, 3] = [1, 2, 3];
     const array2: readonly [4, 5, 6] = [4, 5, 6];
     const result = zip.strict(array1, array2);
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
-  it('on tuples of different lengths', () => {
+  test('on tuples of different lengths', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5] = [4, 5];
     const result1 = zip.strict(array1, array2);
@@ -149,53 +149,53 @@ describe('strict dataFirst typings', () => {
   });
 });
 
-describe('dataLast strict typings', () => {
-  it('on empty tuples', () => {
+describe('strict dataLast typings', () => {
+  test('on empty tuples', () => {
     const array: [] = [];
     const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it('on empty readonly tuples', () => {
+  test('on empty readonly tuples', () => {
     const array: readonly [] = [];
     const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it('on arrays', () => {
+  test('on arrays', () => {
     const array: Array<number> = [];
     const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
-  it('on mixed typeds array', () => {
+  test('on mixed typeds array', () => {
     const array1: Array<number> = [];
     const array2: Array<string> = [];
     const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
   });
 
-  it('on readonly arrays', () => {
+  test('on readonly arrays', () => {
     const array: ReadonlyArray<number> = [];
     const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
-  it('on tuples', () => {
+  test('on tuples', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5, 6] = [4, 5, 6];
     const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
-  it('on readonly tuples', () => {
+  test('on readonly tuples', () => {
     const array1: readonly [1, 2, 3] = [1, 2, 3];
     const array2: readonly [4, 5, 6] = [4, 5, 6];
     const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
-  it('on tuples of different lengths', () => {
+  test('on tuples of different lengths', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5] = [4, 5];
     const result1 = pipe(array1, zip.strict(array2));

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,3 +1,4 @@
+import { pipe } from './pipe';
 import { zip } from './zip';
 
 const first = [1, 2, 3];
@@ -27,7 +28,7 @@ describe('data first', () => {
   });
 });
 
-describe('data first typings', () => {
+describe('dataFirst typings', () => {
   test('arrays', () => {
     const actual = zip(first, second);
     assertType<Array<[number, string]>>(actual);
@@ -44,7 +45,7 @@ describe('data first typings', () => {
   });
 });
 
-describe('data second', () => {
+describe('dataLast', () => {
   test('should zip', () => {
     expect(zip(second)(first)).toEqual([
       [1, 'a'],
@@ -66,24 +67,24 @@ describe('data second', () => {
   });
 });
 
-describe('data second typings', () => {
+describe('dataLast typings', () => {
   test('arrays', () => {
-    const actual = zip(second)(first);
+    const actual = pipe(first, zip(second));
     assertType<Array<[number, string]>>(actual);
   });
   test('tuples', () => {
-    const actual = zip(second as ['a', 'b', 'c'])(first as [1, 2, 3]);
+    const actual = pipe(first as [1, 2, 3], zip(second as ['a', 'b', 'c']));
     assertType<Array<[1 | 2 | 3, 'a' | 'b' | 'c']>>(actual);
   });
   test('variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
-    const actual = zip(secondVariadic)(firstVariadic);
+    const actual = pipe(firstVariadic, zip(secondVariadic));
     assertType<Array<[string | number, string | number]>>(actual);
   });
 });
 
-describe('strict typings', () => {
+describe('strict dataFirst typings', () => {
   it('on empty tuples', () => {
     const array: [] = [];
     const result = zip.strict(array, array);
@@ -148,65 +149,65 @@ describe('strict typings', () => {
   });
 });
 
-describe('data second strict typings', () => {
+describe('dataLast strict typings', () => {
   it('on empty tuples', () => {
     const array: [] = [];
-    const result = zip.strict(array)(array);
+    const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it('on empty readonly tuples', () => {
     const array: readonly [] = [];
-    const result = zip.strict(array)(array);
+    const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it('on arrays', () => {
     const array: Array<number> = [];
-    const result = zip.strict(array)(array);
+    const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   it('on mixed typeds array', () => {
     const array1: Array<number> = [];
     const array2: Array<string> = [];
-    const result = zip.strict(array2)(array1);
+    const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
   });
 
   it('on readonly arrays', () => {
     const array: ReadonlyArray<number> = [];
-    const result = zip.strict(array, array);
+    const result = pipe(array, zip.strict(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   it('on tuples', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5, 6] = [4, 5, 6];
-    const result = zip.strict(array2)(array1);
+    const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   it('on readonly tuples', () => {
     const array1: readonly [1, 2, 3] = [1, 2, 3];
     const array2: readonly [4, 5, 6] = [4, 5, 6];
-    const result = zip.strict(array2)(array1);
+    const result = pipe(array1, zip.strict(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   it('on tuples of different lengths', () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5] = [4, 5];
-    const result1 = zip.strict(array2)(array1);
+    const result1 = pipe(array1, zip.strict(array2));
     expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
-    const result2 = zip.strict(array2, array1);
+    const result2 = pipe(array2, zip.strict(array1));
     expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
   });
 
   test('on variadic tuples', () => {
     const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
     const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
-    const result = zip.strict(firstVariadic, secondVariadic);
+    const result = pipe(secondVariadic, zip.strict(firstVariadic));
     expectTypeOf(result).toEqualTypeOf<
       [[number, string], ...Array<[string, number]>]
     >;

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -82,3 +82,68 @@ describe('data second typings', () => {
     assertType<Array<[string | number, string | number]>>(actual);
   });
 });
+
+describe('strict typings', () => {
+  it('on empty tuples', () => {
+    const array: [] = [];
+    const result = zip.strict(array, array);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on empty readonly tuples', () => {
+    const array: readonly [] = [];
+    const result = zip.strict(array, array);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on arrays', () => {
+    const array: Array<number> = [];
+    const result = zip.strict(array, array);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+  });
+
+  it('on mixed typeds array', () => {
+    const array1: Array<number> = [];
+    const array2: Array<string> = [];
+    const result = zip.strict(array1, array2);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
+  });
+
+  it('on readonly arrays', () => {
+    const array: ReadonlyArray<number> = [];
+    const result = zip.strict(array, array);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+  });
+
+  it('on tuples', () => {
+    const array1: [1, 2, 3] = [1, 2, 3];
+    const array2: [4, 5, 6] = [4, 5, 6];
+    const result = zip.strict(array1, array2);
+    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+  });
+
+  it('on readonly tuples', () => {
+    const array1: readonly [1, 2, 3] = [1, 2, 3];
+    const array2: readonly [4, 5, 6] = [4, 5, 6];
+    const result = zip.strict(array1, array2);
+    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+  });
+
+  it('on tuples of different lengths', () => {
+    const array1: [1, 2, 3] = [1, 2, 3];
+    const array2: [4, 5] = [4, 5];
+    const result1 = zip.strict(array1, array2);
+    expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
+    const result2 = zip.strict(array2, array1);
+    expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
+  });
+
+  test('on variadic tuples', () => {
+    const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
+    const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
+    const result = zip.strict(firstVariadic, secondVariadic);
+    expectTypeOf(result).toEqualTypeOf<
+      Array<[string | number, string | number]>
+    >;
+  });
+});

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -147,3 +147,68 @@ describe('strict typings', () => {
     >;
   });
 });
+
+describe('data second strict typings', () => {
+  it('on empty tuples', () => {
+    const array: [] = [];
+    const result = zip.strict(array)(array);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on empty readonly tuples', () => {
+    const array: readonly [] = [];
+    const result = zip.strict(array)(array);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it('on arrays', () => {
+    const array: Array<number> = [];
+    const result = zip.strict(array)(array);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+  });
+
+  it('on mixed typeds array', () => {
+    const array1: Array<number> = [];
+    const array2: Array<string> = [];
+    const result = zip.strict(array2)(array1);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
+  });
+
+  it('on readonly arrays', () => {
+    const array: ReadonlyArray<number> = [];
+    const result = zip.strict(array, array);
+    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+  });
+
+  it('on tuples', () => {
+    const array1: [1, 2, 3] = [1, 2, 3];
+    const array2: [4, 5, 6] = [4, 5, 6];
+    const result = zip.strict(array2)(array1);
+    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+  });
+
+  it('on readonly tuples', () => {
+    const array1: readonly [1, 2, 3] = [1, 2, 3];
+    const array2: readonly [4, 5, 6] = [4, 5, 6];
+    const result = zip.strict(array2)(array1);
+    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+  });
+
+  it('on tuples of different lengths', () => {
+    const array1: [1, 2, 3] = [1, 2, 3];
+    const array2: [4, 5] = [4, 5];
+    const result1 = zip.strict(array2)(array1);
+    expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
+    const result2 = zip.strict(array2, array1);
+    expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
+  });
+
+  test('on variadic tuples', () => {
+    const firstVariadic: [number, ...Array<string>] = [1, 'b', 'c'];
+    const secondVariadic: [string, ...Array<number>] = ['a', 2, 3];
+    const result = zip.strict(firstVariadic, secondVariadic);
+    expectTypeOf(result).toEqualTypeOf<
+      [[number, string], ...Array<[string, number]>]
+    >;
+  });
+});

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -5,8 +5,8 @@ import { purry } from './purry';
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
  * The length of the returned list will match the shortest of the two inputs.
  *
- * If the input array are non-variadic tuple, you can use the strict option
- * to get another tuple instead of an array type.
+ * If the input array are tuples, you can use the strict option
+ * to get another tuple instead of a generic array type.
  * @param first the first input list
  * @param second the second input list
  * @signature
@@ -26,6 +26,9 @@ export function zip<F, S>(
 /**
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
  * The length of the returned list will match the shortest of the two inputs.
+ *
+ * If the input array are tuples, you can use the strict option
+ * to get another tuple instead of a generic array type.
  * @param second the second input list
  * @signature
  *   R.zip(second)(first)
@@ -33,6 +36,7 @@ export function zip<F, S>(
  *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']]
  * @dataLast
  * @category Array
+ * @strict
  */
 export function zip<S>(
   second: ReadonlyArray<S>
@@ -62,11 +66,6 @@ interface Strict {
   <S extends IterableContainer>(second: S): <F extends IterableContainer>(
     first: F
   ) => Zip<F, S>;
-
-  // This doesn't work, TS cannot correctly infer type arguments
-  // <S extends IterableContainer, F extends IterableContainer>(second: S): (
-  //   first: F
-  // ) => Zip<F, S>;
 }
 
 type Zip<Left extends IterableContainer, Right extends IterableContainer> =
@@ -90,7 +89,7 @@ type Zip<Left extends IterableContainer, Right extends IterableContainer> =
       Array<[Left[number], Right[number]]>;
 
 export namespace zip {
-  // @ts-expect-error - The data second strict version requires only 1 type argument
+  // @ts-expect-error ts[2322] - The data second strict version requires only 1 argument
   // while zip expects 2, so TS will complain that it's not assignable
   export const strict: Strict = zip;
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,16 +1,22 @@
+import { IterableContainer } from './_types';
 import { purry } from './purry';
 
 /**
  * Creates a new list from two supplied lists by pairing up equally-positioned items.
  * The length of the returned list will match the shortest of the two inputs.
+ *
+ * If the input array are non-variadic tuple, you can use the strict option
+ * to get another tuple instead of an array type.
  * @param first the first input list
  * @param second the second input list
  * @signature
  *   R.zip(first, second)
  * @example
- *   R.zip([1, 2], ['a', 'b']) // => [1, 'a'], [2, 'b']
+ *   R.zip([1, 2], ['a', 'b']) // => [[1, 'a'], [2, 'b']] (type: [1 | 2, 'a' | 'b'][])
+ *   R.zip.strict([1, 2] as const, ['a', 'b'] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
  * @dataFirst
  * @category Array
+ * @strict
  */
 export function zip<F, S>(
   first: ReadonlyArray<F>,
@@ -24,7 +30,7 @@ export function zip<F, S>(
  * @signature
  *   R.zip(second)(first)
  * @example
- *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']
+ *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']]
  * @dataLast
  * @category Array
  */
@@ -45,4 +51,40 @@ function _zip(first: Array<unknown>, second: Array<unknown>) {
   }
 
   return result;
+}
+
+type Strict = <T extends IterableContainer, K extends IterableContainer>(
+  first: T,
+  second: K
+) => StrictOut<T, K>;
+
+type JoinTuples<
+  Shorter extends IterableContainer,
+  Longer extends IterableContainer,
+  ShorterFirst extends 0 | 1
+> = {
+  -readonly [P in keyof Shorter]: P extends keyof Longer
+    ? ShorterFirst extends 1
+      ? [Shorter[P], Longer[P]]
+      : [Longer[P], Shorter[P]]
+    : never;
+};
+
+// The first two checks are to ensure that both tuples are finite (checking all
+// the edge cases and possible combinations of variadic tuples is nearly impossible),
+// while the last check is used to determine which tuple is smaller so that it can be
+// used to index the other one
+type StrictOut<
+  K extends IterableContainer,
+  T extends IterableContainer
+> = number extends K['length']
+  ? number extends T['length']
+    ? Array<[K[number], T[number]]>
+    : Array<[K[number], T[number]]>
+  : keyof K extends keyof T
+  ? JoinTuples<K, T, 1>
+  : JoinTuples<T, K, 0>;
+
+export namespace zip {
+  export const strict: Strict = zip;
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -12,7 +12,7 @@ import { purry } from './purry';
  * @signature
  *   R.zip(first, second)
  * @example
- *   R.zip([1, 2], ['a', 'b']) // => [[1, 'a'], [2, 'b']] (type: [1 | 2, 'a' | 'b'][])
+ *   R.zip([1, 2], ['a', 'b']) // => [[1, 'a'], [2, 'b']] (type: [number, string][])
  *   R.zip.strict([1, 2] as const, ['a', 'b'] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
  * @dataFirst
  * @category Array
@@ -33,7 +33,8 @@ export function zip<F, S>(
  * @signature
  *   R.zip(second)(first)
  * @example
- *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']]
+ *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']] (type: [number, string][])
+ *   R.zip.strict(['a', 'b'] as const)([1, 2] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
  * @dataLast
  * @category Array
  * @strict

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -89,7 +89,7 @@ type Zip<Left extends IterableContainer, Right extends IterableContainer> =
       Array<[Left[number], Right[number]]>;
 
 export namespace zip {
-  // @ts-expect-error ts[2322] - The data second strict version requires only 1 argument
+  // @ts-expect-error ts[2322] - The dataLast strict version requires only 1 argument
   // while zip expects 2, so TS will complain that it's not assignable
   export const strict: Strict = zip;
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -53,10 +53,21 @@ function _zip(first: Array<unknown>, second: Array<unknown>) {
   return result;
 }
 
-type Strict = <T extends IterableContainer, K extends IterableContainer>(
-  first: T,
-  second: K
-) => Zip<T, K>;
+interface Strict {
+  <F extends IterableContainer, S extends IterableContainer>(
+    first: F,
+    second: S
+  ): Zip<F, S>;
+
+  <S extends IterableContainer>(second: S): <F extends IterableContainer>(
+    first: F
+  ) => Zip<F, S>;
+
+  // This doesn't work, TS cannot correctly infer type arguments
+  // <S extends IterableContainer, F extends IterableContainer>(second: S): (
+  //   first: F
+  // ) => Zip<F, S>;
+}
 
 type Zip<Left extends IterableContainer, Right extends IterableContainer> =
   // If the array is empty the output is empty, no surprises
@@ -79,5 +90,7 @@ type Zip<Left extends IterableContainer, Right extends IterableContainer> =
       Array<[Left[number], Right[number]]>;
 
 export namespace zip {
+  // @ts-expect-error - The data second strict version requires only 1 type argument
+  // while zip expects 2, so TS will complain that it's not assignable
   export const strict: Strict = zip;
 }


### PR DESCRIPTION
Inspired by https://github.com/remeda/remeda/issues/389, this PR will add a strict version to the data-first version of `zip`, which, given two finite (non-variadic) tuple types, will return another finite tuple type instead of a wider array type.
```ts
R.zip([1, 2], ['a', 'b'])
// => [[1, 'a'], [2, 'b']] (type: [1 | 2, 'a' | 'b'][])
R.zip.strict([1, 2] as const, ['a', 'b'] as const)
// => [[1, 'a'], [2, 'b']] (type: [[1, 'a'], [2, 'b']])
```

I couldn't come up with a strict version of the data-second version, and while I'm not sure that it makes sense to have only one strict version, it is quite useful anyway.

If the maintainers decide that it make sense, I'll probably expand this PR to have strict versions of `zipWith` and `zipObj`, too. If that's not the case, maybe this PR can be a good start for anyone who decides to try to type both the data-first and data-second versions.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`
