### PR TITLE
fix(toPairs): Fix `toPairs` to accept interface types

### DIFF
--- a/src/toPairs.test.ts
+++ b/src/toPairs.test.ts
@@ -9,35 +9,47 @@ test('should return pairs', () => {
   ]);
 });
 
-test('should return pairs, strict', () => {
-  const actual = toPairs.strict({ a: 1, b: 2, c: 3 });
-  expect(actual).toEqual([
-    ['a', 1],
-    ['b', 2],
-    ['c', 3],
-  ]);
+it('should accept interface types', () => {
+  interface T {
+    a: string;
+  }
+
+  expectTypeOf(toPairs<T>({ a: 'b' })).toEqualTypeOf<Array<[string, string]>>();
 });
 
-test('stricter typing', () => {
-  const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as const);
-  assertType<Array<['a' | 'b' | 'c', 1 | 2 | 3]>>(actual);
-});
+describe('stricter', () => {
+  test('should return pairs', () => {
+    const actual = toPairs.strict({ a: 1, b: 2, c: 3 });
+    expect(actual).toEqual([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]);
+  });
 
-test('stricter typing with optional', () => {
-  const actual = toPairs.strict({} as { a?: string });
-  assertType<Array<['a', string]>>(actual);
-});
+  test('typing', () => {
+    const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as const);
+    assertType<Array<['a' | 'b' | 'c', 1 | 2 | 3]>>(actual);
+  });
 
-test('stricter typing with undefined', () => {
-  const actual = toPairs.strict({ a: undefined } as { a: string | undefined });
-  assertType<Array<['a', string | undefined]>>(actual);
-});
+  test('typing with optional', () => {
+    const actual = toPairs.strict({} as { a?: string });
+    assertType<Array<['a', string]>>(actual);
+  });
 
-test('stricter with a broad type', () => {
-  const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as Record<
-    string,
-    unknown
-  >);
+  test('typing with undefined', () => {
+    const actual = toPairs.strict({ a: undefined } as {
+      a: string | undefined;
+    });
+    assertType<Array<['a', string | undefined]>>(actual);
+  });
 
-  assertType<Array<[string, unknown]>>(actual);
+  test('with a broad type', () => {
+    const actual = toPairs.strict({ a: 1, b: 2, c: 3 } as Record<
+      string,
+      unknown
+    >);
+
+    assertType<Array<[string, unknown]>>(actual);
+  });
 });

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -24,7 +24,7 @@ type ObjectValues<T extends Record<PropertyKey, unknown>> =
   Required<T>[ObjectKeys<T>];
 type ObjectEntry<T extends Record<PropertyKey, unknown>> = [
   ObjectKeys<T>,
-  ObjectValues<T>
+  ObjectValues<T>,
 ];
 type ObjectEntries<T extends Record<PropertyKey, unknown>> = Array<
   ObjectEntry<T>

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -12,7 +12,9 @@ import { ObjectKeys } from './_types';
  * @strict
  * @category Object
  */
-export function toPairs<T>(object: Record<string, T>): Array<[string, T]> {
+export function toPairs<T extends object>(
+  object: T
+): Array<[string, Required<T>[keyof T]]> {
   return Object.entries(object);
 }
 
@@ -22,7 +24,7 @@ type ObjectValues<T extends Record<PropertyKey, unknown>> =
   Required<T>[ObjectKeys<T>];
 type ObjectEntry<T extends Record<PropertyKey, unknown>> = [
   ObjectKeys<T>,
-  ObjectValues<T>,
+  ObjectValues<T>
 ];
 type ObjectEntries<T extends Record<PropertyKey, unknown>> = Array<
   ObjectEntry<T>


### PR DESCRIPTION
The current version does not allow interface types.
```
interface Example {
  b: string
}

const a: Example = { b: 'c' }

R.toPairs(a)
```
This PR widens the type to allow any object not just `Record`s.

I was unsure how to type the current strict version however it should be easy after #410 is merged. 

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions!
- `fix`: changes to function implementations that fix a bug where a function produces the wrong _runtime_ results.
- `type`: type-only changes (params, overloading, return types, etc...)
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
