### PR TITLE
chore: define files for coverage repors

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      include: ['src/*.ts'],
+      exclude: ['src/index.ts', 'src/_*.ts'],
+    },
   },
 });


### PR DESCRIPTION
The upgrade to vitest v1 meant that the definition of what's included in the coverage report changed. This caused us to report files that are not part of the module and that caused our score to go down.

This defines just the files we want to export to users for the coverage report.