### PR TITLE
fix(docs): make function card content scrollable on small screens

### DIFF
--- a/docs/src/components/function-card.astro
+++ b/docs/src/components/function-card.astro
@@ -32,7 +32,7 @@ const tags = getTags(func);
     </div>
   </CardHeader>
 
-  <CardContent className="grid gap-6">
+  <CardContent className="grid gap-6 overflow-x-auto">
     {
       func.methods.map(
         method =>


### PR DESCRIPTION
It was working in the original version. Guess something changed with the fixes.

<img width="674" alt="image" src="https://github.com/remeda/remeda/assets/52774564/222c2ad4-434a-4766-a7c9-625994c87b0f">
<img width="648" alt="image" src="https://github.com/remeda/remeda/assets/52774564/5efd9108-9bbd-4bf0-8bf9-a2f1596c0b3c">
