### PR TITLE
feat: Eliminate `any` from the codebase

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,10 +31,6 @@ module.exports = tseslint.config(
         },
       ],
 
-      // TODO: There are a ton of `any` throughout the codebase, they should be
-      // replaced by `unknown` or better types.
-      '@typescript-eslint/no-explicit-any': 'off',
-
       // TODO: A lot of related typing issues arise from the fact that `any` is
       // used throughout the codebase.
       '@typescript-eslint/no-unsafe-argument': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,8 +33,6 @@ module.exports = tseslint.config(
 
       // TODO: A lot of related typing issues arise from the fact that `any` is
       // used throughout the codebase.
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ module.exports = tseslint.config(
 
       // TODO: A lot of related typing issues arise from the fact that `any` is
       // used throughout the codebase.
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',

--- a/src/_narrow.ts
+++ b/src/_narrow.ts
@@ -33,7 +33,7 @@ type NarrowRaw<A> =
   | (A extends [] ? [] : never)
   | (A extends Narrowable ? A : never)
   | {
-      [K in keyof A]: A[K] extends (...args: Array<any>) => any
+      [K in keyof A]: A[K] extends (...args: Array<unknown>) => unknown
         ? A[K]
         : NarrowRaw<A[K]>;
     };

--- a/src/_purryOn.ts
+++ b/src/_purryOn.ts
@@ -5,7 +5,11 @@
  */
 export function purryOn<T>(
   isArg: (firstArg: unknown) => firstArg is T,
-  implementation: (firstArg: T, ...args: Array<any>) => unknown,
+  implementation: (
+    firstArg: T,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Function inference in typescript relies on `any` to work, it doesn't work with `unknown`
+    ...args: Array<any>
+  ) => unknown,
   args: IArguments
 ): unknown {
   const callArgs = Array.from(args);

--- a/src/_purryOrderRules.ts
+++ b/src/_purryOrderRules.ts
@@ -95,6 +95,7 @@ export function purryOrderRulesWithArgument(
   func: <T>(
     data: ReadonlyArray<T>,
     compareFn: CompareFunction<T>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Function inference in typescript relies on `any` to work, it doesn't work with `unknown`
     arg: any
   ) => unknown,
   inputArgs: IArguments

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -22,8 +22,8 @@ interface LazyMany<T> {
 }
 
 export function _reduceLazy<T, K>(
-  array: Array<T>,
-  lazy: (item: T, index?: number, array?: Array<T>) => LazyResult<K>,
+  array: ReadonlyArray<T>,
+  lazy: (item: T, index?: number, array?: ReadonlyArray<T>) => LazyResult<K>,
   indexed?: boolean
 ): Array<K> {
   const newArray: Array<K> = [];

--- a/src/_toLazyIndexed.ts
+++ b/src/_toLazyIndexed.ts
@@ -1,4 +1,5 @@
-export const _toLazyIndexed = <T>(fn: T): T & { indexed: true } => {
-  (fn as any).indexed = true;
-  return fn as any;
-};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Typescript requires using `any` to infer any kind of function type, `unknown` is not enough.
+export const _toLazyIndexed = <Func extends (...args: any) => unknown>(
+  fn: Func
+): Func & { readonly indexed: true } =>
+  Object.assign(fn, { indexed: true as const });

--- a/src/_toSingle.ts
+++ b/src/_toSingle.ts
@@ -1,4 +1,3 @@
-export const _toSingle = <T>(fn: T): T & { single: true } => {
-  (fn as any).single = true;
-  return fn as any;
-};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Typescript requires using `any` to infer any kind of function type, `unknown` is not enough.
+export const _toSingle = <Func extends (...args: any) => unknown>(fn: Func) =>
+  Object.assign(fn, { single: true as const });

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -3,7 +3,7 @@ export type PredIndexed<T, K> = (input: T, index: number, array: Array<T>) => K;
 export type PredIndexedOptional<T, K> = (
   input: T,
   index?: number,
-  array?: Array<T>
+  array?: ReadonlyArray<T>
 ) => K;
 
 export type NonEmptyArray<T> = [T, ...Array<T>];

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1,3 +1,5 @@
+import type { IsAny } from './type-fest/is-any';
+
 export type Pred<T, K> = (input: T) => K;
 export type PredIndexed<T, K> = (input: T, index: number, array: Array<T>) => K;
 export type PredIndexedOptional<T, K> = (
@@ -45,7 +47,11 @@ export type ReadonlyTuple<
  *   function isMyType<T>(data: T | MyType): data is NarrowedTo<T, MyType> { ... }
  */
 export type NarrowedTo<T, Base> =
-  Extract<T, Base> extends never ? Base : Extract<T, Base>;
+  Extract<T, Base> extends never
+    ? Base
+    : IsAny<T> extends true
+      ? Base
+      : Extract<T, Base>;
 
 type BuildTupleHelper<
   Element,

--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -13,7 +13,7 @@ import { purry } from './purry';
  * @category Object
  */
 export function addProp<
-  T extends Record<PropertyKey, any>,
+  T extends Record<PropertyKey, unknown>,
   K extends string,
   V,
 >(obj: T, prop: K, value: V): T & { [x in K]: V };
@@ -30,16 +30,20 @@ export function addProp<
  * @category Object
  */
 export function addProp<
-  T extends Record<PropertyKey, any>,
+  T extends Record<PropertyKey, unknown>,
   K extends string,
   V,
 >(prop: K, value: V): (obj: T) => T & { [x in K]: V };
 
-export function addProp(): any {
+export function addProp() {
   return purry(_addProp, arguments);
 }
 
-function _addProp(obj: any, prop: string, value: any) {
+function _addProp<T extends Record<PropertyKey, unknown>, K extends string, V>(
+  obj: T,
+  prop: K,
+  value: V
+): T & { [x in K]: V } {
   return {
     ...obj,
     [prop]: value,

--- a/src/allPass.ts
+++ b/src/allPass.ts
@@ -42,6 +42,6 @@ export function allPass() {
   return purry(_allPass, arguments);
 }
 
-function _allPass(data: any, fns: Array<(data: any) => boolean>) {
+function _allPass<T>(data: T, fns: Array<(data: T) => boolean>) {
   return fns.every(fn => fn(data));
 }

--- a/src/anyPass.ts
+++ b/src/anyPass.ts
@@ -42,6 +42,6 @@ export function anyPass() {
   return purry(_anyPass, arguments);
 }
 
-function _anyPass(data: any, fns: Array<(data: any) => boolean>) {
+function _anyPass<T>(data: T, fns: ReadonlyArray<(data: T) => boolean>) {
   return fns.some(fn => fn(data));
 }

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- FIXME! */
+
 import { clone } from './clone';
 
 const eq = (a: any, b: any) => {

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- FIXME! */
+
 // from https://github.com/ramda/ramda/blob/master/source/internal/_clone.js
 
 import { type } from './type';

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -34,6 +34,6 @@ export function concat() {
   return purry(_concat, arguments);
 }
 
-function _concat(arr1: Array<any>, arr2: Array<any>) {
+function _concat(arr1: ReadonlyArray<unknown>, arr2: ReadonlyArray<unknown>) {
   return arr1.concat(arr2);
 }

--- a/src/createPipe.ts
+++ b/src/createPipe.ts
@@ -58,6 +58,13 @@ export function createPipe<A, B, C, D, E, F, G, H>(
   op7: (input: G) => H
 ): (value: A) => H;
 
-export function createPipe(...operations: ReadonlyArray<(input: any) => any>) {
-  return (value: any) => (pipe as any)(value, ...operations);
+export function createPipe(
+  ...operations: ReadonlyArray<(input: unknown) => unknown>
+) {
+  return (value: unknown) =>
+    pipe(
+      value,
+      // @ts-expect-error [ts2556] - We can't avoid this error because pipe is typed for users and this is an internal function
+      ...operations
+    );
 }

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,3 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * Function inference doesn't work when `unknown` is used as the parameters
+ * generic type, it **has** to be `any`.
+ */
+
 type Debouncer<
   F extends (...args: any) => unknown,
   IsNullable extends boolean = true,

--- a/src/equals.test.ts
+++ b/src/equals.test.ts
@@ -1,6 +1,6 @@
 import { equals } from './equals';
 
-const tests: any = [
+const tests = [
   {
     description: 'scalars',
     tests: [
@@ -392,9 +392,9 @@ function func2() {
 }
 
 describe('equal', () => {
-  tests.forEach((suite: any) => {
+  tests.forEach(suite => {
     describe(suite.description, () => {
-      suite.tests.forEach((test: any) => {
+      suite.tests.forEach(test => {
         it(test.description, () => {
           expect(equals(test.value1, test.value2)).toEqual(test.equal);
         });

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -18,7 +18,7 @@ const keyList = Object.keys;
  * @dataFirst
  * @category Object
  */
-export function equals(a: any, b: any): boolean;
+export function equals(a: unknown, b: unknown): boolean;
 
 /**
  * Returns true if its arguments are equivalent, false otherwise.
@@ -34,13 +34,13 @@ export function equals(a: any, b: any): boolean;
  * @dataLast
  * @category Object
  */
-export function equals(a: any): (b: any) => boolean;
+export function equals(a: unknown): (b: unknown) => boolean;
 
 export function equals() {
   return purry(_equals, arguments);
 }
 
-function _equals(a: any, b: any) {
+function _equals(a: unknown, b: unknown) {
   if (a === b) {
     return true;
   }
@@ -102,6 +102,7 @@ function _equals(a: any, b: any) {
 
     for (i = length; i-- !== 0; ) {
       key = keys[i]!;
+      // @ts-expect-error [ts7053] - There's no easy way to tell typescript these keys are safe.
       if (!equals(a[key], b[key])) {
         return false;
       }

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -45,7 +45,10 @@ type Evolver<T> = T extends object
 type Evolved<T, E> = T extends object
   ? {
       -readonly [K in keyof T]: K extends keyof E
-        ? E[K] extends (...arg: any) => infer R
+        ? E[K] extends (
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Functions aren't inferred correctly when using `unknown` for the params.
+            ...arg: any
+          ) => infer R
           ? R
           : Evolved<T[K], E[K]>
         : Required<T>[K];

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -54,7 +54,7 @@ export function filter() {
 
 const _filter =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
     return _reduceLazy(
       array,
       indexed ? filter.lazyIndexed(fn) : filter.lazy(fn),
@@ -65,7 +65,11 @@ const _filter =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
+    return (
+      value: T,
+      index?: number,
+      array?: ReadonlyArray<T>
+    ): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       if (valid) {
         return {

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -21,7 +21,7 @@ import { purry } from './purry';
  * @indexed
  * @category Array
  */
-export function flatMapToObj<T, K extends keyof any, V>(
+export function flatMapToObj<T, K extends PropertyKey, V>(
   array: ReadonlyArray<T>,
   fn: (element: T) => Array<[K, V]>
 ): Record<K, V>;
@@ -49,7 +49,7 @@ export function flatMapToObj<T, K extends keyof any, V>(
  * @indexed
  * @category Array
  */
-export function flatMapToObj<T, K extends keyof any, V>(
+export function flatMapToObj<T, K extends PropertyKey, V>(
   fn: (element: T) => Array<[K, V]>
 ): (array: ReadonlyArray<T>) => Record<K, V>;
 
@@ -59,22 +59,31 @@ export function flatMapToObj() {
 
 const _flatMapToObj =
   (indexed: boolean) =>
-  (array: Array<any>, fn: PredIndexedOptional<any, any>) => {
-    return array.reduce((result, element, index) => {
-      const items = indexed ? fn(element, index, array) : fn(element);
-      items.forEach(([key, value]: [any, any]) => {
-        result[key] = value;
-      });
-      return result;
-    }, {});
+  <T>(
+    array: ReadonlyArray<T>,
+    fn: PredIndexedOptional<
+      T,
+      ReadonlyArray<[key: PropertyKey, value: unknown]>
+    >
+  ) => {
+    return array.reduce<Record<PropertyKey, unknown>>(
+      (result, element, index) => {
+        const items = indexed ? fn(element, index, array) : fn(element);
+        items.forEach(([key, value]) => {
+          result[key] = value;
+        });
+        return result;
+      },
+      {}
+    );
   };
 
 export namespace flatMapToObj {
-  export function indexed<T, K extends keyof any, V>(
+  export function indexed<T, K extends PropertyKey, V>(
     array: ReadonlyArray<T>,
     fn: (element: T, index: number, array: ReadonlyArray<T>) => Array<[K, V]>
   ): Record<K, V>;
-  export function indexed<T, K extends keyof any, V>(
+  export function indexed<T, K extends PropertyKey, V>(
     fn: (element: T, index: number, array: ReadonlyArray<T>) => Array<[K, V]>
   ): (array: ReadonlyArray<T>) => Record<K, V>;
   export function indexed() {

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- FIXME! */
+
 import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { purry } from './purry';
 

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- FIXME! */
+
 import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { purry } from './purry';
 

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -62,7 +62,7 @@ export function forEach() {
 
 const _forEach =
   (indexed: boolean) =>
-  <T, K>(array: Array<T>, fn: PredIndexedOptional<T, K>) => {
+  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) => {
     return _reduceLazy(
       array,
       indexed ? forEach.lazyIndexed(fn) : forEach.lazy(fn),
@@ -73,7 +73,11 @@ const _forEach =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, void>) => {
-    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
+    return (
+      value: T,
+      index?: number,
+      array?: ReadonlyArray<T>
+    ): LazyResult<T> => {
       if (indexed) {
         fn(value, index, array);
       } else {

--- a/src/forEachObj.ts
+++ b/src/forEachObj.ts
@@ -1,11 +1,10 @@
 import { purry } from './purry';
 
-type IndexedIteratee<T extends Record<PropertyKey, any>, K extends keyof T> = (
-  value: T[K],
-  key: K,
-  obj: T
-) => void;
-type UnindexedIteratee<T extends Record<PropertyKey, any>> = (
+type IndexedIteratee<
+  T extends Record<PropertyKey, unknown>,
+  K extends keyof T,
+> = (value: T[K], key: K, obj: T) => void;
+type UnindexedIteratee<T extends Record<PropertyKey, unknown>> = (
   value: T[keyof T]
 ) => void;
 
@@ -26,7 +25,7 @@ type UnindexedIteratee<T extends Record<PropertyKey, any>> = (
  * @dataFirst
  * @category Object
  */
-export function forEachObj<T extends Record<PropertyKey, any>>(
+export function forEachObj<T extends Record<PropertyKey, unknown>>(
   object: T,
   fn: UnindexedIteratee<T>
 ): T;
@@ -48,7 +47,7 @@ export function forEachObj<T extends Record<PropertyKey, any>>(
  * @dataLast
  * @category Object
  */
-export function forEachObj<T extends Record<PropertyKey, any>>(
+export function forEachObj<T extends Record<PropertyKey, unknown>>(
   fn: UnindexedIteratee<T>
 ): (object: T) => T;
 
@@ -58,23 +57,30 @@ export function forEachObj() {
 
 const _forEachObj =
   (indexed: boolean) =>
-  (object: any, fn: (value: any, key?: any, obj?: any) => void) => {
-    for (const key in object) {
-      if (Object.prototype.hasOwnProperty.call(object, key)) {
-        const val = object[key];
-        if (indexed) fn(val, key, object);
+  <T extends Record<PropertyKey, unknown>>(
+    data: T,
+    fn: (
+      value: T[Extract<keyof T, string>],
+      key?: Extract<keyof T, string>,
+      obj?: T
+    ) => void
+  ) => {
+    for (const key in data) {
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
+        const val = data[key];
+        if (indexed) fn(val, key, data);
         else fn(val);
       }
     }
-    return object;
+    return data;
   };
 
 export namespace forEachObj {
-  export function indexed<T extends Record<PropertyKey, any>>(
+  export function indexed<T extends Record<PropertyKey, unknown>>(
     object: T,
     fn: IndexedIteratee<T, keyof T>
   ): T;
-  export function indexed<T extends Record<PropertyKey, any>>(
+  export function indexed<T extends Record<PropertyKey, unknown>>(
     fn: IndexedIteratee<T, keyof T>
   ): (object: T) => T;
   export function indexed() {

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -20,7 +20,7 @@ import { PredIndexedOptional, PredIndexed } from './_types';
  */
 export function indexBy<T>(
   array: ReadonlyArray<T>,
-  fn: (item: T) => any
+  fn: (item: T) => unknown
 ): Record<string, T>;
 
 /**
@@ -48,7 +48,7 @@ export function indexBy<T>(
  * @strict
  */
 export function indexBy<T>(
-  fn: (item: T) => any
+  fn: (item: T) => unknown
 ): (array: ReadonlyArray<T>) => Record<string, T>;
 
 export function indexBy() {
@@ -57,7 +57,7 @@ export function indexBy() {
 
 const _indexBy =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) => {
     return array.reduce<Record<string, T>>((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
@@ -93,10 +93,10 @@ const _indexByStrict = <K extends PropertyKey, T>(
 export namespace indexBy {
   export function indexed<T>(
     array: ReadonlyArray<T>,
-    fn: PredIndexed<T, any>
+    fn: PredIndexed<T, unknown>
   ): Record<string, T>;
   export function indexed<T>(
-    fn: PredIndexed<T, any>
+    fn: PredIndexed<T, unknown>
   ): (array: ReadonlyArray<T>) => Record<string, T>;
   export function indexed() {
     return purry(_indexBy(true), arguments);

--- a/src/isArray.test.ts
+++ b/src/isArray.test.ts
@@ -1,37 +1,43 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isArray } from './isArray';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isArray', () => {
-  test('isArray: should infer ReadonlyArray<unknown> when given any', () => {
-    const data1: any = [];
-    if (isArray(data1)) {
-      expectTypeOf(data1).not.toBeAny();
-      expectTypeOf(data1[0]).toBeUnknown();
+  it('should infer ReadonlyArray<unknown> when given any', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- explicitly testing `any`
+    const data = [] as any;
+    if (isArray(data)) {
+      expectTypeOf(data).not.toBeAny();
+      expectTypeOf(data[0]).toBeUnknown();
     }
   });
-  test('isArray: should work as type guard', () => {
-    const data = typesDataProvider('array');
+
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.array as AllTypesDataProviderTypes;
     if (isArray(data)) {
       expect(Array.isArray(data)).toEqual(true);
-      assertType<Array<number>>(data);
-    }
-
-    const data1: unknown = typesDataProvider('array');
-    if (isArray(data1)) {
-      assertType<ReadonlyArray<unknown>>(data1);
+      expectTypeOf(data).toEqualTypeOf<
+        Array<number> | [number, number, number]
+      >();
     }
   });
-  test('isArray: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('array'),
-      typesDataProvider('date'),
-    ].filter(isArray);
+
+  it('should infer ReadonlyArray<unknown> when given `unknown`', () => {
+    const data = TYPES_DATA_PROVIDER.array as unknown;
+    if (isArray(data)) {
+      expectTypeOf(data).toEqualTypeOf<ReadonlyArray<unknown>>();
+    }
+  });
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isArray);
     expect(data.every(c => Array.isArray(c))).toEqual(true);
-    assertType<Array<Array<number>>>(data);
+    expectTypeOf(data).toEqualTypeOf<
+      Array<Array<number> | [number, number, number]>
+    >();
   });
 });
 

--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -1,9 +1,5 @@
-import { IfIsAny } from './_types';
+import { NarrowedTo } from './_types';
 
-type DefinitelyArray<T> =
-  Extract<T, Array<any> | ReadonlyArray<any>> extends never
-    ? ReadonlyArray<unknown>
-    : Extract<T, Array<any> | ReadonlyArray<any>>;
 /**
  * A function that checks if the passed parameter is an Array and narrows its type accordingly
  * @param data the variable to check
@@ -18,6 +14,6 @@ type DefinitelyArray<T> =
  */
 export function isArray<T>(
   data: T | ArrayLike<unknown>
-): data is IfIsAny<T, ReadonlyArray<unknown>, DefinitelyArray<T>> {
+): data is NarrowedTo<T, ReadonlyArray<unknown>> {
   return Array.isArray(data);
 }

--- a/src/isBoolean.test.ts
+++ b/src/isBoolean.test.ts
@@ -1,36 +1,38 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isBoolean } from './isBoolean';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isBoolean', () => {
-  test('isBoolean: should work as type guard', () => {
-    const data = typesDataProvider('boolean');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.boolean as AllTypesDataProviderTypes;
     if (isBoolean(data)) {
       expect(typeof data).toEqual('boolean');
       expectTypeOf(data).toEqualTypeOf<boolean>();
     }
+  });
 
-    const data1: unknown = typesDataProvider('boolean');
-    if (isBoolean(data1)) {
-      expect(typeof data1).toEqual('boolean');
-      expectTypeOf(data1).toEqualTypeOf<boolean>();
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- We are explicitly testing the `any` case here
-    const data2: any = typesDataProvider('boolean');
-    if (isBoolean(data2)) {
-      expect(typeof data2).toEqual('boolean');
-      expectTypeOf(data2).toEqualTypeOf<boolean>();
+  it('should narrow `unknown`', () => {
+    const data = TYPES_DATA_PROVIDER.boolean as unknown;
+    if (isBoolean(data)) {
+      expect(typeof data).toEqual('boolean');
+      expectTypeOf(data).toEqualTypeOf<boolean>();
     }
   });
-  test('isBoolean: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-    ].filter(isBoolean);
+
+  it('should narrow `any`', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- We are explicitly testing the `any` case here
+    const data = TYPES_DATA_PROVIDER.boolean as any;
+    if (isBoolean(data)) {
+      expect(typeof data).toEqual('boolean');
+      expectTypeOf(data).toEqualTypeOf<boolean>();
+    }
+  });
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isBoolean);
     expect(data.every(c => typeof c === 'boolean')).toEqual(true);
     expectTypeOf(data).toEqualTypeOf<Array<boolean>>();
   });

--- a/src/isBoolean.test.ts
+++ b/src/isBoolean.test.ts
@@ -6,19 +6,20 @@ describe('isBoolean', () => {
     const data = typesDataProvider('boolean');
     if (isBoolean(data)) {
       expect(typeof data).toEqual('boolean');
-      assertType<boolean>(data);
+      expectTypeOf(data).toEqualTypeOf<boolean>();
     }
 
     const data1: unknown = typesDataProvider('boolean');
     if (isBoolean(data1)) {
       expect(typeof data1).toEqual('boolean');
-      assertType<boolean>(data1);
+      expectTypeOf(data1).toEqualTypeOf<boolean>();
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- We are explicitly testing the `any` case here
     const data2: any = typesDataProvider('boolean');
     if (isBoolean(data2)) {
       expect(typeof data2).toEqual('boolean');
-      assertType<boolean>(data2);
+      expectTypeOf(data2).toEqualTypeOf<boolean>();
     }
   });
   test('isBoolean: should work as type guard in filter', () => {
@@ -31,6 +32,6 @@ describe('isBoolean', () => {
       typesDataProvider('boolean'),
     ].filter(isBoolean);
     expect(data.every(c => typeof c === 'boolean')).toEqual(true);
-    assertType<Array<boolean>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<boolean>>();
   });
 });

--- a/src/isBoolean.ts
+++ b/src/isBoolean.ts
@@ -1,9 +1,4 @@
-type DefinitelyBoolean<T> =
-  Extract<T, boolean> extends never
-    ? boolean
-    : Extract<T, boolean> extends any
-      ? boolean
-      : Extract<T, number>;
+import type { NarrowedTo } from './_types';
 
 /**
  * A function that checks if the passed parameter is a boolean and narrows its type accordingly
@@ -17,7 +12,8 @@ type DefinitelyBoolean<T> =
  *    R.isBoolean('somethingElse') //=> false
  * @category Guard
  */
-
-export function isBoolean<T>(data: T | boolean): data is DefinitelyBoolean<T> {
+export function isBoolean<T>(
+  data: T | boolean
+): data is NarrowedTo<T, boolean> {
   return typeof data === 'boolean';
 }

--- a/src/isDate.test.ts
+++ b/src/isDate.test.ts
@@ -1,29 +1,29 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isDate } from './isDate';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isDate', () => {
-  test('isDate: should work as type guard', () => {
-    const data = typesDataProvider('date');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
     if (isDate(data)) {
       expect(data instanceof Date).toEqual(true);
-      assertType<Date>(data);
-    }
-
-    const data1: unknown = typesDataProvider('date');
-    if (isDate(data1)) {
-      assertType<Date>(data1);
+      expectTypeOf(data).toEqualTypeOf<Date>();
     }
   });
-  test('isDate: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('number'),
-      typesDataProvider('date'),
-    ].filter(isDate);
+
+  it('should narrow `unknown`', () => {
+    const data = TYPES_DATA_PROVIDER.date as unknown;
+    if (isDate(data)) {
+      expectTypeOf(data).toEqualTypeOf<Date>();
+    }
+  });
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isDate);
     expect(data.every(c => c instanceof Date)).toEqual(true);
-    assertType<Array<Date>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<Date>>();
   });
 });

--- a/src/isDefined.test.ts
+++ b/src/isDefined.test.ts
@@ -1,15 +1,20 @@
-import { typesDataProvider, type TestClass } from '../test/types_data_provider';
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+  TestClass,
+} from '../test/types_data_provider';
 import { isDefined } from './isDefined';
 
 describe('isDefined', () => {
-  test('isDefined": should work as type guard', () => {
-    const data = typesDataProvider('date');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
     if (isDefined(data)) {
       expect(data instanceof Date).toEqual(true);
-      assertType<
+      expectTypeOf(data).toEqualTypeOf<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -23,23 +28,17 @@ describe('isDefined', () => {
         | symbol
         | TestClass
         | Uint8Array
-      >(data);
+      >();
     }
   });
-  test('isDefined: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('number'),
-    ].filter(isDefined);
-    expect(data).toHaveLength(4);
-    assertType<
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isDefined);
+    expect(data).toHaveLength(16);
+    expectTypeOf(data).toEqualTypeOf<
       Array<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -54,19 +53,19 @@ describe('isDefined', () => {
         | TestClass
         | Uint8Array
       >
-    >(data);
+    >();
   });
 });
 
 describe('strict', () => {
-  test('isDefined": should work as type guard', () => {
-    const data = typesDataProvider('date');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
     if (isDefined.strict(data)) {
       expect(data instanceof Date).toEqual(true);
-      assertType<
+      expectTypeOf(data).toEqualTypeOf<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -81,24 +80,18 @@ describe('strict', () => {
         | symbol
         | TestClass
         | Uint8Array
-      >(data);
+      >();
     }
   });
-  test('isDefined: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('number'),
-      typesDataProvider('undefined'),
-    ].filter(isDefined.strict);
-    expect(data).toHaveLength(5);
-    assertType<
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isDefined.strict);
+    expect(data).toHaveLength(17);
+    expectTypeOf(data).toEqualTypeOf<
       Array<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -114,6 +107,6 @@ describe('strict', () => {
         | TestClass
         | Uint8Array
       >
-    >(data);
+    >();
   });
 });

--- a/src/isError.test.ts
+++ b/src/isError.test.ts
@@ -1,31 +1,29 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isError } from './isError';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isError', () => {
-  test('isError: should work as type guard', () => {
-    const data = typesDataProvider('error');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.error as AllTypesDataProviderTypes;
     if (isError(data)) {
       expect(data instanceof Error).toEqual(true);
-      assertType<Error>(data);
+      expectTypeOf(data).toEqualTypeOf<Error>();
     }
 
     class MyError extends Error {}
 
     let maybeError: MyError | undefined;
     if (isError(maybeError)) {
-      assertType<MyError>(maybeError);
+      expectTypeOf(maybeError).toEqualTypeOf<MyError>();
     }
   });
-  test('isError: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-      typesDataProvider('function'),
-      typesDataProvider('object'),
-      typesDataProvider('number'),
-    ].filter(isError);
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isError);
     expect(data.every(c => c instanceof Error)).toEqual(true);
-    assertType<Array<Error>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<Error>>();
   });
 });

--- a/src/isFunction.test.ts
+++ b/src/isFunction.test.ts
@@ -1,30 +1,28 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isFunction } from './isFunction';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isFunction', () => {
-  test('isFunction: should work as type guard', () => {
-    const data = typesDataProvider('null');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.function as AllTypesDataProviderTypes;
     if (isFunction(data)) {
-      expect(data).toEqual(null);
-      assertType<() => void>(data);
+      expect(typeof data).toEqual('function');
+      expectTypeOf(data).toEqualTypeOf<() => void>();
     }
 
     let maybeFunction: string | ((a: number) => string) | undefined;
     if (isFunction(maybeFunction)) {
       maybeFunction(1);
-      assertType<(a: number) => string>(maybeFunction);
+      expectTypeOf(maybeFunction).toEqualTypeOf<(a: number) => string>();
     }
   });
-  test('isFunction: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('function'),
-      typesDataProvider('object'),
-      typesDataProvider('number'),
-    ].filter(isFunction);
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isFunction);
     expect(data.every(c => typeof c === 'function')).toEqual(true);
-    assertType<Array<() => void>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<() => void>>();
   });
 });

--- a/src/isNil.test.ts
+++ b/src/isNil.test.ts
@@ -1,24 +1,22 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isNil } from './isNil';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isNil', () => {
-  test('isNil: should work as type guard', () => {
-    const data = typesDataProvider('null');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.null as AllTypesDataProviderTypes;
     if (isNil(data)) {
       expect(data).toEqual(null);
-      assertType<undefined | null>(data);
+      expectTypeOf(data).toEqualTypeOf<null | undefined>();
     }
   });
-  test('isNil: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('number'),
-    ].filter(isNil);
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isNil);
     expect(data.every(c => c == null)).toEqual(true);
-    assertType<Array<undefined | null>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<undefined | null>>();
   });
 });

--- a/src/isNonNull.test.ts
+++ b/src/isNonNull.test.ts
@@ -1,15 +1,20 @@
-import { typesDataProvider, type TestClass } from '../test/types_data_provider';
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+  TestClass,
+} from '../test/types_data_provider';
 import { isNonNull } from './isNonNull';
 
 describe('isNonNull', () => {
-  test('isNonNull": should work as type guard', () => {
-    const data = typesDataProvider('date');
+  test('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
     if (isNonNull(data)) {
       expect(data instanceof Date).toEqual(true);
-      assertType<
+      expectTypeOf(data).toEqualTypeOf<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -24,24 +29,17 @@ describe('isNonNull', () => {
         | TestClass
         | Uint8Array
         | undefined
-      >(data);
+      >();
     }
   });
-  test('isNonNull: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('array'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('number'),
-      typesDataProvider('undefined'),
-    ].filter(isNonNull);
-    expect(data).toHaveLength(5);
-    assertType<
+  test('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isNonNull);
+    expect(data).toHaveLength(17);
+    expectTypeOf(data).toEqualTypeOf<
       Array<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date

--- a/src/isNot.test.ts
+++ b/src/isNot.test.ts
@@ -1,17 +1,22 @@
-import { typesDataProvider, type TestClass } from '../test/types_data_provider';
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+  TestClass,
+} from '../test/types_data_provider';
 import { isNot } from './isNot';
 import { isPromise } from './isPromise';
 import { isString } from './isString';
 
 describe('isNot', () => {
-  test('isNot: should work as type guard', () => {
-    const data = typesDataProvider('promise');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
     if (isNot(isString)(data)) {
       expect(data instanceof Promise).toEqual(true);
-      assertType<
+      expectTypeOf(data).toEqualTypeOf<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -29,21 +34,15 @@ describe('isNot', () => {
       >(data);
     }
   });
-  test('isNot: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('promise'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-      typesDataProvider('function'),
-    ];
-    const result = data.filter(isNot(isPromise));
-    expect(result.some(c => c instanceof Promise)).toEqual(false);
 
-    assertType<
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isNot(isPromise));
+    expect(data.some(c => c instanceof Promise)).toEqual(false);
+    expectTypeOf(data).toEqualTypeOf<
       Array<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | boolean
         | Date
@@ -59,6 +58,6 @@ describe('isNot', () => {
         | Uint8Array
         | undefined
       >
-    >(result);
+    >();
   });
 });

--- a/src/isNot.ts
+++ b/src/isNot.ts
@@ -13,8 +13,9 @@
 export function isNot<T, S extends T>(
   predicate: (data: T) => data is S
 ): (data: T) => data is Exclude<T, S>;
-export function isNot<T>(predicate: (data: T) => any): (data: T) => boolean;
-export function isNot<T>(predicate: (data: T) => any) {
+export function isNot<T>(predicate: (data: T) => boolean): (data: T) => boolean;
+
+export function isNot<T>(predicate: (data: T) => boolean) {
   return (data: T) => {
     return !predicate(data);
   };

--- a/src/isNumber.test.ts
+++ b/src/isNumber.test.ts
@@ -1,41 +1,41 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isNumber } from './isNumber';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isNumber', () => {
-  test('isNumber: should work as type guard', () => {
-    const data = typesDataProvider('number');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.number as AllTypesDataProviderTypes;
     if (isNumber(data)) {
       expect(typeof data).toEqual('number');
-      assertType<number>(data);
+      expectTypeOf(data).toEqualTypeOf<number>();
     }
   });
-  test('isNumber: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('promise'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-      typesDataProvider('function'),
-      typesDataProvider('object'),
-      typesDataProvider('number'),
-    ].filter(isNumber);
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isNumber);
     expect(data.every(c => typeof c === 'number')).toEqual(true);
-    assertType<Array<number>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<number>>();
   });
-  test('should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('number');
+
+  it('should work even if data type is unknown', () => {
+    const data = TYPES_DATA_PROVIDER.number as unknown;
     if (isNumber(data)) {
       expect(typeof data).toEqual('number');
       assertType<number>(data);
     }
   });
-  test('should work with literal types', () => {
+
+  it('should work with literal types', () => {
     const data = (): 1 | 2 | 3 | string => {
       return 1;
     };
     const x = data();
     if (isNumber(x)) {
       expect(typeof x).toEqual('number');
-      assertType<1 | 2 | 3>(x);
+      expectTypeOf(x).toEqualTypeOf<1 | 2 | 3>(x);
     }
   });
 });

--- a/src/isNumber.ts
+++ b/src/isNumber.ts
@@ -1,9 +1,4 @@
-type DefinitelyNumber<T> =
-  Extract<T, number> extends never
-    ? number
-    : Extract<T, number> extends any
-      ? number
-      : Extract<T, number>;
+import type { NarrowedTo } from './_types';
 
 /**
  * A function that checks if the passed parameter is a number and narrows its type accordingly
@@ -16,6 +11,6 @@ type DefinitelyNumber<T> =
  *    R.isNumber('notANumber') //=> false
  * @category Guard
  */
-export function isNumber<T>(data: T | number): data is DefinitelyNumber<T> {
+export function isNumber<T>(data: T | number): data is NarrowedTo<T, number> {
   return typeof data === 'number' && !isNaN(data);
 }

--- a/src/isObject.test.ts
+++ b/src/isObject.test.ts
@@ -1,17 +1,18 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
-  typesDataProvider,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
   type TestClass,
 } from '../test/types_data_provider';
 import { isObject } from './isObject';
 
 describe('isObject', () => {
-  test('isObject: should work as type guard', () => {
-    const data = typesDataProvider('object');
+  test('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.object as AllTypesDataProviderTypes;
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      assertType<
-        | { a: string }
+      expectTypeOf(data).toEqualTypeOf<
+        | { readonly a: 'asd' }
         | Date
         | Error
         | Map<string, string>
@@ -20,46 +21,42 @@ describe('isObject', () => {
         | Set<string>
         | TestClass
         | Uint8Array
-      >(data);
+      >();
     }
   });
 
-  test('isObject: should work as type guard', () => {
+  test('should work as type guard', () => {
     const data = { data: 5 } as ReadonlyArray<number> | { data: 5 };
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      assertType<{
-        data: 5;
-      }>(data);
+      expectTypeOf(data).toEqualTypeOf<{ data: 5 }>();
     }
   });
 
-  test('isObject: should work as type guard for more narrow types', () => {
+  test('should work as type guard for more narrow types', () => {
     const data = { data: 5 } as Array<number> | { data: number };
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      assertType<{
-        data: number;
-      }>(data);
+      expectTypeOf(data).toEqualTypeOf<{ data: number }>();
     }
   });
 
   test('should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('object');
+    const data = TYPES_DATA_PROVIDER.object as unknown;
     if (isObject(data)) {
       expect(typeof data).toEqual('object');
-      assertType<Record<string, unknown>>(data);
+      expectTypeOf(data).toEqualTypeOf<Record<string, unknown>>();
     }
   });
 
-  test('isObject: should work as type guard in filter', () => {
+  test('should work as type guard in filter', () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isObject);
     expect(data.every(c => typeof c === 'object' && !Array.isArray(c))).toEqual(
       true
     );
-    assertType<
+    expectTypeOf(data).toEqualTypeOf<
       Array<
-        | { a: string }
+        | { readonly a: 'asd' }
         | Date
         | Error
         | Map<string, string>

--- a/src/isObject.ts
+++ b/src/isObject.ts
@@ -1,6 +1,5 @@
-/* eslint @typescript-eslint/ban-types: ["error",{types:{Function: false},extendDefaults:true}] --
- * Function is used generically in this file to define any type of function, so
- * this lint error is not relevant for it.
+/* eslint-disable @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any --
+ * This function is deprecated so it doesn't matter that it uses bad types.
  */
 type DefinitelyObject<T> =
   Exclude<

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -119,4 +119,12 @@ describe('typing', () => {
       >
     >();
   });
+
+  test('Can narrow down `any`', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
+    const data: any = { hello: 'world' };
+    if (isObjectType(data)) {
+      expectTypeOf(data).toEqualTypeOf<object>();
+    }
+  });
 });

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -1,7 +1,8 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
   TestClass,
-  typesDataProvider,
 } from '../test/types_data_provider';
 import { isObjectType } from './isObjectType';
 
@@ -73,13 +74,13 @@ describe('typing', () => {
     }
   });
 
-  test('isObjectType: should work as type guard', () => {
-    const data = typesDataProvider('object');
+  test('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.object as AllTypesDataProviderTypes;
     if (isObjectType(data)) {
       expectTypeOf(data).toEqualTypeOf<
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | Date
         | Error
@@ -94,27 +95,27 @@ describe('typing', () => {
   });
 
   test('should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('object');
+    const data = TYPES_DATA_PROVIDER.object as unknown;
     if (isObjectType(data)) {
       expectTypeOf(data).toEqualTypeOf<object>();
     }
   });
 
-  test('isObjectType: should work as type guard in filter', () => {
+  test('should work as type guard in filter', () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isObjectType);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | RegExp
         | (() => void)
         | [number, number, number]
-        | { a: string }
+        | { readonly a: 'asd' }
         | Array<number>
         | Date
         | Error
-        | Promise<number>
-        | TestClass
-        | Set<string>
         | Map<string, string>
+        | Promise<number>
+        | RegExp
+        | Set<string>
+        | TestClass
         | Uint8Array
       >
     >();
@@ -122,7 +123,7 @@ describe('typing', () => {
 
   test('Can narrow down `any`', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
-    const data: any = { hello: 'world' };
+    const data = { hello: 'world' } as any;
     if (isObjectType(data)) {
       expectTypeOf(data).toEqualTypeOf<object>();
     }

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -1,7 +1,8 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
   TestClass,
-  typesDataProvider,
 } from '../test/types_data_provider';
 import { isPlainObject } from './isPlainObject';
 
@@ -58,14 +59,14 @@ describe('typing', () => {
   });
 
   test('should work as type guard', () => {
-    const data = typesDataProvider('object');
+    const data = TYPES_DATA_PROVIDER.object as AllTypesDataProviderTypes;
     if (isPlainObject(data)) {
-      expectTypeOf(data).toEqualTypeOf<{ a: string }>();
+      expectTypeOf(data).toEqualTypeOf<{ readonly a: 'asd' }>();
     }
   });
 
   test('should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('object');
+    const data = TYPES_DATA_PROVIDER.object as unknown;
     if (isPlainObject(data)) {
       expectTypeOf(data).toEqualTypeOf<Record<PropertyKey, unknown>>();
     }
@@ -73,12 +74,12 @@ describe('typing', () => {
 
   test('should work as type guard in filter', () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isPlainObject);
-    expectTypeOf(data).toEqualTypeOf<Array<{ a: string }>>();
+    expectTypeOf(data).toEqualTypeOf<Array<{ readonly a: 'asd' }>>();
   });
 
   test('Can narrow down `any`', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
-    const data: any = { hello: 'world' };
+    const data = { hello: 'world' } as any;
     if (isPlainObject(data)) {
       expectTypeOf(data).toEqualTypeOf<Record<PropertyKey, unknown>>();
     }

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -75,4 +75,12 @@ describe('typing', () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isPlainObject);
     expectTypeOf(data).toEqualTypeOf<Array<{ a: string }>>();
   });
+
+  test('Can narrow down `any`', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
+    const data: any = { hello: 'world' };
+    if (isPlainObject(data)) {
+      expectTypeOf(data).toEqualTypeOf<Record<PropertyKey, unknown>>();
+    }
+  });
 });

--- a/src/isPromise.test.ts
+++ b/src/isPromise.test.ts
@@ -1,21 +1,21 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isPromise } from './isPromise';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isPromise', () => {
-  test('isPromise: should work as type guard', () => {
-    const data = typesDataProvider('promise');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
     if (isPromise(data)) {
       expect(data instanceof Promise).toEqual(true);
-      assertType<Promise<number>>(data);
+      expectTypeOf(data).toEqualTypeOf<Promise<number>>();
     }
   });
-  test('isPromise: should work as type guard in filter', () => {
-    const data = [
-      typesDataProvider('promise'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-      typesDataProvider('function'),
-    ].filter(isPromise);
+
+  it('should work as type guard in filter', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isPromise);
     expect(data.every(c => c instanceof Promise)).toEqual(true);
     assertType<Array<Promise<number>>>(data);
   });

--- a/src/isString.test.ts
+++ b/src/isString.test.ts
@@ -1,42 +1,41 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isString } from './isString';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isString', () => {
-  test('isString: should work as type guard', () => {
-    const data = typesDataProvider('string');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.string as AllTypesDataProviderTypes;
     if (isString(data)) {
       expect(typeof data).toEqual('string');
-      assertType<string>(data);
-    }
-  });
-  test('isString: should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('string');
-    if (isString(data)) {
-      expect(typeof data).toEqual('string');
-      assertType<string>(data);
+      expectTypeOf(data).toEqualTypeOf<string>();
     }
   });
 
-  test('isString: should work with literal types', () => {
+  it('should work even if data type is unknown', () => {
+    const data = TYPES_DATA_PROVIDER.string as unknown;
+    if (isString(data)) {
+      expect(typeof data).toEqual('string');
+      expectTypeOf(data).toEqualTypeOf<string>();
+    }
+  });
+
+  it('should work with literal types', () => {
     const data = (): 'a' | 'b' | 'c' | number => {
       return 'a';
     };
     const x = data();
     if (isString(x)) {
       expect(typeof x).toEqual('string');
-      assertType<'a' | 'b' | 'c'>(x);
+      expectTypeOf(x).toEqualTypeOf<'a' | 'b' | 'c'>();
     }
   });
-  test('isString: should work as type guard in array', () => {
-    const data = [
-      typesDataProvider('error'),
-      typesDataProvider('string'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-    ].filter(isString);
+
+  it('should work as type guard in array', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isString);
     expect(data.every(c => typeof c === 'string')).toEqual(true);
-    assertType<Array<string>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<string>>();
   });
 });

--- a/src/isString.ts
+++ b/src/isString.ts
@@ -1,9 +1,4 @@
-type DefinitelyString<T> =
-  Extract<T, string> extends never
-    ? string
-    : Extract<T, string> extends any
-      ? string
-      : Extract<T, string>;
+import type { NarrowedTo } from './_types';
 
 /**
  * A function that checks if the passed parameter is a string and narrows its type accordingly
@@ -16,6 +11,6 @@ type DefinitelyString<T> =
  *    R.isString(1) //=> false
  * @category Guard
  */
-export function isString<T>(data: T | string): data is DefinitelyString<T> {
+export function isString<T>(data: T | string): data is NarrowedTo<T, string> {
   return typeof data === 'string';
 }

--- a/src/isSymbol.test.ts
+++ b/src/isSymbol.test.ts
@@ -1,32 +1,39 @@
+import {
+  ALL_TYPES_DATA_PROVIDER,
+  AllTypesDataProviderTypes,
+  TYPES_DATA_PROVIDER,
+} from '../test/types_data_provider';
 import { isSymbol } from './isSymbol';
-import { typesDataProvider } from '../test/types_data_provider';
 
 describe('isSymbol', () => {
-  test('isSymbol: should work as type guard', () => {
-    const data = typesDataProvider('symbol');
+  it('should work as type guard', () => {
+    const data = TYPES_DATA_PROVIDER.symbol as AllTypesDataProviderTypes;
     if (isSymbol(data)) {
       expect(typeof data).toEqual('symbol');
-      assertType<symbol>(data);
+      expectTypeOf(data).toEqualTypeOf<symbol>();
     }
   });
-  test('isSymbol: should work even if data type is unknown', () => {
-    const data: unknown = typesDataProvider('symbol');
+
+  it('should work even if data type is `unknown`', () => {
+    const data = TYPES_DATA_PROVIDER.symbol as unknown;
     if (isSymbol(data)) {
       expect(typeof data).toEqual('symbol');
-      assertType<symbol>(data);
+      expectTypeOf(data).toEqualTypeOf<symbol>();
     }
   });
-  test('isSymbol: should work as type guard in array', () => {
-    const data = [
-      typesDataProvider('symbol'),
-      typesDataProvider('error'),
-      typesDataProvider('string'),
-      typesDataProvider('function'),
-      typesDataProvider('null'),
-      typesDataProvider('array'),
-      typesDataProvider('boolean'),
-    ].filter(isSymbol);
+
+  it('should work even if data type is `any`', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly checking any
+    const data = TYPES_DATA_PROVIDER.symbol as any;
+    if (isSymbol(data)) {
+      expect(typeof data).toEqual('symbol');
+      expectTypeOf(data).toEqualTypeOf<symbol>();
+    }
+  });
+
+  it('should work as type guard in array', () => {
+    const data = ALL_TYPES_DATA_PROVIDER.filter(isSymbol);
     expect(data.every(c => typeof c === 'symbol')).toEqual(true);
-    assertType<Array<symbol>>(data);
+    expectTypeOf(data).toEqualTypeOf<Array<symbol>>();
   });
 });

--- a/src/isSymbol.ts
+++ b/src/isSymbol.ts
@@ -1,9 +1,4 @@
-type DefinitelySymbol<T> =
-  Extract<T, string> extends never
-    ? symbol
-    : Extract<T, symbol> extends any
-      ? symbol
-      : Extract<T, symbol>;
+import type { NarrowedTo } from './_types';
 
 /**
  * A function that checks if the passed parameter is a symbol and narrows its type accordingly
@@ -16,6 +11,6 @@ type DefinitelySymbol<T> =
  *    R.isSymbol(1) //=> false
  * @category Guard
  */
-export function isSymbol<T>(data: T | symbol): data is DefinitelySymbol<T> {
+export function isSymbol<T>(data: T | symbol): data is NarrowedTo<T, symbol> {
   return typeof data === 'symbol';
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -56,7 +56,7 @@ export function map() {
 
 const _map =
   (indexed: boolean) =>
-  <T, K>(array: Array<T>, fn: PredIndexedOptional<T, K>) => {
+  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) => {
     return _reduceLazy(
       array,
       indexed ? map.lazyIndexed(fn) : map.lazy(fn),
@@ -67,7 +67,11 @@ const _map =
 const _lazy =
   (indexed: boolean) =>
   <T, K>(fn: PredIndexedOptional<T, K>) => {
-    return (value: T, index?: number, array?: Array<T>): LazyResult<K> => {
+    return (
+      value: T,
+      index?: number,
+      array?: ReadonlyArray<T>
+    ): LazyResult<K> => {
       return {
         done: false,
         hasNext: true,

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -1,6 +1,9 @@
+import { purry } from './purry';
+import { toPairs } from './toPairs';
+
 /**
  * Maps keys of `object` and keeps the same values.
- * @param object the object to map
+ * @param data the object to map
  * @param fn the mapping function
  * @signature
  *    R.mapKeys(object, fn)
@@ -9,9 +12,9 @@
  * @dataFirst
  * @category Object
  */
-export function mapKeys<T, S extends keyof any>(
-  object: T,
-  fn: (key: keyof T, value: T[keyof T]) => S
+export function mapKeys<T, S extends PropertyKey>(
+  data: T,
+  fn: (key: keyof T, value: Required<T>[keyof T]) => S
 ): Record<S, T[keyof T]>;
 
 /**
@@ -24,20 +27,21 @@ export function mapKeys<T, S extends keyof any>(
  * @dataLast
  * @category Object
  */
-export function mapKeys<T, S extends keyof any>(
-  fn: (key: keyof T, value: T[keyof T]) => S
-): (object: T) => Record<S, T[keyof T]>;
+export function mapKeys<T, S extends PropertyKey>(
+  fn: (key: keyof T, value: Required<T>[keyof T]) => S
+): (data: T) => Record<S, T[keyof T]>;
 
-export function mapKeys(arg1: any, arg2?: any): any {
-  if (arguments.length === 1) {
-    return (data: any) => _mapKeys(data, arg1);
-  }
-  return _mapKeys(arg1, arg2);
+export function mapKeys() {
+  return purry(_mapKeys, arguments);
 }
 
-function _mapKeys(obj: any, fn: (key: string, value: any) => any) {
-  return Object.keys(obj).reduce<any>((acc, key) => {
-    acc[fn(key, obj[key])] = obj[key];
-    return acc;
-  }, {});
+function _mapKeys<T extends object>(
+  data: T,
+  fn: (key: keyof T, value: Required<T>[keyof T]) => PropertyKey
+) {
+  const out: Partial<Record<PropertyKey, Required<T>[keyof T]>> = {};
+  for (const [key, value] of toPairs.strict(data)) {
+    out[fn(key, value)] = value;
+  }
+  return out;
 }

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -16,7 +16,7 @@ import { purry } from './purry';
  * @indexed
  * @category Array
  */
-export function mapToObj<T, K extends keyof any, V>(
+export function mapToObj<T, K extends PropertyKey, V>(
   array: ReadonlyArray<T>,
   fn: (element: T) => [K, V]
 ): Record<K, V>;
@@ -41,7 +41,7 @@ export function mapToObj<T, K extends keyof any, V>(
  * @indexed
  * @category Array
  */
-export function mapToObj<T, K extends keyof any, V>(
+export function mapToObj<T, K extends PropertyKey, V>(
   fn: (element: T) => [K, V]
 ): (array: ReadonlyArray<T>) => Record<K, V>;
 
@@ -51,20 +51,26 @@ export function mapToObj() {
 
 const _mapToObj =
   (indexed: boolean) =>
-  (array: Array<any>, fn: PredIndexedOptional<any, any>) => {
-    return array.reduce((result, element, index) => {
-      const [key, value] = indexed ? fn(element, index, array) : fn(element);
-      result[key] = value;
-      return result;
-    }, {});
+  (
+    array: ReadonlyArray<unknown>,
+    fn: PredIndexedOptional<unknown, [PropertyKey, unknown]>
+  ) => {
+    return array.reduce<Record<PropertyKey, unknown>>(
+      (result, element, index) => {
+        const [key, value] = indexed ? fn(element, index, array) : fn(element);
+        result[key] = value;
+        return result;
+      },
+      {}
+    );
   };
 
 export namespace mapToObj {
-  export function indexed<T, K extends keyof any, V>(
+  export function indexed<T, K extends PropertyKey, V>(
     array: ReadonlyArray<T>,
     fn: (element: T, index: number, array: ReadonlyArray<T>) => [K, V]
   ): Record<K, V>;
-  export function indexed<T, K extends keyof any, V>(
+  export function indexed<T, K extends PropertyKey, V>(
     fn: (element: T, index: number, array: ReadonlyArray<T>) => [K, V]
   ): (array: ReadonlyArray<T>) => Record<K, V>;
   export function indexed() {

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -1,8 +1,10 @@
 import { ObjectKeys } from './_types';
+import { purry } from './purry';
+import { toPairs } from './toPairs';
 
 /**
  * Maps values of `object` and keeps the same keys.
- * @param object the object to map
+ * @param data the object to map
  * @param fn the mapping function
  * @signature
  *    R.mapValues(object, fn)
@@ -11,8 +13,8 @@ import { ObjectKeys } from './_types';
  * @dataFirst
  * @category Object
  */
-export function mapValues<T extends Record<PropertyKey, any>, S>(
-  object: T,
+export function mapValues<T extends Record<PropertyKey, unknown>, S>(
+  data: T,
   fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S
 ): Record<ObjectKeys<T>, S>;
 
@@ -26,20 +28,21 @@ export function mapValues<T extends Record<PropertyKey, any>, S>(
  * @dataLast
  * @category Object
  */
-export function mapValues<T extends Record<PropertyKey, any>, S>(
+export function mapValues<T extends Record<PropertyKey, unknown>, S>(
   fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S
-): (object: T) => Record<ObjectKeys<T>, S>;
+): (data: T) => Record<ObjectKeys<T>, S>;
 
-export function mapValues(arg1: any, arg2?: any): any {
-  if (arguments.length === 1) {
-    return (data: any) => _mapValues(data, arg1);
-  }
-  return _mapValues(arg1, arg2);
+export function mapValues() {
+  return purry(_mapValues, arguments);
 }
 
-function _mapValues(obj: any, fn: (key: string, value: any) => any) {
-  return Object.keys(obj).reduce<any>((acc, key) => {
-    acc[key] = fn(obj[key], key);
-    return acc;
-  }, {});
+function _mapValues<T extends object>(
+  data: T,
+  fn: (value: Required<T>[keyof T], key: keyof T) => unknown
+) {
+  const out: Partial<Record<keyof T, unknown>> = {};
+  for (const [key, value] of toPairs.strict(data)) {
+    out[key] = fn(value, key);
+  }
+  return out;
 }

--- a/src/mergeAll.ts
+++ b/src/mergeAll.ts
@@ -18,6 +18,6 @@ export function mergeAll<A, B, C, D, E>(
 ): A & B & C & D & E;
 export function mergeAll(array: ReadonlyArray<object>): object;
 
-export function mergeAll(items: ReadonlyArray<any>) {
+export function mergeAll(items: ReadonlyArray<object>) {
   return items.reduce((acc, x) => ({ ...acc, ...x }), {});
 }

--- a/src/objOf.ts
+++ b/src/objOf.ts
@@ -29,6 +29,6 @@ export function objOf() {
   return purry(_objOf, arguments);
 }
 
-function _objOf(value: any, key: string) {
+function _objOf<T, K extends string>(value: T, key: K) {
   return { [key]: value };
 }

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -1,3 +1,4 @@
+import { keys } from './keys';
 import { purry } from './purry';
 
 /**
@@ -32,8 +33,15 @@ export function omitBy() {
   return purry(_omitBy, arguments);
 }
 
-function _omitBy(object: any, fn: (value: any, key: any) => boolean) {
-  return Object.keys(object).reduce<any>((acc, key) => {
+function _omitBy<T>(
+  object: T,
+  fn: <K extends keyof T>(value: T[K], key: K) => boolean
+) {
+  if (object === undefined || object === null) {
+    return object;
+  }
+
+  return keys.strict(object).reduce<Partial<T>>((acc, key) => {
     if (!fn(object[key], key)) {
       acc[key] = object[key];
     }

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -21,7 +21,7 @@ describe('data first', () => {
     expect(partition(array, x => x.a === 1)).toEqual(expected);
   });
   test('partition with type guard', () => {
-    const isNumber = function (value: any): value is number {
+    const isNumber = function (value: unknown): value is number {
       return typeof value === 'number';
     };
     const actual = partition([1, 'a', 2, 'b'], isNumber);

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -75,7 +75,7 @@ export function partition() {
 
 const _partition =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, any>) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
     const ret: [Array<T>, Array<T>] = [[], []];
     array.forEach((item, index) => {
       const matches = indexed ? fn(item, index, array) : fn(item);

--- a/src/pathOr.ts
+++ b/src/pathOr.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { purry } from './purry';
 
 /**

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -7,10 +7,6 @@ describe('data first', () => {
     const result = pick({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd']);
     expect(result).toStrictEqual({ a: 1, d: 4 });
   });
-  test('allow undefined or null', () => {
-    expect(pick(undefined as any, ['foo'])).toEqual({});
-    expect(pick(null as any, ['foo'])).toEqual({});
-  });
   test('support inherited properties', () => {
     class BaseClass {
       testProp() {

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -11,8 +11,8 @@ describe('data first', () => {
     expect(result).toStrictEqual({ A: 3, B: 4 });
   });
   test('allow undefined or null', () => {
-    expect(pickBy(undefined as any, (_, key) => key === 'foo')).toEqual({});
-    expect(pickBy(null as any, (_, key) => key === 'foo')).toEqual({});
+    expect(pickBy(undefined as unknown, (_, key) => key === 'foo')).toEqual({});
+    expect(pickBy(null as unknown, (_, key) => key === 'foo')).toEqual({});
   });
   test('allow partial type', () => {
     const result = pickBy(

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -1,3 +1,4 @@
+import { keys } from './keys';
 import { purry } from './purry';
 
 /**
@@ -32,11 +33,14 @@ export function pickBy() {
   return purry(_pickBy, arguments);
 }
 
-function _pickBy(object: any, fn: (value: any, key: any) => boolean) {
+function _pickBy<T>(
+  object: T,
+  fn: <K extends keyof T>(value: T[K], key: K) => boolean
+): Partial<T> {
   if (object == null) {
     return {};
   }
-  return Object.keys(object).reduce<any>((acc, key) => {
+  return keys.strict(object).reduce<Partial<T>>((acc, key) => {
     if (fn(object[key], key)) {
       acc[key] = object[key];
     }

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { LazyResult } from './_reduceLazy';
 
 /**

--- a/src/purry.test.ts
+++ b/src/purry.test.ts
@@ -5,21 +5,21 @@ function sub(a: number, b: number) {
 }
 
 test('all arguments', () => {
-  function fn(...args: Array<any>) {
+  function fn(...args: Array<unknown>) {
     return purry(sub, args);
   }
   expect(fn(10, 5)).toEqual(5);
 });
 
 test('1 missing', () => {
-  function fn(...args: Array<any>) {
+  function fn(...args: Array<unknown>) {
     return purry(sub, args);
   }
   expect(fn(5)(10)).toEqual(5);
 });
 
 test('wrong number of arguments', () => {
-  function fn(...args: Array<any>) {
+  function fn(...args: Array<unknown>) {
     return purry(sub, args);
   }
   expect(() => fn(5, 10, 40)).toThrowError('Wrong number of arguments');

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Creates a function with `data-first` and `data-last` signatures.
  *

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -48,7 +48,7 @@ export function reject() {
 
 const _reject =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
     return _reduceLazy(
       array,
       indexed ? reject.lazyIndexed(fn) : reject.lazy(fn),
@@ -59,7 +59,11 @@ const _reject =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
+    return (
+      value: T,
+      index?: number,
+      array?: ReadonlyArray<T>
+    ): LazyResult<T> => {
       const valid = indexed ? fn(value, index, array) : fn(value);
       if (!valid) {
         return {

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -43,6 +43,6 @@ export function reverse() {
   return purry(_reverse, arguments);
 }
 
-function _reverse(array: Array<any>) {
+function _reverse<T>(array: ReadonlyArray<T>): Array<T> {
   return array.slice().reverse();
 }

--- a/src/set.ts
+++ b/src/set.ts
@@ -31,7 +31,7 @@ export function set() {
   return purry(_set, arguments);
 }
 
-function _set(obj: any, prop: string, value: any) {
+function _set<T, K extends keyof T>(obj: T, prop: K, value: T[K]): T {
   return {
     ...obj,
     [prop]: value,

--- a/src/setPath.ts
+++ b/src/setPath.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { purry } from './purry';
 import { Path, SupportsValueAtPath, ValueAtPath } from './_paths';
 import { Narrow } from './_narrow';

--- a/src/splice.ts
+++ b/src/splice.ts
@@ -45,12 +45,12 @@ export function splice() {
   return purry(_splice, arguments);
 }
 
-function _splice(
-  items: ReadonlyArray<any>,
+function _splice<T>(
+  items: ReadonlyArray<T>,
   start: number,
   deleteCount: number,
-  replacement: ReadonlyArray<any>
-): Array<any> {
+  replacement: ReadonlyArray<T>
+): Array<T> {
   const result = [...items];
   result.splice(start, deleteCount, ...replacement);
   return result;

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -9,7 +9,7 @@
 export function stringToPath<Path extends string>(
   path: Path
 ): StringToPath<Path> {
-  return _stringToPath(path) as any;
+  return _stringToPath(path) as StringToPath<Path>;
 }
 
 function _stringToPath(path: string): Array<string> {

--- a/src/swapProps.ts
+++ b/src/swapProps.ts
@@ -62,7 +62,7 @@ function _swapProps<T extends object, K1 extends keyof T, K2 extends keyof T>(
   key1: K1,
   key2: K2
 ): {
-  [K in PropertyKey]: any;
+  [K in PropertyKey]: unknown;
 } {
   const { [key1]: value1, [key2]: value2 } = obj;
   return {

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -51,7 +51,7 @@ describe('data last', () => {
 
   it('should infer types after tapping function reference with parameter type any', () => {
     // (same as console.log)
-    function foo(x: any) {
+    function foo(x: unknown) {
       return x;
     }
 

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -38,7 +38,7 @@ export function tap<T>(value: T, fn: (value: T) => void): T;
  * @dataLast
  * @category Other
  */
-export function tap<T, F extends (value: T) => any>(fn: F): (value: T) => T;
+export function tap<T, F extends (value: T) => unknown>(fn: F): (value: T) => T;
 
 export function tap() {
   return purry(_tap, arguments);

--- a/src/type-fest/is-any.ts
+++ b/src/type-fest/is-any.ts
@@ -1,0 +1,1 @@
+export type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,7 +16,7 @@
  *    R.type(undefined); //=> "Undefined"
  * @category Type
  */
-export function type(val: any) {
+export function type(val: unknown) {
   return val === null
     ? 'Null'
     : val === undefined

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -31,9 +31,9 @@ function _uniq<T>(array: Array<T>) {
 }
 
 export namespace uniq {
-  export function lazy() {
-    const set = new Set<unknown>();
-    return (value: unknown): LazyResult<unknown> => {
+  export function lazy<T>() {
+    const set = new Set<T>();
+    return (value: T): LazyResult<T> => {
       if (set.has(value)) {
         return {
           done: false,

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -32,8 +32,8 @@ function _uniq<T>(array: Array<T>) {
 
 export namespace uniq {
   export function lazy() {
-    const set = new Set<any>();
-    return (value: any): LazyResult<any> => {
+    const set = new Set<unknown>();
+    return (value: unknown): LazyResult<unknown> => {
       if (set.has(value)) {
         return {
           done: false,

--- a/src/uniqBy.ts
+++ b/src/uniqBy.ts
@@ -38,9 +38,9 @@ function _uniqBy<T, K>(array: Array<T>, transformer: (item: T) => K) {
   return _reduceLazy(array, lazyUniqBy(transformer));
 }
 
-function lazyUniqBy(transformer: (item: any) => any) {
-  const set = new Set<any>();
-  return (value: any): LazyResult<any> => {
+function lazyUniqBy<T, K>(transformer: (item: T) => K) {
+  const set = new Set<K>();
+  return (value: T): LazyResult<T> => {
     const appliedItem = transformer(value);
     if (set.has(appliedItem)) {
       return {

--- a/src/uniqWith.ts
+++ b/src/uniqWith.ts
@@ -49,13 +49,17 @@ export function uniqWith() {
   return purry(_uniqWith, arguments, uniqWith.lazy);
 }
 
-function _uniqWith<T>(array: Array<T>, isEquals: IsEquals<T>) {
+function _uniqWith<T>(array: ReadonlyArray<T>, isEquals: IsEquals<T>) {
   const lazy = uniqWith.lazy(isEquals);
   return _reduceLazy(array, lazy, true);
 }
 
 function _lazy<T>(isEquals: IsEquals<T>) {
-  return (value: T, index?: number, array?: Array<T>): LazyResult<T> => {
+  return (
+    value: T,
+    index?: number,
+    array?: ReadonlyArray<T>
+  ): LazyResult<T> => {
     if (
       array &&
       array.findIndex(otherValue => isEquals(value, otherValue)) === index

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -1,3 +1,5 @@
+type ZippingFunction<F = unknown, S = unknown, R = unknown> = (f: F, s: S) => R;
+
 /**
  * Creates a new list from two supplied lists by calling the supplied function
  * with the same-positioned element from each list.
@@ -12,9 +14,9 @@
  * @category Array
  */
 export function zipWith<F, S, R>(
-  first: Array<F>,
-  second: Array<S>,
-  fn: (f: F, s: S) => R
+  first: ReadonlyArray<F>,
+  second: ReadonlyArray<S>,
+  fn: ZippingFunction<F, S, R>
 ): Array<R>;
 
 /**
@@ -29,8 +31,8 @@ export function zipWith<F, S, R>(
  * @category Array
  */
 export function zipWith<F, S, R>(
-  fn: (f: F, s: S) => R
-): (first: Array<F>, second: Array<S>) => Array<R>;
+  fn: ZippingFunction<F, S, R>
+): (first: ReadonlyArray<F>, second: ReadonlyArray<S>) => Array<R>;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -45,31 +47,33 @@ export function zipWith<F, S, R>(
  * @category Array
  */
 export function zipWith<F, S, R>(
-  fn: (f: F, s: S) => R,
-  second: Array<S>
-): (first: Array<F>) => Array<R>;
+  fn: ZippingFunction<F, S, R>,
+  second: ReadonlyArray<S>
+): (first: ReadonlyArray<F>) => Array<R>;
 
-export function zipWith() {
-  const args = Array.from(arguments);
-  if (typeof args[0] === 'function' && args.length === 1) {
-    return function (f: any, s: any) {
-      return _zipWith(f, s, args[0]);
-    };
+export function zipWith(
+  arg0: ZippingFunction | ReadonlyArray<unknown>,
+  arg1?: ReadonlyArray<unknown>,
+  arg2?: ZippingFunction
+): unknown {
+  if (typeof arg0 === 'function') {
+    return arg1 === undefined
+      ? (f: ReadonlyArray<unknown>, s: ReadonlyArray<unknown>) =>
+          _zipWith(f, s, arg0)
+      : (f: ReadonlyArray<unknown>) => _zipWith(f, arg1, arg0);
   }
 
-  if (typeof args[0] === 'function' && args.length === 2) {
-    return function (f: any) {
-      return _zipWith(f, args[1], args[0]);
-    };
+  if (arg1 === undefined || arg2 === undefined) {
+    throw new Error('zipWith: Missing arguments in dataFirst function call');
   }
 
-  return _zipWith(args[0], args[1], args[2]);
+  return _zipWith(arg0, arg1, arg2);
 }
 
 function _zipWith<F, S, R>(
-  first: Array<F>,
-  second: Array<S>,
-  fn: (f: F, s: S) => R
+  first: ReadonlyArray<F>,
+  second: ReadonlyArray<S>,
+  fn: ZippingFunction<F, S, R>
 ) {
   const resultLength =
     first.length > second.length ? second.length : first.length;

--- a/test/types_data_provider.ts
+++ b/test/types_data_provider.ts
@@ -4,88 +4,29 @@ export class TestClass {
   }
 }
 
-type TestObj =
-  | (() => void)
-  | [number, number, number]
-  | { a: string }
-  | Array<number>
-  | boolean
-  | Date
-  | Error
-  | Map<string, string>
-  | null
-  | number
-  | Promise<number>
-  | RegExp
-  | Set<string>
-  | string
-  | symbol
-  | TestClass
-  | Uint8Array
-  | undefined;
+export const TYPES_DATA_PROVIDER = {
+  array: [1, 2, 3] as Array<number>,
+  boolean: false as boolean,
+  date: new Date('1985-07-24T07:40:00.000Z'),
+  error: new Error('asd'),
+  function: () => {
+    /* (intentionally empty) */
+  },
+  instance: new TestClass(),
+  map: new Map<string, string>(),
+  null: null,
+  number: 5 as number,
+  object: { a: 'asd' },
+  promise: Promise.resolve(5),
+  regex: /test/gu,
+  set: new Set<string>(),
+  string: 'text' as string,
+  symbol: Symbol('symbol'),
+  tuple: [1, 2, 3] as [number, number, number],
+  typedArray: new Uint8Array(1),
+  undefined: undefined,
+} as const;
 
-const ALL_TYPES = [
-  'array',
-  'boolean',
-  'date',
-  'error',
-  'function',
-  'instance',
-  'map',
-  'null',
-  'number',
-  'object',
-  'promise',
-  'regex',
-  'set',
-  'string',
-  'symbol',
-  'tuple',
-  'typedArray',
-  'undefined',
-] as const;
-type Type = (typeof ALL_TYPES)[number];
-
-export const typesDataProvider = (t: Type): TestObj => {
-  switch (t) {
-    case 'number':
-      return 5;
-    case 'array':
-    case 'tuple':
-      return [1, 2, 3];
-    case 'boolean':
-      return false;
-    case 'date':
-      return new Date('1985-07-24T07:40:00.000Z');
-    case 'function':
-      return () => {
-        /* (intentionally empty) */
-      };
-    case 'null':
-      return null;
-    case 'promise':
-      return Promise.resolve(5);
-    case 'string':
-      return 'text';
-    case 'object':
-      return { a: 'asd' };
-    case 'error':
-      return new Error('asd');
-    case 'symbol':
-      return Symbol('symbol');
-    case 'undefined':
-      return undefined;
-    case 'instance':
-      return new TestClass();
-    case 'regex':
-      return /test/gu;
-    case 'map':
-      return new Map();
-    case 'set':
-      return new Set();
-    case 'typedArray':
-      return new Uint8Array(1);
-  }
-};
-
-export const ALL_TYPES_DATA_PROVIDER = ALL_TYPES.map(typesDataProvider);
+export const ALL_TYPES_DATA_PROVIDER = Object.values(TYPES_DATA_PROVIDER);
+export type AllTypesDataProviderTypes =
+  (typeof ALL_TYPES_DATA_PROVIDER)[number];


### PR DESCRIPTION
Reinstate the lint warning about `any` and fix typing throughout the project. The goal for this PR is to ensure that the lint rule can check new PRs and prevent adding any additional `any` in the codebase, and to reduce the number of rejections for those issues in PRs.

Bigger changes that happened here:
* Type Guards now accept `any` and narrow it properly.
* Rewrote the tests for all the guards, they weren't testing some cases correctly due to the usage of `assertType` instead of `expectTypeOf` which is stricter.
* Rewrote some functions here and there, mainly the implementation, not the declarations, so it shouldn't break anyone's code: `zipWith`, `pickBy` and `omitBy`
* Made arrays readonly where I could.