### PR TITLE
feat(only): Add `only`

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -66,6 +66,7 @@ documentation when migrating._
 | `omit`              | `omit`              | `omit`              |
 | `omitBy`            | `omitBy`            |                     |
 | `once`              | `once`              | `once`              |
+| `only`              |                     |                     |
 | `partition`         | `partition`         | `partition`         |
 | `pathOr`            | `get`               | `pathOr`            |
 | `pick`              | `pick`              | `pick`              |

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ export * from './objOf';
 export * from './omit';
 export * from './omitBy';
 export * from './once';
+export * from './only';
 export * from './partition';
 export * from './pathOr';
 export * from './pick';

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -1,0 +1,129 @@
+import { only } from './only';
+
+describe('strict typing', () => {
+  test('simple empty array', () => {
+    const arr: Array<number> = [];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple array', () => {
+    const arr: Array<number> = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple non-empty array', () => {
+    const arr: [number, ...Array<number>] = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple tuple', () => {
+    const arr: [number, string] = [1, 'a'];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('array with more than one item', () => {
+    const arr: [number, number, ...Array<number>] = [1, 2];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('trivial empty array', () => {
+    const arr: [] = [];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf(undefined);
+    expect(result).toEqual(undefined);
+  });
+
+  test('array with last', () => {
+    const arr: [...Array<number>, number] = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('tuple with last', () => {
+    const arr: [...Array<string>, number] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('tuple with two last', () => {
+    const arr: [...Array<string>, number, number] = ['a', 1, 2];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('tuple with first and last', () => {
+    const arr: [number, ...Array<string>, number] = [1, 'a', 2];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple empty readonly array', () => {
+    const arr: ReadonlyArray<number> = [];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('simple readonly array', () => {
+    const arr: ReadonlyArray<number> = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple non-empty readonly array', () => {
+    const arr: readonly [number, ...Array<number>] = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('simple readonly tuple', () => {
+    const arr: readonly [number, string] = [1, 'a'];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('readonly array with more than one item', () => {
+    const arr: readonly [number, number, ...Array<number>] = [1, 2];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+    expect(result).toEqual(undefined);
+  });
+
+  test('readonly trivial empty array', () => {
+    const arr: readonly [] = [];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf(undefined);
+    expect(result).toEqual(undefined);
+  });
+
+  test('readonly array with last', () => {
+    const arr: readonly [...Array<number>, number] = [1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    expect(result).toEqual(1);
+  });
+
+  test('readonly tuple with last', () => {
+    const arr: readonly [...Array<string>, number] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toEqual(undefined);
+  });
+});

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -1,4 +1,33 @@
 import { only } from './only';
+import { pipe } from './pipe';
+
+describe('data first', () => {
+  test('empty array', () => {
+    expect(only([])).toEqual(undefined);
+  });
+
+  test('length 1 array', () => {
+    expect(only([1])).toEqual(1);
+  });
+
+  test('length 2 array', () => {
+    expect(only([1, 2])).toEqual(undefined);
+  });
+});
+
+describe('data last', () => {
+  test('empty array', () => {
+    expect(pipe([], only())).toEqual(undefined);
+  });
+
+  test('length 1 array', () => {
+    expect(pipe([1], only())).toEqual(1);
+  });
+
+  test('length 2 array', () => {
+    expect(pipe([1, 2], only())).toEqual(undefined);
+  });
+});
 
 describe('strict typing', () => {
   test('simple empty array', () => {

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -3,7 +3,7 @@ import { pipe } from './pipe';
 
 describe('data first', () => {
   test('empty array', () => {
-    expect(only([])).toEqual(undefined);
+    expect(only([])).toBeUndefined();
   });
 
   test('length 1 array', () => {
@@ -11,13 +11,13 @@ describe('data first', () => {
   });
 
   test('length 2 array', () => {
-    expect(only([1, 2])).toEqual(undefined);
+    expect(only([1, 2])).toBeUndefined();
   });
 });
 
 describe('data last', () => {
   test('empty array', () => {
-    expect(pipe([], only())).toEqual(undefined);
+    expect(pipe([], only())).toBeUndefined();
   });
 
   test('length 1 array', () => {
@@ -25,7 +25,7 @@ describe('data last', () => {
   });
 
   test('length 2 array', () => {
-    expect(pipe([1, 2], only())).toEqual(undefined);
+    expect(pipe([1, 2], only())).toBeUndefined();
   });
 });
 
@@ -34,7 +34,7 @@ describe('strict typing', () => {
     const arr: Array<number> = [];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<number | undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('simple array', () => {
@@ -55,21 +55,21 @@ describe('strict typing', () => {
     const arr: [number, string] = [1, 'a'];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('array with more than one item', () => {
     const arr: [number, number, ...Array<number>] = [1, 2];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('trivial empty array', () => {
     const arr: [] = [];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf(undefined);
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('array with last', () => {
@@ -83,28 +83,42 @@ describe('strict typing', () => {
     const arr: [...Array<string>, number] = ['a', 1];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('tuple with two last', () => {
     const arr: [...Array<string>, number, number] = ['a', 1, 2];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('tuple with first and last', () => {
     const arr: [number, ...Array<string>, number] = [1, 'a', 2];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test('tuple with optional and array', () => {
+    const arr: [string?, ...Array<number>] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toBeUndefined();
+  });
+
+  test('tuple with all optional', () => {
+    const arr: [string?, number?] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toBeUndefined();
   });
 
   test('simple empty readonly array', () => {
     const arr: ReadonlyArray<number> = [];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<number | undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('simple readonly array', () => {
@@ -125,21 +139,21 @@ describe('strict typing', () => {
     const arr: readonly [number, string] = [1, 'a'];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('readonly array with more than one item', () => {
     const arr: readonly [number, number, ...Array<number>] = [1, 2];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('readonly trivial empty array', () => {
     const arr: readonly [] = [];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf(undefined);
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test('readonly array with last', () => {
@@ -153,6 +167,20 @@ describe('strict typing', () => {
     const arr: readonly [...Array<string>, number] = ['a', 1];
     const result = only(arr);
     expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test('readonly tuple with optional and array', () => {
+    const arr: readonly [string?, ...Array<number>] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toBeUndefined();
+  });
+
+  test('readonly tuple with all optional', () => {
+    const arr: readonly [string?, number?] = ['a', 1];
+    const result = only(arr);
+    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expect(result).toBeUndefined();
   });
 });

--- a/src/only.ts
+++ b/src/only.ts
@@ -2,14 +2,14 @@ import { IterableContainer } from './_types';
 import { purry } from './purry';
 
 type Only<T extends IterableContainer> = T extends
-  | []
+  | readonly []
   | readonly [unknown, unknown, ...Array<unknown>]
   | readonly [unknown, ...Array<unknown>, unknown]
   | readonly [...Array<unknown>, unknown, unknown]
   ? undefined
   : T extends readonly [unknown]
-    ? T[0]
-    : T[0] | undefined;
+    ? T[number]
+    : T[number] | undefined;
 
 /**
  * Returns the first and only element of `array`, or undefined otherwise.
@@ -24,8 +24,25 @@ type Only<T extends IterableContainer> = T extends
  *    R.only([1, 2]) // => undefined
  * @pipeable
  * @category Array
+ * @dataFirst
  */
 export function only<T extends IterableContainer>(array: Readonly<T>): Only<T>;
+
+/**
+ * Returns the first and only element of `array`, or undefined otherwise.
+ * Note: In `pipe`, use `only()` form instead of `only`. Otherwise, the
+ * inferred type is lost.
+ * @param array the target array
+ * @signature
+ *    R.only(array)
+ * @example
+ *    R.only([]) // => undefined
+ *    R.only([1]) // => 1
+ *    R.only([1, 2]) // => undefined
+ * @pipeable
+ * @category Array
+ * @dataLast
+ */
 export function only<T extends IterableContainer>(): (
   array: Readonly<T>
 ) => Only<T>;

--- a/src/only.ts
+++ b/src/only.ts
@@ -1,0 +1,39 @@
+import { IterableContainer } from './_types';
+import { purry } from './purry';
+
+type Only<T extends IterableContainer> = T extends
+  | []
+  | readonly [unknown, unknown, ...Array<unknown>]
+  | readonly [unknown, ...Array<unknown>, unknown]
+  | readonly [...Array<unknown>, unknown, unknown]
+  ? undefined
+  : T extends readonly [unknown]
+    ? T[0]
+    : T[0] | undefined;
+
+/**
+ * Returns the first and only element of `array`, or undefined otherwise.
+ * @param array the target array
+ * @signature
+ *    R.only(array)
+ * @example
+ *    R.only([]) // => undefined
+ *    R.only([1]) // => 1
+ *    R.only([1, 2]) // => undefined
+ * @category Array
+ */
+export function only<T extends IterableContainer>(array: Readonly<T>): Only<T>;
+export function only<T extends IterableContainer>(): (
+  array: Readonly<T>
+) => Only<T>;
+
+export function only() {
+  return purry(_only, arguments);
+}
+
+function _only<T>(array: ReadonlyArray<T>) {
+  if (array.length === 1) {
+    return array[0];
+  }
+  return undefined;
+}

--- a/src/only.ts
+++ b/src/only.ts
@@ -13,6 +13,8 @@ type Only<T extends IterableContainer> = T extends
 
 /**
  * Returns the first and only element of `array`, or undefined otherwise.
+ * Note: In `pipe`, use `only()` form instead of `only`. Otherwise, the
+ * inferred type is lost.
  * @param array the target array
  * @signature
  *    R.only(array)
@@ -20,6 +22,7 @@ type Only<T extends IterableContainer> = T extends
  *    R.only([]) // => undefined
  *    R.only([1]) // => 1
  *    R.only([1, 2]) // => undefined
+ * @pipeable
  * @category Array
  */
 export function only<T extends IterableContainer>(array: Readonly<T>): Only<T>;


### PR DESCRIPTION
closes #467 

i don't think `only` can be made lazy; here's the argument. when called with a value, we either:

* return it immediately as `next`. later if we get another value we can't "take back" the value we gave before
* don't return it as `next`. but then we don't get called again, so there's no way for the caller to get the value

there are changes that can be made to the architecture to allow it to be lazy. the one that needs least changes, i think, is to change `pipe` to be

```diff
    if ((lastLazySeq as any).single) {
-      ret = acc[0];
+      ret = acc[acc.length - 1];
    } else {
      ret = acc;
    }
```

this lets `only` "take back" a value it returned, and replace it with `undefined` (and, surprisingly to me, all tests pass after this change). i don't like it though

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
