### PR TITLE
fix: remove more `any` from the codebase

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,6 @@ module.exports = tseslint.config(
 
       // TODO: A lot of related typing issues arise from the fact that `any` is
       // used throughout the codebase.
-      '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ const tseslint = require('typescript-eslint');
 
 module.exports = tseslint.config(
   {
-    ignores: ['dist', 'docs'],
+    ignores: ['dist', 'docs', 'examples'],
   },
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,

--- a/src/_purryOn.ts
+++ b/src/_purryOn.ts
@@ -15,7 +15,6 @@ export function purryOn<T>(
 ): unknown {
   // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
   const callArgs = Array.from(args) as ReadonlyArray<unknown>;
-
   return isArg(args[0])
     ? // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
       (data: unknown) => implementation(data, ...callArgs)

--- a/src/_purryOn.ts
+++ b/src/_purryOn.ts
@@ -13,11 +13,9 @@ export function purryOn<T>(
   ) => unknown,
   args: IArguments
 ): unknown {
-  // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
-  const callArgs = Array.from(args) as ReadonlyArray<unknown>;
   return isArg(args[0])
     ? // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      (data: unknown) => implementation(data, ...callArgs)
+      (data: unknown) => implementation(data, ...args)
     : // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      implementation(...callArgs);
+      implementation(...args);
 }

--- a/src/_purryOn.ts
+++ b/src/_purryOn.ts
@@ -13,9 +13,12 @@ export function purryOn<T>(
   ) => unknown,
   args: IArguments
 ): unknown {
+  // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
+  const callArgs = Array.from(args) as ReadonlyArray<unknown>;
+
   return isArg(args[0])
     ? // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      (data: unknown) => implementation(data, ...args)
+      (data: unknown) => implementation(data, ...callArgs)
     : // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      implementation(...args);
+      implementation(...callArgs);
 }

--- a/src/_purryOrderRules.ts
+++ b/src/_purryOrderRules.ts
@@ -100,7 +100,9 @@ export function purryOrderRulesWithArgument(
   ) => unknown,
   inputArgs: IArguments
 ): unknown {
-  const [first, second, ...rest] = Array.from(inputArgs);
+  const [first, second, ...rest] = Array.from(
+    inputArgs
+  ) as ReadonlyArray<unknown>;
 
   // We need to pull the `n` argument out to make it work with purryOrderRules.
   let arg: unknown;
@@ -162,10 +164,12 @@ function isOrderRule<T>(x: unknown): x is OrderRule<T> {
     return false;
   }
 
-  const [maybeProjection, maybeDirection, ...rest] = x;
+  const [maybeProjection, maybeDirection, ...rest] =
+    x as ReadonlyArray<unknown>;
 
   return (
     isProjection(maybeProjection) &&
+    typeof maybeDirection === 'string' &&
     maybeDirection in COMPARATORS &&
     // Has to be a 2-tuple
     rest.length === 0

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- FIXME! */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment -- FIXME! */
 
 import { clone } from './clone';
 

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- FIXME! */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment -- FIXME! */
 
 // from https://github.com/ramda/ramda/blob/master/source/internal/_clone.js
 

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -208,7 +208,7 @@ function isCase(maybeCase: unknown): maybeCase is Case<unknown, unknown> {
     return false;
   }
 
-  const [when, then, ...rest] = maybeCase;
+  const [when, then, ...rest] = maybeCase as ReadonlyArray<unknown>;
   return (
     typeof when === 'function' &&
     when.length <= 1 &&

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any --
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment --
  * Function inference doesn't work when `unknown` is used as the parameters
  * generic type, it **has** to be `any`.
  */

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument -- FIXME! */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment -- FIXME! */
 
 import { _reduceLazy, LazyResult } from './_reduceLazy';
 import { purry } from './purry';

--- a/src/forEachObj.test.ts
+++ b/src/forEachObj.test.ts
@@ -36,7 +36,7 @@ describe('data_last', () => {
   });
 
   it('forEachObj.indexed', () => {
-    const cb = vi.fn();
+    const cb = vi.fn<[number, string, typeof obj]>();
     const result = pipe(obj, forEachObj.indexed(cb));
     expect(cb.mock.calls).toEqual([
       [1, 'a', obj],

--- a/src/isArray.test.ts
+++ b/src/isArray.test.ts
@@ -7,7 +7,7 @@ import { isArray } from './isArray';
 
 describe('isArray', () => {
   it('should infer ReadonlyArray<unknown> when given any', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- explicitly testing `any`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
     const data = [] as any;
     if (isArray(data)) {
       expectTypeOf(data).not.toBeAny();

--- a/src/isBoolean.test.ts
+++ b/src/isBoolean.test.ts
@@ -23,7 +23,7 @@ describe('isBoolean', () => {
   });
 
   it('should narrow `any`', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- We are explicitly testing the `any` case here
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
     const data = TYPES_DATA_PROVIDER.boolean as any;
     if (isBoolean(data)) {
       expect(typeof data).toEqual('boolean');

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -122,7 +122,7 @@ describe('typing', () => {
   });
 
   test('Can narrow down `any`', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
     const data = { hello: 'world' } as any;
     if (isObjectType(data)) {
       expectTypeOf(data).toEqualTypeOf<object>();

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -78,7 +78,7 @@ describe('typing', () => {
   });
 
   test('Can narrow down `any`', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly testing `any`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
     const data = { hello: 'world' } as any;
     if (isPlainObject(data)) {
       expectTypeOf(data).toEqualTypeOf<Record<PropertyKey, unknown>>();

--- a/src/isPlainObject.ts
+++ b/src/isPlainObject.ts
@@ -32,6 +32,7 @@ export function isPlainObject<T>(
     return false;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- This is a low-level check, we can't avoid it being typed as `any`.
   const proto = Object.getPrototypeOf(data);
   return proto === null || proto === Object.prototype;
 }

--- a/src/isSymbol.test.ts
+++ b/src/isSymbol.test.ts
@@ -23,7 +23,7 @@ describe('isSymbol', () => {
   });
 
   it('should work even if data type is `any`', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Explicitly checking any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly checking any
     const data = TYPES_DATA_PROVIDER.symbol as any;
     if (isSymbol(data)) {
       expect(typeof data).toEqual('symbol');

--- a/src/pathOr.ts
+++ b/src/pathOr.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { purry } from './purry';
 
 /**
@@ -148,13 +146,18 @@ export function pathOr() {
   return purry(_pathOr, arguments);
 }
 
-function _pathOr(object: any, path: Array<any>, defaultValue: any): any {
-  let current = object;
+function _pathOr(
+  data: unknown,
+  path: ReadonlyArray<PropertyKey>,
+  defaultValue: unknown
+): unknown {
+  let current = data;
   for (const prop of path) {
-    if (current == null || current[prop] == null) {
-      return defaultValue;
+    if (current == null) {
+      break;
     }
-    current = current[prop];
+    current = (current as Record<PropertyKey, unknown>)[prop];
   }
-  return current;
+
+  return current ?? defaultValue;
 }

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -15,9 +15,9 @@ describe('data first', () => {
     }
     class TestClass extends BaseClass {}
     const testClass = new TestClass();
-    expect(pick(testClass, ['testProp'])).toEqual({
-      testProp: expect.any(Function),
-    });
+    expectTypeOf(pick(testClass, ['testProp'])).toEqualTypeOf<{
+      testProp: () => string;
+    }>();
   });
 });
 

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -229,11 +229,25 @@ export function pipe(
 
     const accumulator: Array<unknown> = [];
 
-    for (const item of output) {
-      if (_processItem(item, accumulator, lazySequence)) {
+    const iterator = output[Symbol.iterator]();
+
+    // eslint-disable-next-line no-constant-condition -- TODO: Once we bump the TS target version above ES5 we can use the built-in for-of loop instead.
+    while (true) {
+      const result = iterator.next();
+      if (result.done ?? false) {
+        break;
+      }
+
+      const shouldExitEarly = _processItem(
+        result.value,
+        accumulator,
+        lazySequence
+      );
+      if (shouldExitEarly) {
         break;
       }
     }
+
     const { isSingle } = lazySequence[lazySequence.length - 1]!;
     if (isSingle) {
       output = accumulator[0];

--- a/src/purry.test.ts
+++ b/src/purry.test.ts
@@ -5,21 +5,22 @@ function sub(a: number, b: number) {
 }
 
 test('all arguments', () => {
-  function fn(...args: Array<unknown>) {
+  function fn(...args: ReadonlyArray<unknown>) {
     return purry(sub, args);
   }
   expect(fn(10, 5)).toEqual(5);
 });
 
 test('1 missing', () => {
-  function fn(...args: Array<unknown>) {
+  function fn(...args: ReadonlyArray<unknown>) {
     return purry(sub, args);
   }
-  expect(fn(5)(10)).toEqual(5);
+  const purried = fn(5) as (...args: ReadonlyArray<unknown>) => unknown;
+  expect(purried(10)).toEqual(5);
 });
 
 test('wrong number of arguments', () => {
-  function fn(...args: Array<unknown>) {
+  function fn(...args: ReadonlyArray<unknown>) {
     return purry(sub, args);
   }
   expect(() => fn(5, 10, 40)).toThrowError('Wrong number of arguments');

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+type LazyFactory = (...args: any) => unknown;
+
+type MaybeLazyFunction = {
+  (...args: any): unknown;
+  lazy?: LazyFactory;
+};
+
 /**
  * Creates a function with `data-first` and `data-last` signatures.
  *
@@ -31,22 +38,22 @@
  * @category Function
  */
 export function purry(
-  fn: any,
-  args: IArguments | ReadonlyArray<any>,
-  lazy?: any
-) {
+  fn: MaybeLazyFunction,
+  args: IArguments | ReadonlyArray<unknown>,
+  lazyFactory?: LazyFactory
+): unknown {
   const diff = fn.length - args.length;
-  const arrayArgs = Array.from(args);
   if (diff === 0) {
-    return fn(...arrayArgs);
+    return fn(...args);
   }
+
   if (diff === 1) {
-    const ret: any = (data: any) => fn(data, ...arrayArgs);
-    if (lazy || fn.lazy) {
-      ret.lazy = lazy || fn.lazy;
-      ret.lazyArgs = args;
-    }
-    return ret;
+    const ret = (data: unknown) => fn(data, ...args);
+    const lazy = lazyFactory ?? fn.lazy;
+    return lazy === undefined
+      ? ret
+      : Object.assign(ret, { lazy, lazyArgs: args });
   }
+
   throw new Error('Wrong number of arguments');
 }

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -42,13 +42,16 @@ export function purry(
   args: IArguments | ReadonlyArray<unknown>,
   lazyFactory?: LazyFactory
 ): unknown {
+  // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
+  const callArgs = Array.from(args) as ReadonlyArray<unknown>;
+
   const diff = fn.length - args.length;
   if (diff === 0) {
-    return fn(...args);
+    return fn(...callArgs);
   }
 
   if (diff === 1) {
-    const ret = (data: unknown) => fn(data, ...args);
+    const ret = (data: unknown) => fn(data, ...callArgs);
     const lazy = lazyFactory ?? fn.lazy;
     return lazy === undefined
       ? ret

--- a/src/setPath.ts
+++ b/src/setPath.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- FIXME! */
 
 import { purry } from './purry';
 import { Path, SupportsValueAtPath, ValueAtPath } from './_paths';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "types": ["vitest/globals"],
 
     // EMIT
+    "downlevelIteration": true,
     "noEmit": true,
 
     // JAVASCRIPT SUPPORT

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "types": ["vitest/globals"],
 
     // EMIT
-    "downlevelIteration": true,
     "noEmit": true,
 
     // JAVASCRIPT SUPPORT


### PR DESCRIPTION
Continuing to clean up and strictify the codebase by removing any `any`, using eslint to guide me.

The main change here (and the reason i'm adding a "fix" type so that we bump a version) is the changes to purry/pipe, including changing the compilation flag to allow iterating in es5