### PR TITLE
docs: use multiple badge colors in menu

### DIFF
--- a/docs/src/Menu.tsx
+++ b/docs/src/Menu.tsx
@@ -1,6 +1,19 @@
 import { useState } from 'react';
 import type { FunctionsData } from '../scripts/transform';
 
+const BADGE_COLORS: Record<string, string> = {
+  Array: 'bg-emerald-500',
+  Object: 'bg-amber-500',
+  Function: 'bg-fuchsia-500',
+  Number: 'bg-blue-500',
+  String: 'bg-violet-500',
+  Guard: 'bg-rose-500',
+  Type: 'bg-stone-500',
+  Other: 'bg-gray-500',
+};
+
+const DEFAULT_COLOR = 'bg-red-200';
+
 export function Menu({ items }: { readonly items: FunctionsData }) {
   const [searchTerm, setSearchTerm] = useState('');
   const searchTermLowered = searchTerm.toLowerCase();
@@ -25,7 +38,11 @@ export function Menu({ items }: { readonly items: FunctionsData }) {
               className="flex items-center px-6 py-1 font-medium text-black/60 hover:bg-[#f2f3f4] hover:no-underline"
             >
               <span>{item.name}</span>
-              <div className=" badge badge-success ml-auto">
+              <div
+                className={`badge ml-auto text-white ${
+                  BADGE_COLORS[item?.category ?? ''] ?? DEFAULT_COLOR
+                }`}
+              >
                 {item.category}
               </div>
               {item.methods[0].indexed && (


### PR DESCRIPTION
This PR adds different badge colors per each function type in the side menu. The goal is to make finding the right function easier.

Note: color choices are very arbitrary, I'm open to suggestions.

Example:
![image](https://github.com/remeda/remeda/assets/6901309/933ea14c-3597-4514-ab4c-cadd0b291461)

---
_[does not apply probably]_
Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
