### PR TITLE
chore: use strictest typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    tsconfigRootDir: __dirname,
+    tsconfigRootDir: true,
     project: ['./tsconfig.json'],
     sourceType: 'module',
   },
@@ -55,6 +55,13 @@ module.exports = {
     // reserved keyword, but it's recommended to use a variadic instead (e.g.
     // `function foo(...args: readonly unknown[])`)
     'prefer-rest-params': 'off',
+
+    // This isn't very useful in a utility library, a lot of utilities need to
+    // access arrays in a random-access way.
+    // TODO: Once we bump our typescript `target` we should enable this rule
+    // again, go over all the non-null-assertions, and see which ones are due to
+    // a for loop which could use `Array.prototype.entries` instead.
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
 
   overrides: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.35",
       "license": "MIT",
       "devDependencies": {
-        "@tsconfig/recommended": "^1.0.3",
+        "@types/eslint": "^8.56.2",
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "@typescript-eslint/parser": "^6.13.2",
         "@vitest/coverage-v8": "^1.0.1",
@@ -1388,11 +1388,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@tsconfig/recommended": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
-      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
-      "dev": true
+    "node_modules/@types/eslint": {
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
+      "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "vitest"
   },
   "devDependencies": {
-    "@tsconfig/recommended": "^1.0.3",
+    "@types/eslint": "^8.56.2",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
     "@vitest/coverage-v8": "^1.0.1",

--- a/src/_binarySearchCutoffIndex.ts
+++ b/src/_binarySearchCutoffIndex.ts
@@ -25,7 +25,7 @@ export function _binarySearchCutoffIndex<T>(
     // We use bitwise operator here as a way to find the mid-point and round it
     // down using the same operation.
     const pivotIndex = (lowIndex + highIndex) >>> 1;
-    const pivot = array[pivotIndex];
+    const pivot = array[pivotIndex]!;
 
     if (predicate(pivot, pivotIndex)) {
       lowIndex = pivotIndex + 1;

--- a/src/_heap.ts
+++ b/src/_heap.ts
@@ -4,6 +4,7 @@
 
 import { swapInPlace } from './_swapInPlace';
 import type { CompareFunction } from './_types';
+import { hasAtLeast } from './hasAtLeast';
 
 /**
  * Mutates an array into a "max"-heap based on `compareFn` so that for any `item` in the heap, `compareFn(heap[0], item) > 0`
@@ -40,6 +41,10 @@ export function heapMaybeInsert<T>(
   compareFn: CompareFunction<T>,
   item: T
 ): T | undefined {
+  if (!hasAtLeast(heap, 1)) {
+    return;
+  }
+
   const head = heap[0];
 
   if (compareFn(item, head) >= 0) {
@@ -69,7 +74,7 @@ function heapSiftDown<T>(
     const firstChildIndex = currentIndex * 2 + 1;
 
     let swapIndex =
-      compareFn(heap[currentIndex], heap[firstChildIndex]) < 0
+      compareFn(heap[currentIndex]!, heap[firstChildIndex]!) < 0
         ? // Is the parent "smaller" (in regards to `compareFn`) to its child?
           firstChildIndex
         : currentIndex;
@@ -77,7 +82,7 @@ function heapSiftDown<T>(
     const secondChildIndex = firstChildIndex + 1;
     if (
       secondChildIndex < heap.length &&
-      compareFn(heap[swapIndex], heap[secondChildIndex]) < 0
+      compareFn(heap[swapIndex]!, heap[secondChildIndex]!) < 0
     ) {
       // Is there a second child? Is it the smallest of the three?
       swapIndex = secondChildIndex;

--- a/src/_quickSelect.ts
+++ b/src/_quickSelect.ts
@@ -45,7 +45,7 @@ function quickSelectImplementation<T>(
   compareFn: CompareFunction<T>
 ): T {
   if (left === right) {
-    return data[left];
+    return data[left]!;
   }
 
   const pivotIndex = partition(data, left, right, compareFn);
@@ -53,7 +53,7 @@ function quickSelectImplementation<T>(
   return index === pivotIndex
     ? // Once a pivot is chosen it's location is final, so if it matches the
       // index we found out item!
-      data[index]
+      data[index]!
     : quickSelectImplementation(
         data,
         // We continue by recursing into the partition where index would be
@@ -70,11 +70,11 @@ function partition<T>(
   right: number,
   compareFn: CompareFunction<T>
 ): number {
-  const pivot = data[right];
+  const pivot = data[right]!;
 
   let i = left;
   for (let j = left; j < right; j++) {
-    if (compareFn(data[j], pivot) < 0) {
+    if (compareFn(data[j]!, pivot) < 0) {
       // Move items smaller then the pivot to the start of the array.
       swapInPlace(data, i, j);
       i++;

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -29,7 +29,7 @@ export function _reduceLazy<T, K>(
   const newArray: Array<K> = [];
   // We intentionally use a for loop here instead of reduce for performance reasons. See https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/ for more info
   for (let index = 0; index < array.length; index++) {
-    const item = array[index];
+    const item = array[index]!;
     const result = indexed ? lazy(item, index, array) : lazy(item);
     if (result.hasMany === true) {
       newArray.push(...result.next);

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -60,30 +60,6 @@ describe('deep clone objects', () => {
     x.c.b = 1;
     assert.notDeepEqual(cloned.c.b, x.c.b);
   });
-
-  // it('clone instances', () => {
-  //   const Obj = function(x) {
-  //     this.x = x;
-  //   };
-  //   Obj.prototype.get = () => {
-  //     return this.x;
-  //   };
-  //   Obj.prototype.set = function(x) {
-  //     this.x = x;
-  //   };
-
-  //   const obj = new Obj(10);
-  //   eq(obj.get(), 10);
-
-  //   const cloned = clone(obj);
-  //   eq(cloned.get(), 10);
-
-  //   assert.notStrictEqual(obj, cloned);
-
-  //   obj.set(11);
-  //   eq(obj.get(), 11);
-  //   eq(cloned.get(), 10);
-  // });
 });
 
 describe('deep clone arrays', () => {
@@ -111,7 +87,7 @@ describe('deep clone functions', () => {
     const fn = (x: number) => {
       return x + x;
     };
-    const list = [{ a: fn }];
+    const list = [{ a: fn }] as const;
 
     const cloned = clone(list);
 
@@ -156,7 +132,7 @@ describe('deep clone deep nested mixed objects', () => {
   it('clones array with arrays', () => {
     const list: Array<Array<any>> = [[1], [[3]]];
     const cloned = clone(list);
-    list[1][0] = null;
+    list[1]![0] = null;
     eq(cloned, [[1], [[3]]]);
   });
 
@@ -165,17 +141,17 @@ describe('deep clone deep nested mixed objects', () => {
     const list = [{ b: obj }, { b: obj }];
     const cloned = clone(list);
 
-    assert.strictEqual(list[0].b, list[1].b);
-    assert.strictEqual(cloned[0].b, cloned[1].b);
-    assert.notStrictEqual(cloned[0].b, list[0].b);
-    assert.notStrictEqual(cloned[1].b, list[1].b);
+    assert.strictEqual(list[0]?.b, list[1]?.b);
+    assert.strictEqual(cloned[0]?.b, cloned[1]?.b);
+    assert.notStrictEqual(cloned[0]?.b, list[0]?.b);
+    assert.notStrictEqual(cloned[1]?.b, list[1]?.b);
 
-    eq(cloned[0].b, { a: 1 });
-    eq(cloned[1].b, { a: 1 });
+    eq(cloned[0]?.b, { a: 1 });
+    eq(cloned[1]?.b, { a: 1 });
 
     obj.a = 2;
-    eq(cloned[0].b, { a: 1 });
-    eq(cloned[1].b, { a: 1 });
+    eq(cloned[0]?.b, { a: 1 });
+    eq(cloned[1]?.b, { a: 1 });
   });
 });
 
@@ -192,19 +168,3 @@ describe('deep clone edge cases', () => {
     assert.notStrictEqual(clone(list), list);
   });
 });
-
-// describe('Let `clone` use an arbitrary user defined `clone` method', () => {
-//   it('dispatches to `clone` method if present', () => {
-//     function ArbitraryClone(x: any) {
-//       this.value = x;
-//     }
-//     ArbitraryClone.prototype.clone = () => {
-//       return new ArbitraryClone(this.value);
-//     };
-
-//     const obj = new ArbitraryClone(42);
-//     const arbitraryClonedObj = clone(obj);
-//     eq(arbitraryClonedObj, new ArbitraryClone(42));
-//     eq(arbitraryClonedObj instanceof ArbitraryClone, true);
-//   });
-// });

--- a/src/dropLastWhile.ts
+++ b/src/dropLastWhile.ts
@@ -45,7 +45,7 @@ function _dropLastWhile<T>(
   predicate: (item: T) => boolean
 ): Array<T> {
   for (let i = data.length - 1; i >= 0; i--) {
-    if (!predicate(data[i])) {
+    if (!predicate(data[i]!)) {
       return data.slice(0, i + 1);
     }
   }

--- a/src/dropWhile.ts
+++ b/src/dropWhile.ts
@@ -45,7 +45,7 @@ function _dropWhile<T>(
   predicate: (item: T) => boolean
 ): Array<T> {
   for (let i = 0; i < data.length; i++) {
-    if (!predicate(data[i])) {
+    if (!predicate(data[i]!)) {
       return data.slice(i);
     }
   }

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -95,13 +95,13 @@ function _equals(a: any, b: any) {
     }
 
     for (i = length; i-- !== 0; ) {
-      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) {
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i]!)) {
         return false;
       }
     }
 
     for (i = length; i-- !== 0; ) {
-      key = keys[i];
+      key = keys[i]!;
       if (!equals(a[key], b[key])) {
         return false;
       }

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -59,11 +59,7 @@ describe('data first', () => {
   });
 
   it('ignores undefined transformations', function () {
-    const evolver = { n: undefined };
-    const data: { n: number } = { n: 0 };
-    const expected = { n: 0 };
-    const result = evolve(data, evolver);
-    expect(result).toEqual(expected);
+    expect(evolve({ n: 0 }, {})).toEqual({ n: 0 });
   });
 
   it('can handle data that is complex nested objects', function () {
@@ -145,10 +141,8 @@ describe('data last', () => {
   });
 
   it('ignores undefined transformations', function () {
-    const evolver = { n: undefined };
-    const data = { n: 0 };
     const expected = { n: 0 };
-    const result = pipe(data, evolve(evolver));
+    const result = pipe({ n: 0 }, evolve({}));
     expect(result).toEqual(expected);
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
@@ -277,8 +271,8 @@ describe('typing', () => {
           arg2arg3Optional: 1,
         },
         {
-          arg2Optional: (arg1: number, arg2?: number) => arg2 === undefined,
-          arg2arg3Optional: (arg1: number, arg2?: number, arg3?: number) =>
+          arg2Optional: (_: number, arg2?: number) => arg2 === undefined,
+          arg2arg3Optional: (_: number, arg2?: number, arg3?: number) =>
             arg2 === undefined && arg3 === undefined,
         }
       );
@@ -372,8 +366,8 @@ describe('typing', () => {
           arg2arg3Optional: 1,
         },
         evolve({
-          arg2Optional: (arg1: number, arg2?: number) => arg2 === undefined,
-          arg2arg3Optional: (arg1: number, arg2?: number, arg3?: string) =>
+          arg2Optional: (_: number, arg2?: number) => arg2 === undefined,
+          arg2arg3Optional: (_: number, arg2?: number, arg3?: string) =>
             arg2 === undefined && arg3 === undefined,
         })
       );

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -1,5 +1,5 @@
+import { Pred, PredIndexed, PredIndexedOptional } from './_types';
 import { purry } from './purry';
-import { Pred, PredIndexedOptional, PredIndexed } from './_types';
 
 /**
  * Returns the value of the last element in the array where predicate is true, and undefined
@@ -55,10 +55,11 @@ const _findLast =
   (indexed: boolean) =>
   <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
-      if (indexed ? fn(array[i], i, array) : fn(array[i])) {
+      if (indexed ? fn(array[i]!, i, array) : fn(array[i]!)) {
         return array[i];
       }
     }
+    return undefined;
   };
 
 export namespace findLast {

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -54,7 +54,7 @@ const _findLastIndex =
   (indexed: boolean) =>
   <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
     for (let i = array.length - 1; i >= 0; i--) {
-      if (indexed ? fn(array[i], i, array) : fn(array[i])) {
+      if (indexed ? fn(array[i]!, i, array) : fn(array[i]!)) {
         return i;
       }
     }

--- a/src/firstBy.ts
+++ b/src/firstBy.ts
@@ -81,12 +81,12 @@ function firstByImplementation<T>(
   data: ReadonlyArray<T>,
   compareFn: CompareFunction<T>
 ): T | undefined {
-  let [currentFirst] = data;
-
   if (!hasAtLeast(data, 2)) {
     // If we have 0 or 1 item we simply return the trivial result.
-    return currentFirst;
+    return data[0];
   }
+
+  let [currentFirst] = data;
 
   // Remove the first item, we won't compare it with itself.
   const [, ...rest] = data;

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,6 +1,6 @@
+import { NonEmptyArray } from './_types';
 import { groupBy } from './groupBy';
 import { pipe } from './pipe';
-import { NonEmptyArray } from './_types';
 
 const array = [
   { a: 1, b: 1 },
@@ -87,7 +87,7 @@ describe('Filtering on undefined grouper result', () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty('even');
-    expect(result.even).toEqual([0, 2, 4, 6, 8]);
+    expect(result['even']).toEqual([0, 2, 4, 6, 8]);
   });
 
   test('regular indexed', () => {
@@ -97,7 +97,7 @@ describe('Filtering on undefined grouper result', () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty('even');
-    expect(result.even).toEqual(['a', 'c', 'e', 'g', 'i']);
+    expect(result['even']).toEqual(['a', 'c', 'e', 'g', 'i']);
   });
 
   test('strict', () => {

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -53,10 +53,12 @@ const _groupBy =
       const key = indexed ? fn(item, index, array) : fn(item);
       if (key !== undefined) {
         const actualKey = String(key);
-        if (!ret[actualKey]) {
-          ret[actualKey] = [];
+        let items = ret[actualKey];
+        if (items === undefined) {
+          items = [];
+          ret[actualKey] = items;
         }
-        ret[actualKey].push(item);
+        items.push(item);
       }
     });
     return ret;

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -42,7 +42,7 @@ function _invert(
   const result: Record<PropertyKey, PropertyKey> = {};
 
   for (const key in object) {
-    result[object[key]] = key;
+    result[object[key]!] = key;
   }
 
   return result;

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -10,7 +10,7 @@ describe('data_first', () => {
     expect(result).toEqual([2, 4, 6]);
   });
   it('map.indexed', () => {
-    const result = map.indexed([0, 0, 0] as const, (x, i) => i);
+    const result = map.indexed([0, 0, 0] as const, (_, i) => i);
     expect(result).toEqual([0, 1, 2]);
   });
 });
@@ -26,7 +26,7 @@ describe('data_last', () => {
   it('map.indexed', () => {
     const result = pipe(
       [0, 0, 0] as const,
-      map.indexed((x, i) => i)
+      map.indexed((_, i) => i)
     );
     expect(result).toEqual([0, 1, 2]);
   });
@@ -51,7 +51,7 @@ describe('pipe', () => {
     const count = vi.fn();
     const result = pipe(
       [0, 0, 0] as const,
-      map.indexed((x, i) => {
+      map.indexed((_, i) => {
         count();
         return i;
       }),

--- a/src/mapToObj.test.ts
+++ b/src/mapToObj.test.ts
@@ -7,7 +7,7 @@ describe('data_first', () => {
     expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
   });
   it('mapToObj.indexed', () => {
-    const result = mapToObj.indexed([0, 0, 0] as const, (x, i) => [i, i]);
+    const result = mapToObj.indexed([0, 0, 0] as const, (_, i) => [i, i]);
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });
@@ -23,7 +23,7 @@ describe('data_last', () => {
   it('mapToObj.indexed', () => {
     const result = pipe(
       [0, 0, 0] as const,
-      mapToObj.indexed((x, i) => [i, i])
+      mapToObj.indexed((_, i) => [i, i])
     );
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,4 +1,5 @@
 import { fromPairs } from './fromPairs';
+import { hasAtLeast } from './hasAtLeast';
 import { purry } from './purry';
 
 /**
@@ -40,11 +41,14 @@ function _omit<T extends object, K extends keyof T>(
   data: T,
   propNames: ReadonlyArray<K>
 ): Omit<T, K> {
-  if (propNames.length === 0) {
+  if (!hasAtLeast(propNames, 1)) {
+    // No props to omit at all!
     return { ...data };
   }
 
-  if (propNames.length === 1) {
+  if (!hasAtLeast(propNames, 2)) {
+    // Only one prop to omit.
+
     const [propName] = propNames;
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars -- use destructuring to remove a single key, letting JS optimize here...
@@ -53,6 +57,8 @@ function _omit<T extends object, K extends keyof T>(
     } = data;
     return remaining;
   }
+
+  // Multiple props to omit...
 
   if (!propNames.some(propName => propName in data)) {
     return { ...data };

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -5,7 +5,7 @@ describe('data first', () => {
   test('it should omit props', () => {
     const result = omitBy(
       { a: 1, b: 2, A: 3, B: 4 },
-      (val, key) => key.toUpperCase() === key
+      (_, key) => key.toUpperCase() === key
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
@@ -13,7 +13,7 @@ describe('data first', () => {
   test('allow partial type', () => {
     const result = omitBy(
       {} as Partial<{ a: string; b: number }>,
-      (val, key) => key === 'a'
+      (_, key) => key === 'a'
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
@@ -24,7 +24,7 @@ describe('data last', () => {
   test('it should omit props', () => {
     const result = pipe(
       { a: 1, b: 2, A: 3, B: 4 },
-      omitBy((val, key) => key.toUpperCase() === key)
+      omitBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
@@ -32,7 +32,7 @@ describe('data last', () => {
   test('allow partial type', () => {
     const result = pipe(
       {} as Partial<{ a: string; b: number }>,
-      omitBy((val, key) => key.toUpperCase() === key)
+      omitBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -5,19 +5,19 @@ describe('data first', () => {
   test('it should pick props', () => {
     const result = pickBy(
       { a: 1, b: 2, A: 3, B: 4 },
-      (val, key) => key.toUpperCase() === key
+      (_, key) => key.toUpperCase() === key
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
   });
   test('allow undefined or null', () => {
-    expect(pickBy(undefined as any, (val, key) => key === 'foo')).toEqual({});
-    expect(pickBy(null as any, (val, key) => key === 'foo')).toEqual({});
+    expect(pickBy(undefined as any, (_, key) => key === 'foo')).toEqual({});
+    expect(pickBy(null as any, (_, key) => key === 'foo')).toEqual({});
   });
   test('allow partial type', () => {
     const result = pickBy(
       {} as { a?: string; b?: number },
-      (val, key) => key === 'a'
+      (_, key) => key === 'a'
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});
@@ -28,7 +28,7 @@ describe('data last', () => {
   test('it should pick props', () => {
     const result = pipe(
       { a: 1, b: 2, A: 3, B: 4 },
-      pickBy((val, key) => key.toUpperCase() === key)
+      pickBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Record<'a' | 'b' | 'A' | 'B', number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
@@ -36,7 +36,7 @@ describe('data last', () => {
   test('allow partial type', () => {
     const result = pipe(
       {} as { a?: string; b?: number },
-      pickBy((val, key) => key.toUpperCase() === key)
+      pickBy((_, key) => key.toUpperCase() === key)
     );
     assertType<Partial<{ a: string; b: number }>>(result);
     expect(result).toEqual({});

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -211,7 +211,7 @@ export function pipe(
   });
   let opIdx = 0;
   while (opIdx < operations.length) {
-    const op = operations[opIdx];
+    const op = operations[opIdx]!;
     const lazyOp = lazyOps[opIdx];
     if (!lazyOp) {
       ret = op(ret);

--- a/src/rankBy.test.ts
+++ b/src/rankBy.test.ts
@@ -10,7 +10,10 @@ describe('runtime (dataFirst)', () => {
     const data = [5, 1, 3] as const;
     const sorted = [...data].sort();
     for (let i = 0; i < sorted.length; i += 1) {
-      expect(rankBy(data, sorted[i], identity)).toBe(i);
+      // TODO: Use `Array.prototype.entries` once we bump our TS target so we
+      // can get both the index and the item at the same time, and don't need
+      // the non-null assertion.
+      expect(rankBy(data, sorted[i]!, identity)).toBe(i);
     }
   });
 

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -152,7 +152,7 @@ function sampleImplementation<T>(data: Array<T>, sampleSize: number): Array<T> {
   if (sampleSize === actualSampleSize) {
     return Array.from(sampleIndices)
       .sort((a, b) => a - b)
-      .map(index => data[index]);
+      .map(index => data[index]!);
   }
 
   return data.filter((_, index) => !sampleIndices.has(index));

--- a/src/shuffle.ts
+++ b/src/shuffle.ts
@@ -31,8 +31,8 @@ function _shuffle<T>(items: ReadonlyArray<T>): Array<T> {
   const result = items.slice();
   for (let index = 0; index < items.length; index += 1) {
     const rand = index + Math.floor(Math.random() * (items.length - index));
-    const value = result[rand];
-    result[rand] = result[index];
+    const value = result[rand]!;
+    result[rand] = result[index]!;
     result[index] = value;
   }
   return result;

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -37,7 +37,10 @@ export function splitWhen() {
 
 function _splitWhen<T>(array: Array<T>, fn: (item: T) => boolean) {
   for (let i = 0; i < array.length; i++) {
-    if (fn(array[i])) {
+    // TODO: Use `Array.prototype.entries` once we bump our TS target so we
+    // can get both the index and the item at the same time, and don't need
+    // the non-null assertion.
+    if (fn(array[i]!)) {
       return splitAt(array, i);
     }
   }

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -19,6 +19,7 @@ function _stringToPath(path: string): Array<string> {
     path.match(/^\[(.+?)\](.*)$/) ?? path.match(/^\.?([^.[\]]+)(.*)$/);
   if (match) {
     const [, key, rest] = match;
+    // @ts-expect-error [ts2322] - Can we improve typing here to assure that `key` and `rest` are defined when the regex matches?
     return [key, ..._stringToPath(rest)];
   }
   return [path];

--- a/src/takeLastWhile.ts
+++ b/src/takeLastWhile.ts
@@ -43,7 +43,7 @@ function _takeLastWhile<T>(
   predicate: (item: T) => boolean
 ): Array<T> {
   for (let i = data.length - 1; i >= 0; i--) {
-    if (!predicate(data[i])) {
+    if (!predicate(data[i]!)) {
       return data.slice(i + 1);
     }
   }

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -46,7 +46,7 @@ function _zipObj(
     first.length > second.length ? second.length : first.length;
   const result: Record<string | number | symbol, unknown> = {};
   for (let i = 0; i < resultLength; i++) {
-    result[first[i]] = second[i];
+    result[first[i]!] = second[i];
   }
 
   return result;

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -63,9 +63,7 @@ export function zipWith() {
     };
   }
 
-  if (args.length === 3) {
-    return _zipWith(args[0], args[1], args[2]);
-  }
+  return _zipWith(args[0], args[1], args[2]);
 }
 
 function _zipWith<F, S, R>(
@@ -77,7 +75,7 @@ function _zipWith<F, S, R>(
     first.length > second.length ? second.length : first.length;
   const result = [];
   for (let i = 0; i < resultLength; i++) {
-    result.push(fn(first[i], second[i]));
+    result.push(fn(first[i]!, second[i]!));
   }
 
   return result;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,46 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
 
-  "extends": "@tsconfig/recommended/tsconfig.json",
-
   "include": ["src", "test", "**/.eslintrc.js", "*.config.js", "*.config.ts"],
 
   "compilerOptions": {
     // TYPE CHECKING
+    "strict": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     // MODULES
+    "module": "commonjs",
     "types": ["vitest/globals"],
 
     // EMIT
     "noEmit": true,
 
+    // JAVASCRIPT SUPPORT
+    "checkJs": true,
+
+    // INTEROP CONSTRAINTS
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+
     // LANGUAGE and ENVIRONMENT
-    "lib": ["ES6", "ES2017.Object", "DOM", "DOM.Iterable"],
     // TODO: The recommended target is ES2015 (ES6). Node10 supports es2018 and
     // the vast majority of browsers are probably above that too already. It's
     // most likely safe to up this value, and it would probably result in a
     // smaller package size.
     "target": "ES5",
+    "lib": ["ES6", "ES2017.Object", "DOM", "DOM.Iterable"],
+
+    // COMPLETENESS
+    "skipLibCheck": true,
   },
 }


### PR DESCRIPTION
Inlining the configuration of "recommended" and "strictest" from tsconfig bases and fixing any typing issues.

This mainly adds non-null-assertion (!) ts opreators to a lot of code. Most of them make sense, some of them could be replaced by better code or better loops. 

For now this is just to make sure that new contributions to the codebase remain strict, reducing the back and forth for reviews on type stuff.