### PR TITLE
docs: improve sidebar opening perf by disabling modal mode

### DIFF
--- a/docs/src/components/mobile-nav.tsx
+++ b/docs/src/components/mobile-nav.tsx
@@ -12,7 +12,7 @@ export function MobileNav({
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+    <Sheet open={isOpen} onOpenChange={setIsOpen} modal={false}>
       <SheetTrigger asChild>
         <Button variant="ghost" size="icon" className="md:hidden">
           <HamburgerMenuIcon />

--- a/docs/src/components/navbar.tsx
+++ b/docs/src/components/navbar.tsx
@@ -76,7 +76,7 @@ function NavbarEntry({
 }: NavbarEntry & { readonly onSelect: (() => void) | undefined }): ReactNode {
   return (
     <a
-      href={`#${name}`}
+      href={`/docs/#${name}`}
       className={cn([
         buttonVariants({ variant: "ghost" }),
         "text-muted-foreground",


### PR DESCRIPTION
Because **react-remove-scroll** causes a reflow and /docs page is huge, sidebar opens really slow in modal mode.

Also changed hrefs in navbar so links work correctly from home page.