### PR TITLE
docs: Fix link in header component

### DIFF
--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -25,10 +25,10 @@ const { pathname } = Astro.url;
       </a>
 
       <a
-        href="/docs"
+        href="/docs/"
         class:list={[
           "transition-colors hover:text-foreground/80",
-          pathname === "/docs" ? "text-foreground" : "text-foreground/60",
+          pathname === "/docs/" ? "text-foreground" : "text-foreground/60",
         ]}
       >
         Docs


### PR DESCRIPTION
The URL path is normalized in production by adding a terminating backslash. We need to support this when highlighting the section