### PR TITLE
docs: fix overflow issue in examples

### DIFF
--- a/docs/src/components/code-block.astro
+++ b/docs/src/components/code-block.astro
@@ -9,7 +9,7 @@ interface Props {
 const { code, lang = 'ts' } = Astro.props;
 ---
 
-<Code code={code} lang={lang} theme="poimandres" />
+<Code code={code} lang={lang} theme="poimandres" wrap />
 
 <style is:global>
   .astro-code {

--- a/docs/src/components/function-card.astro
+++ b/docs/src/components/function-card.astro
@@ -15,7 +15,7 @@ const { func } = Astro.props;
 const tags = getTags(func);
 ---
 
-<Card id={func.name} className="scroll-mt-20">
+<Card id={func.name} className="scroll-mt-20 overflow-hidden">
   <CardHeader>
     <div class="flex items-center gap-2">
       <CardTitle className="text-2xl">{func.name}</CardTitle>
@@ -39,7 +39,6 @@ const tags = getTags(func);
           method.signature !== undefined && (
             <div class="flex flex-col gap-2">
               {method.tag !== undefined && <p>{method.tag}</p>}
-
               <MethodSignature
                 args={method.args}
                 returns={method.returns}
@@ -47,9 +46,10 @@ const tags = getTags(func);
               >
                 <CodeBlock code={method.signature} />
               </MethodSignature>
-
               {method.example !== undefined && (
-                <CodeBlock code={method.example} />
+                <section class="text-xs md:text-base">
+                  <CodeBlock code={method.example} />
+                </section>
               )}
             </div>
           )

--- a/docs/src/layouts/layout.astro
+++ b/docs/src/layouts/layout.astro
@@ -20,7 +20,7 @@ import ThemeScript from '@/components/theme-script.astro';
   <body>
     <Header />
 
-    <div class="container">
+    <div class="container overflow-hidden">
       <slot />
     </div>
   </body>


### PR DESCRIPTION
Mobile view is currently unusable because it takes the width of the longest example. This makes the mobile experience better by allowing wrapping, limiting containers to the screen width, and decreasing font size.