### PR TITLE
chore: remove redundant script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: 🧪 Run tests
-        run: npm run test:ci
+        run: npm run test
 
   lint:
     name: 🧹 Lint

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "prepare": "husky install",
     "prettier": "prettier . --write",
     "prettier:check": "prettier . --check",
-    "test": "vitest",
-    "test:ci": "vitest run"
+    "test": "vitest"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.3",


### PR DESCRIPTION
vitest will run without watch mode automatically in ci