### PR TITLE
feat: add `unset` function

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -90,6 +90,8 @@ documentation when migrating._
 | `uniq`              | `uniq`              | `uniq`              |
 | `uniqBy`            | `uniqBy`            | `uniqBy`            |
 | `uniqWith`          | `uniqWith`          | `uniqWith`          |
+| `unset`             | `-`                 | `dissoc`            |
+| `-`                 | `unset`             | `dissocPath`        |
 | `zipObj`            | `zipObj`            | `zipObj`            |
 
 ## Helpful one-liners

--- a/mapping.md
+++ b/mapping.md
@@ -91,7 +91,6 @@ documentation when migrating._
 | `uniqBy`            | `uniqBy`            | `uniqBy`            |
 | `uniqWith`          | `uniqWith`          | `uniqWith`          |
 | `unset`             | `-`                 | `dissoc`            |
-| `-`                 | `unset`             | `dissocPath`        |
 | `zipObj`            | `zipObj`            | `zipObj`            |
 
 ## Helpful one-liners

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ export * from './type';
 export * from './uniq';
 export * from './uniqBy';
 export * from './uniqWith';
+export * from './unset';
 export * from './values';
 export * from './zip';
 export * from './zipObj';

--- a/src/unset.test.ts
+++ b/src/unset.test.ts
@@ -1,0 +1,73 @@
+import { pipe } from './pipe';
+import { unset } from './unset';
+
+describe('data first', () => {
+  test('unset', () => {
+    expect(unset({ a: 1 }, 'a')).toEqual({});
+    expect(unset({ a: { b: 1 } }, 'a')).toEqual({});
+    expect(unset({ a: 1, b: 2 }, 'a')).toEqual({ b: 2 });
+  });
+
+  test("prop that doesn't exist", () => {
+    const data = { a: 1 };
+    const actual = unset(data, 'b');
+    expect(actual).toEqual(data);
+    assert.notStrictEqual(actual, data);
+  });
+
+  test('abstract type', () => {
+    const obj: object = { a: 1 };
+    expect(unset(obj, 'a')).toEqual({});
+  });
+
+  it('should handle nil', () => {
+    expect(unset(null, 'a')).toEqual(null);
+  });
+});
+
+describe('data last', () => {
+  test('unset', () => {
+    expect(pipe({ a: 1 }, unset('a'))).toEqual({});
+  });
+
+  test('abstract type', () => {
+    const obj: object = { a: 1 };
+    expect(pipe(obj, unset('a'))).toEqual({});
+  });
+});
+
+describe('strict', () => {
+  describe('data first', () => {
+    test('unset', () => {
+      expect(pipe({ a: 1 }, unset.strict('a'))).toEqual({});
+    });
+
+    test("prop that doesn't exist", () => {
+      // @ts-expect-error -- we can't pass a prop that doesn't exist
+      expect(pipe({ a: 1 }, unset.strict('b'))).toEqual({ a: 1 });
+    });
+
+    test('abstract type', () => {
+      const obj: object = { a: 1 };
+      // @ts-expect-error -- we can't use abstract type in strict mode
+      expect(unset.strict(obj, 'a')).toEqual({});
+    });
+  });
+
+  describe('data last', () => {
+    test('unset', () => {
+      expect(pipe({ a: 1 }, unset.strict('a'))).toEqual({});
+    });
+
+    test("prop that doesn't exist", () => {
+      // @ts-expect-error -- we can't pass a prop that doesn't exist
+      expect(pipe({ a: 1 }, unset.strict('b'))).toEqual({ a: 1 });
+    });
+
+    test('abstract type', () => {
+      const obj: object = { a: 1 };
+      // @ts-expect-error -- we can't use abstract type in strict mode
+      expect(pipe(obj, unset.strict('a'))).toEqual({});
+    });
+  });
+});

--- a/src/unset.ts
+++ b/src/unset.ts
@@ -1,0 +1,57 @@
+import { isNil } from './isNil';
+import { purry } from './purry';
+
+/**
+ * Remove the `prop` of `obj`.
+ * @param obj the target object
+ * @param prop the property name
+ * @signature
+ *    R.unset(obj, prop)
+ * @example
+ *    R.unset({ a: 1, b: 2 }, 'a') // => { b: 2 }
+ * @dataFirst
+ * @category Object
+ */
+export function unset<T, K extends PropertyKey>(obj: T, prop: K): Omit<T, K>;
+
+/**
+ * Remove the `prop`  of `obj`.
+ * @param obj the target object
+ * @param prop the property name
+ * @signature
+ *    R.unset(prop)(obj)
+ * @example
+ *    R.pipe({ a: 1, b: 2 }, R.unset('a')) // => { b: 2 }
+ * @dataLast
+ * @category Object
+ */
+export function unset<T, K extends PropertyKey>(
+  prop: K
+): (obj: T) => Omit<T, K>;
+
+export function unset() {
+  return purry(_unset, arguments);
+}
+
+function _unset(obj: Record<PropertyKey, any>, prop: PropertyKey) {
+  if (isNil(obj)) {
+    return obj;
+  }
+
+  const result = { ...obj };
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- for efficiency
+  delete result[prop];
+  return result;
+}
+
+interface Strict {
+  // Data-First
+  <T, K extends keyof T>(obj: T, prop: K): Omit<T, K>;
+
+  // Data-Last
+  <T, K extends keyof T>(prop: K): (obj: T) => Omit<T, K>;
+}
+
+export namespace unset {
+  export const strict: Strict = unset;
+}


### PR DESCRIPTION
Add a `unset` function with the nearly same functionality as ramda's [dissoc](https://ramdajs.com/docs/#dissoc).

- what `nearly` means...: this `unset` don't handle array, but ramda's `dissoc` can handle arrays. This is consistent with the fact that with remeda's `set` don't handle array.
- I named it `unset`, because this function do the opposite of `set`. but, I have no particular preference.


Thanks for creating a great library!


---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions!
- `fix`: changes to function implementations that fix a bug where a function produces the wrong _runtime_ results.
- `type`: type-only changes (params, overloading, return types, etc...)
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
