### PR TITLE
docs: Disable single line breaks in docs site

### DIFF
--- a/docs/scripts/transform.ts
+++ b/docs/scripts/transform.ts
@@ -41,7 +41,6 @@ export type FunctionsData = ReadonlyArray<
 
 const MARKED_OPTIONS = {
   gfm: true,
-  breaks: true,
 } satisfies MarkedOptions;
 
 const PRETTIER_OPTIONS = {


### PR DESCRIPTION
So that JSDocs of functions can be formatted on multiple lines without affecting the docs site. Double line breaks will still be rendered as a new paragraph.

This is done by disabling the GFM (GitHub flavored markdown) style of line breaks when parsing the function descriptions with the 'marked' package.
