### PR TITLE
fix(isArray): handle inferrence of ReadonlyArray inside an array

### DIFF
--- a/src/isArray.test.ts
+++ b/src/isArray.test.ts
@@ -34,3 +34,29 @@ describe('isArray', () => {
     assertType<Array<Array<number>>>(data);
   });
 });
+
+describe('typing', () => {
+  test('mutable arrays work', () => {
+    const data = [] as Array<number> | string;
+
+    if (isArray(data)) {
+      expectTypeOf(data).toEqualTypeOf<Array<number>>();
+    }
+
+    // We check the type when it's inferred from within an array due to https://github.com/remeda/remeda/issues/459 surfacing the issue. I don't know why it works differently than when checking data directly.
+    expectTypeOf([data].filter(isArray)).toEqualTypeOf<Array<Array<number>>>();
+  });
+
+  test('readonly arrays work', () => {
+    const data = [] as ReadonlyArray<number> | string;
+
+    if (isArray(data)) {
+      expectTypeOf(data).toEqualTypeOf<ReadonlyArray<number>>();
+    }
+
+    // We check the type when it's inferred from within an array due to https://github.com/remeda/remeda/issues/459 surfacing the issue. I don't know why it works differently than when checking data directly.
+    expectTypeOf([data].filter(isArray)).toEqualTypeOf<
+      Array<ReadonlyArray<number>>
+    >();
+  });
+});

--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -19,7 +19,7 @@ type DefinitelyArray<T> = Extract<
  * @category Guard
  */
 export function isArray<T>(
-  data: T | ReadonlyArray<unknown>
+  data: T | ArrayLike<unknown>
 ): data is IfIsAny<T, ReadonlyArray<unknown>, DefinitelyArray<T>> {
   return Array.isArray(data);
 }


### PR DESCRIPTION
It took me a while to figure out what was causing the issue or how to fix it. I'm still not sure I understand.

Fixes #459
