### PR TITLE
build: split coverage and typechecking from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         typescript-version:
+          - '~5.3.0'
           - '~5.2.0'
           - '~5.1.0'
-          - '~5.0.0'
           # We use features that were added in v4.2 of typescript, so that is
           # the lowest we can go here. This also means this is the lowest
           # version we support. When this value changes in the future it needs

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,15 +9,19 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: ⬇️ Checkout
         uses: actions/checkout@v4
-      - name: Setup Node.js
+
+      - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
-      - name: Run tests
-        run: npm run test:ci -- --coverage
-      - name: Upload coverage
+
+      - name: ☔ Collect coverage
+        run: npm run coverage
+
+      - name: 🗺️ Upload coverage
         uses: codecov/codecov-action@v3

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,14 +1,17 @@
 module.exports = {
-  // Code
-  '*.+(js|ts|jsx|tsx|mjs|cjs)': ['eslint --fix', 'prettier --write'],
-  // Configs
-  '*.+(json|json5|yaml|yml)': 'prettier --write',
-  // CSS
-  '*.+(css|scss|less)': 'prettier --write',
-  // Web
-  '*.+(htm|html|svg)': 'prettier --write',
-  // Markdown
-  '*.md': 'prettier --write',
-  // GraphQL
-  '*.graphql': 'prettier --write',
+  // The Typescript compiler can't type-check a single file, it needs to run on
+  // the whole project. To do that we use a function (instead of a string or
+  // array) so that no matter what file or how many, we will always run the same
+  // command.
+  '*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
+
+  // Javascript and Typescript (including commonJs and esm variants)
+  '*.@(js|jsx|ts|tsx|cjs|mjs)': ['eslint --fix', 'prettier --write'],
+
+  // _try_ prettier on anything, it supports a lot of things! If this is touching a file
+  // you don't want add it to .prettierignore.
+  // lint-staged runs *all* matching rules and doesn't have an "anything else" rule, so
+  // instead, we add all previous file extensions to the glob here so it doesn't run on
+  // any of those files.
+  '!(*.@(js|jsx|ts|tsx|cjs|mjs))': 'prettier --ignore-unknown --write',
 };

--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "clean": "rm -rf ./dist && mkdir dist",
     "compile": "tsc",
     "compile:dist": "tsc --project tsconfig.dist.json",
+    "coverage": "vitest run --coverage",
     "docs:build": "cd docs && npm ci && npm run build:netlify-ci",
     "lint": "eslint src/**/*.ts --fix",
     "lint:check": "eslint src/**/*.ts",
     "prepare": "husky install",
     "prettier": "prettier . --write",
     "prettier:check": "prettier . --check",
-    "test": "vitest run --coverage && npm run compile",
+    "test": "vitest",
     "test:ci": "vitest run"
   },
   "devDependencies": {


### PR DESCRIPTION
A few changes to our scripts and build process to make things a little faster and more ergonomic:
* Don't collect coverage data in regular test runs
* Don't run typechecking (building?) during test runs
* Do typechecking on the commit hook (instead)
* bump version of typechecking github action (following the release of ts 5.3)
* cleanup lint-staged to run on any prettier supported file (extendable with plugins) instead of a fixed set.