### PR TITLE
docs: fix signatures for `add`, `divide`, `multiply` and `subtract`

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -20,7 +20,7 @@ export function add(value: number, addend: number): number;
  * @param value The number.
  * @param addend The number to add to the value.
  * @signature
- *    R.clamp(addend)(value);
+ *    R.add(addend)(value);
  * @example
  *    R.add(5)(10) // => 15
  *    R.add(-5)(10) // => 5

--- a/src/divide.ts
+++ b/src/divide.ts
@@ -19,7 +19,7 @@ export function divide(value: number, divisor: number): number;
  * @param value The number.
  * @param divisor The number to divide the value by.
  * @signature
- *    R.clamp(divisor)(value);
+ *    R.divide(divisor)(value);
  * @example
  *    R.divide(3)(12) // => 4
  *    R.map([2, 4, 6, 8], R.divide(2)) // => [1, 2, 3, 4]

--- a/src/multiply.ts
+++ b/src/multiply.ts
@@ -19,7 +19,7 @@ export function multiply(value: number, multiplicand: number): number;
  * @param value The number.
  * @param multiplicand The number to multiply the value by.
  * @signature
- *    R.clamp(multiplicand)(value);
+ *    R.multiply(multiplicand)(value);
  * @example
  *    R.multiply(4)(3) // => 12
  *    R.map([1, 2, 3, 4], R.multiply(2)) // => [2, 4, 6, 8]

--- a/src/subtract.ts
+++ b/src/subtract.ts
@@ -20,7 +20,7 @@ export function subtract(value: number, subtrahend: number): number;
  * @param value The number.
  * @param subtrahend The number to subtract from the value.
  * @signature
- *    R.clamp(subtrahend)(value);
+ *    R.subtract(subtrahend)(value);
  * @example
  *    R.subtract(5)(10) // => 5
  *    R.subtract(-5)(10) // => 15


### PR DESCRIPTION
Those 4 [relatively new functions](https://github.com/remeda/remeda/pull/443) have a small issue in their data-last signature - they all show `R.clamp` instead of the actual function name. This PR fixes this issue.

---
_[does not apply probably]_
Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
