### PR TITLE
build: generate declarations with comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   ],
   "scripts": {
     "build": "npm run clean && npm run build:es && npm run build:cjs",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir \"./dist/commonjs\"",
-    "build:es": "tsc --project tsconfig.build.json --module esnext --outDir \"./dist/es\"",
+    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir \"./dist/commonjs\" && npm run build:cjs:types",
+    "build:cjs:types": "tsc --project tsconfig.build.types.json --module commonjs --outDir \"./dist/commonjs\"",
+    "build:es": "tsc --project tsconfig.build.json --module esnext --outDir \"./dist/es\" && npm run build:es:types",
+    "build:es:types": "tsc --project tsconfig.build.types.json --module esnext --outDir \"./dist/es\"",
     "clean": "rm -rf ./dist && mkdir dist",
     "compile": "tsc",
     "compile:dist": "tsc --project tsconfig.dist.json",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,8 +5,6 @@
   "exclude": ["**/*.test.ts"],
 
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "noEmit": false /* Enabled in the base config */,
     "removeComments": true
   }

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "removeComments": false
+  }
+}


### PR DESCRIPTION
Generate `d.ts` with tsdoc comments by running tsc for type declarations separately from `.js` sources.

Related Issue: https://github.com/remeda/remeda/issues/533

---

Make sure that you:

- [ x] Typedoc added for new methods and updated for changed
- [ x] Tests added for new methods and updated for changed
- [ x] New methods added to `src/index.ts`
- [ x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
