### PR TITLE
fix: opinionated lint rules (auto-fixers)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -233,6 +233,8 @@ module.exports = tseslint.config(
       ],
 
       // Security & Correctness
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "@typescript-eslint/prefer-readonly-parameter-types": "error",
       "@typescript-eslint/no-useless-empty-export": "error",
       "@typescript-eslint/prefer-regexp-exec": "error",
       // TODO: Requires manual fixes, enable in a separate PR.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call -- I don't understand FlatConfigs, this follows the typescript example so I don't know how to fix it... */
-
 const js = require("@eslint/js");
 const tseslint = require("typescript-eslint");
 
@@ -9,6 +7,7 @@ module.exports = tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -25,24 +24,18 @@ module.exports = tseslint.config(
       // etc...) via namespaces by design.
       "@typescript-eslint/no-namespace": "off",
 
-      "@typescript-eslint/array-type": [
-        "error",
-        {
-          // We like it this way...
-          default: "generic",
-        },
-      ],
+      // @see https://tkdodo.eu/blog/array-types-in-type-script
+      "@typescript-eslint/array-type": ["error", { default: "generic" }],
 
-      // TODO: The idiom for using `purry` right now is via the `arguments`
-      // reserved keyword, but it's recommended to use a variadic instead (e.g.
-      // `function foo(...args: readonly unknown[])`)
+      // TODO: Once we bump our Typescript target version to ES2015 or above we
+      // can migrate all `argument` to variadic rest params. This will remove
+      // a step currently done in all purried functions to convert the arguments
+      // into an array.
       "prefer-rest-params": "off",
 
       // This isn't very useful in a utility library, a lot of utilities need to
       // access arrays in a random-access way.
-      // TODO: Once we bump our typescript `target` we should enable this rule
-      // again, go over all the non-null-assertions, and see which ones are due to
-      // a for loop which could use `Array.prototype.entries` instead.
+      // TODO: Once we bump our typescript `target` we should enable this rule again, go over all the non-null-assertions, and see which ones are due to a for loop which could use `Array.prototype.entries` instead.
       "@typescript-eslint/no-non-null-assertion": "off",
 
       // When our return type is just `undefined` (like `first([])`) this rule
@@ -52,12 +45,225 @@ module.exports = tseslint.config(
       // what this rule expects us to do in those cases so turning it off for
       // now instead...
       "@typescript-eslint/no-confusing-void-expression": "off",
+
+      // TODO: Once we bump our typescript `target` we should enable this rule
+      "prefer-object-has-own": "off",
+
+      // TODO: Once we bump our minimum Typescript version above 4.5 we need to change the linting to prefer the inline style which allows us to combine type imports and regular ones:
+      "no-duplicate-imports": "off",
+      "@typescript-eslint/consistent-type-imports": ["warn"],
+
+      // -----------------------------------------------------------------------
+      // TODO: These rules are part of the typescript configs but require manual fixes which I want to do in a separate PR for easier reviewing and reverting. Turning them off for now so that our CI is green.
+      "@typescript-eslint/class-literal-property-style": "off",
+      "@typescript-eslint/no-empty-function": "off",
+      "@typescript-eslint/prefer-nullish-coalescing": "off",
+
+      // -----------------------------------------------------------------------
+
+      // === ESLint ============================================================
+      // (We are assuming that the config is extended by eslint's: recommended
+      // extension)
+
+      // --- Optional Rules ----------------------------------------------------
+      // These aren't enabled by default
+
+      // Possible Problems
+      "array-callback-return": [
+        "warn",
+        {
+          checkForEach: true,
+          // Recommended by unicorn
+          // @see https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-undefined.md
+          allowImplicit: true,
+        },
+      ],
+      "no-await-in-loop": "error",
+      "no-constant-binary-expression": "error",
+      "no-new-native-nonconstructor": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-promise-executor-return": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-self-compare": "error",
+      "no-template-curly-in-string": "warn",
+      "no-unmodified-loop-condition": "error",
+      "no-unreachable-loop": "error",
+      "require-atomic-updates": "error",
+
+      // Suggestions
+      "arrow-body-style": "warn",
+      curly: "error",
+      "default-case-last": "warn",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "dot-notation": "warn",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // eqeqeq: ["error", "always", { null: "always" }],
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "func-style": ["error", "declaration", { allowArrowFunctions: true }],
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "guard-for-in": "error",
+      "logical-assignment-operators": "warn",
+      "operator-assignment": "warn",
+      "object-shorthand": "warn",
+      "prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
+      "prefer-const": "error",
+      "prefer-exponentiation-operator": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "prefer-named-capture-group": "warn",
+      "prefer-numeric-literals": "error",
+      "prefer-object-spread": "error",
+      "prefer-promise-reject-errors": ["error", { allowEmptyReject: false }],
+      "prefer-regex-literals": ["error", { disallowRedundantWrapping: true }],
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "require-await": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "require-unicode-regexp": "warn",
+      "symbol-description": "warn",
+
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-bitwise": "warn",
+      "no-caller": "error",
+      "no-console": "error",
+      "no-else-return": ["warn", { allowElseIf: false }],
+      "no-eval": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-label": "error",
+      "no-implicit-coercion": ["error", { disallowTemplateShorthand: true }],
+      "no-implied-eval": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": "error",
+      "no-lone-blocks": "error",
+      "no-lonely-if": "warn",
+      "no-multi-assign": "error",
+      "no-negated-condition": "warn",
+      "no-new": "error",
+      "no-new-func": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-new-wrappers": "error",
+      "no-object-constructor": "error",
+      "no-octal-escape": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-param-reassign": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-plusplus": ["warn", { allowForLoopAfterthoughts: true }],
+      "no-proto": "error",
+      "no-return-assign": ["warn", "always"],
+      "no-script-url": "error",
+      "no-sequences": ["error", { allowInParentheses: false }],
+      "no-throw-literal": "error",
+      "no-unneeded-ternary": "warn",
+      "no-useless-call": "error",
+      "no-useless-computed-key": "warn",
+      "no-useless-concat": "warn",
+      "no-useless-rename": "error",
+
+      // === Typescript ========================================================
+      // (We are assuming that the config is extended by typescript's:
+      // strict-type-checked, and stylistic-type-checked extensions)
+
+      // --- Overrides ---------------------------------------------------------
+      // These are rules defined in the recommended extension that we needed to
+      // make changes to.
+
+      // Types are actually stricter than interfaces because they can't be
+      // extended via declaration merging, meaning they are immune to some
+      // typing edge-cases that interfaces aren't; in @typescript-eslint's
+      // "strict" extension this rule is defined the opposite way though(?!).
+      "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
+
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          // The default config for this rule doesn't provide *some* way of
+          // ignoring an unused argument, and we need one!
+          argsIgnorePattern: "^_",
+          // This allows removing props by destructuring an object, which is
+          // useful in arrow functions.
+          ignoreRestSiblings: true,
+        },
+      ],
+
+      // --- Optional ----------------------------------------------------------
+      // These aren't enabled by default
+
+      // Style & Conventions
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "prefer-destructuring": "off",
+      // "@typescript-eslint/prefer-destructuring": [
+      //   "warn",
+      //   { array: true, object: true },
+      //   { enforceForRenamedProperties: true },
+      // ],
+      "@typescript-eslint/sort-type-constituents": "warn",
+      "@typescript-eslint/promise-function-async": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-unused-expressions": "off",
+      // "@typescript-eslint/no-unused-expressions": [
+      //   "error",
+      //   { enforceForJSX: true },
+      // ],
+      "no-use-before-define": "off",
+      "@typescript-eslint/no-use-before-define": [
+        "error",
+        // We just want to ensure that types are defined before they are used,
+        // other than that we don't need this rule...
+        { functions: false, variables: false },
+      ],
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "@typescript-eslint/strict-boolean-expressions": [
+      //   "warn",
+      //   {
+      //     // As strict as possible...
+      //     allowString: false,
+      //     allowNumber: false,
+      //     allowNullableObject: false,
+      //   },
+      // ],
+      // @see https://github.com/prettier/eslint-config-prettier#forbid-unnecessary-backticks
+      quotes: "off",
+      "@typescript-eslint/quotes": [
+        "warn",
+        "double",
+        { avoidEscape: true, allowTemplateLiterals: false },
+      ],
+
+      // Security & Correctness
+      "@typescript-eslint/no-useless-empty-export": "error",
+      "@typescript-eslint/prefer-regexp-exec": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "@typescript-eslint/require-array-sort-compare": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        { requireDefaultForNonUnion: true },
+      ],
+      "default-param-last": "off",
+      "@typescript-eslint/default-param-last": "error",
+      "no-return-await": "off",
+      "@typescript-eslint/return-await": ["error", "always"],
+      "@typescript-eslint/method-signature-style": "error",
+      "no-loop-func": "off",
+      "@typescript-eslint/no-loop-func": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      // TODO: Requires manual fixes, enable in a separate PR.
+      // "no-shadow": "off",
+      // "@typescript-eslint/no-shadow": [
+      //   "error",
+      //   { ignoreTypeValueShadow: false },
+      // ],
+      "@typescript-eslint/no-unsafe-unary-minus": "error",
     },
   },
   {
     files: ["*.config.js"],
     rules: {
       "no-undef": "off",
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-var-requires": "off",
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,9 +65,6 @@ module.exports = tseslint.config(
       // (We are assuming that the config is extended by eslint's: recommended
       // extension)
 
-      // --- Optional Rules ----------------------------------------------------
-      // These aren't enabled by default
-
       // Possible Problems
       "array-callback-return": [
         "warn",

--- a/src/_narrow.ts
+++ b/src/_narrow.ts
@@ -24,7 +24,7 @@ export type Try<A1, A2, Catch = never> = A1 extends A2 ? A1 : Catch;
 /**
  * Describes types that can be narrowed
  */
-export type Narrowable = string | number | bigint | boolean;
+export type Narrowable = bigint | boolean | number | string;
 
 /**
  * @hidden

--- a/src/_paths.ts
+++ b/src/_paths.ts
@@ -4,8 +4,8 @@ export type Path<
 > = Obj extends Primitive
   ? Prefix
   : Obj extends Array<infer Item>
-    ? Prefix | Path<Item, [...Prefix, number]>
-    : Prefix | PathsOfObject<Obj, Prefix>;
+    ? Path<Item, [...Prefix, number]> | Prefix
+    : PathsOfObject<Obj, Prefix> | Prefix;
 
 type PathsOfObject<Obj, Prefix extends Array<PropertyKey>> = {
   [K in keyof Obj]: Path<Obj[K], [...Prefix, K]>;
@@ -27,4 +27,4 @@ export type ValueAtPath<
 export type SupportsValueAtPath<Obj, Path extends Array<PropertyKey>, Value> =
   Value extends ValueAtPath<Obj, Path> ? Obj : never;
 
-type Primitive = string | number | boolean | null | undefined | symbol;
+type Primitive = boolean | number | string | symbol | null | undefined;

--- a/src/_purryOrderRules.ts
+++ b/src/_purryOrderRules.ts
@@ -40,13 +40,13 @@ type Projection<T> = (x: T) => Comparable;
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#type_coercion
 type Comparable =
   | ComparablePrimitive
-  | { [Symbol.toPrimitive](hint: string): ComparablePrimitive }
-  | { valueOf(): ComparablePrimitive }
-  | { toString(): string };
+  | { [Symbol.toPrimitive]: (hint: string) => ComparablePrimitive }
+  | { toString: () => string }
+  | { valueOf: () => ComparablePrimitive };
 
 //  Notice that `boolean` is special in that it is coerced as a number (0 for
 // `false`, 1 for `true`) implicitly.
-type ComparablePrimitive = number | string | boolean;
+type ComparablePrimitive = boolean | number | string;
 
 /**
  * Allows functions that want to handle a variadic number of order rules a
@@ -66,8 +66,8 @@ export function purryOrderRules<T>(
   const [dataOrRule, ...rules] = (
     Array.isArray(inputArgs) ? inputArgs : Array.from(inputArgs)
   ) as
-    | [data: ReadonlyArray<T>, ...rules: Readonly<NonEmptyArray<OrderRule<T>>>]
-    | Readonly<NonEmptyArray<OrderRule<T>>>;
+    | Readonly<NonEmptyArray<OrderRule<T>>>
+    | [data: ReadonlyArray<T>, ...rules: Readonly<NonEmptyArray<OrderRule<T>>>];
 
   if (!isOrderRule<T>(dataOrRule)) {
     // dataFirst!

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -1,25 +1,25 @@
-export type LazyResult<T> = LazyEmpty | LazyNext<T> | LazyMany<T>;
+export type LazyResult<T> = LazyEmpty | LazyMany<T> | LazyNext<T>;
 
-interface LazyEmpty {
+type LazyEmpty = {
   done: boolean;
   hasNext: false;
   hasMany?: false | undefined;
   next?: undefined;
-}
+};
 
-interface LazyNext<T> {
+type LazyNext<T> = {
   done: boolean;
   hasNext: true;
   hasMany?: false | undefined;
   next: T;
-}
+};
 
-interface LazyMany<T> {
+type LazyMany<T> = {
   done: boolean;
   hasNext: true;
   hasMany: true;
   next: Array<T>;
-}
+};
 
 export function _reduceLazy<T, K>(
   array: ReadonlyArray<T>,

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -71,4 +71,4 @@ export type CompareFunction<T> = (a: T, b: T) => number;
  * Based on type-fest's IsAny
  * @see https://github.com/sindresorhus/type-fest/blob/main/source/is-any.d.ts
  */
-export type IfIsAny<T, Then, Else> = 0 extends 1 & T ? Then : Else;
+export type IfIsAny<T, Then, Else> = 0 extends T & 1 ? Then : Else;

--- a/src/_withPrecision.ts
+++ b/src/_withPrecision.ts
@@ -15,7 +15,7 @@ export function _withPrecision(roundingFn: (value: number) => number) {
     }
 
     if (precision > MAX_PRECISION || precision < -MAX_PRECISION) {
-      throw new RangeError(`precision must be between -15 and 15`);
+      throw new RangeError("precision must be between -15 and 15");
     }
 
     if (Number.isNaN(value) || !Number.isFinite(value)) {

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -1,5 +1,5 @@
 import { chunk } from "./chunk";
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 
 describe("data first", () => {
   test("equal size", () => {

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,11 +1,11 @@
-import { IterableContainer, NonEmptyArray } from "./_types";
+import type { IterableContainer, NonEmptyArray } from "./_types";
 import { purry } from "./purry";
 
 type Chunked<T extends IterableContainer> = T[number] extends never
   ? []
   : T extends
-        | readonly [unknown, ...Array<unknown>]
         | readonly [...Array<unknown>, unknown]
+        | readonly [unknown, ...Array<unknown>]
     ? NonEmptyArray<NonEmptyArray<T[number]>>
     : Array<NonEmptyArray<T[number]>>;
 

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -86,9 +86,7 @@ describe("deep clone arrays", () => {
 
 describe("deep clone functions", () => {
   it("keep reference to function", () => {
-    const fn = (x: number) => {
-      return x + x;
-    };
+    const fn = (x: number) => x + x;
     const list = [{ a: fn }] as const;
 
     const cloned = clone(list);

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -14,7 +14,7 @@ import { isTruthy } from "./isTruthy";
  * @deprecated equivalent to `R.filter(R.isTruthy)` and so will be removed in v2.
  */
 export function compact<T>(
-  items: ReadonlyArray<T | null | undefined | false | "" | 0>,
+  items: ReadonlyArray<T | "" | 0 | false | null | undefined>,
 ): Array<T> {
   // TODO: Make lazy version
   return items.filter(isTruthy);

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -14,7 +14,7 @@ import { purry } from "./purry";
 export function concat<T, K>(
   arr1: ReadonlyArray<T>,
   arr2: ReadonlyArray<K>,
-): Array<T | K>;
+): Array<K | T>;
 
 /**
  * Combines two arrays.
@@ -28,7 +28,7 @@ export function concat<T, K>(
  */
 export function concat<T, K>(
   arr2: ReadonlyArray<K>,
-): (arr1: ReadonlyArray<T>) => Array<T | K>;
+): (arr1: ReadonlyArray<T>) => Array<K | T>;
 
 export function concat() {
   return purry(_concat, arguments);

--- a/src/conditional.test.ts
+++ b/src/conditional.test.ts
@@ -48,7 +48,7 @@ describe("runtime (dataFirst)", () => {
     expect(() =>
       conditional("Jokic", [() => false, () => "world"]),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: conditional: data failed for all cases]`,
+      "[Error: conditional: data failed for all cases]",
     );
   });
 });
@@ -69,7 +69,7 @@ describe("runtime (dataLast)", () => {
 
 describe("typing", () => {
   it("can narrow types in the transformers", () => {
-    const data = 3 as string | number;
+    const data = 3 as number | string;
     conditional(
       data,
       [

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,7 +1,7 @@
 import { purryOn } from "./_purryOn";
 
 type Case<In, Out, Thru extends In = In> = readonly [
-  when: ((data: In) => data is Thru) | ((data: In) => boolean),
+  when: ((data: In) => boolean) | ((data: In) => data is Thru),
   then: (data: Thru) => Out,
 ];
 

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -1,14 +1,13 @@
 import { purry } from "./purry";
-import { Pred, PredIndexed, PredIndexedOptional } from "./_types";
+import type { Pred, PredIndexed, PredIndexedOptional } from "./_types";
 
 const _countBy =
   (indexed: boolean) =>
-  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) => {
-    return array.reduce((ret, item, index) => {
+  <T>(array: Array<T>, fn: PredIndexedOptional<T, boolean>) =>
+    array.reduce((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       return ret + (value ? 1 : 0);
     }, 0);
-  };
 
 /**
  * Counts how many values of the collection pass the specified predicate.

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -403,7 +403,7 @@ describe("typing", () => {
 
   test("argument typing to be good (with defaults)", () => {
     const debouncer = debounce(
-      (a: string, b: number = 2, c: boolean = true) => `${a}${b}${c}`,
+      (a: string, b = 2, c = true) => `${a}${b}${c}`,
       {},
     );
     // @ts-expect-error [ts2554]: Expected 3 arguments, but got 1.

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -98,13 +98,13 @@ type DebounceOptions = {
  */
 export function debounce<F extends (...args: any) => any>(
   func: F,
-  options: { readonly timing?: "trailing" } & DebounceOptions,
+  options: DebounceOptions & { readonly timing?: "trailing" },
 ): Debouncer<F>;
 export function debounce<F extends (...args: any) => any>(
   func: F,
   options:
-    | ({ readonly timing: "leading" } & Omit<DebounceOptions, "maxWaitMs">)
-    | ({ readonly timing: "both" } & DebounceOptions),
+    | (DebounceOptions & { readonly timing: "both" })
+    | (Omit<DebounceOptions, "maxWaitMs"> & { readonly timing: "leading" }),
 ): Debouncer<F, false /* call CAN'T return null */>;
 
 export function debounce<F extends (...args: any) => any>(
@@ -114,7 +114,7 @@ export function debounce<F extends (...args: any) => any>(
     timing = "trailing",
     maxWaitMs,
   }: DebounceOptions & {
-    readonly timing?: "leading" | "both" | "trailing";
+    readonly timing?: "both" | "leading" | "trailing";
   },
 ): Debouncer<F> {
   if (maxWaitMs !== undefined && waitMs !== undefined && maxWaitMs < waitMs) {

--- a/src/difference.ts
+++ b/src/difference.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 /**
  * Excludes the values from `other` array.

--- a/src/differenceWith.ts
+++ b/src/differenceWith.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { LazyResult, _reduceLazy } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 type IsEquals<TFirst, TSecond> = (a: TFirst, b: TSecond) => boolean;
 

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 /**
  * Removes first `n` elements from the `array`.

--- a/src/dropFirstBy.ts
+++ b/src/dropFirstBy.ts
@@ -1,5 +1,6 @@
 import { heapify, heapMaybeInsert } from "./_heap";
-import { OrderRule, purryOrderRulesWithArgument } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRulesWithArgument } from "./_purryOrderRules";
 import type { CompareFunction, NonEmptyArray } from "./_types";
 
 /**

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -9,7 +9,7 @@ import { reduce } from "./reduce";
 const sum = reduce((a, b: number) => add(a, b), 0);
 
 describe("data first", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", function () {
+  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     const evolver = {
       id: add(1),
       quartile: sum,
@@ -30,7 +30,7 @@ describe("data first", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("does not invoke function if `data` does not contain the key", function () {
+  it("does not invoke function if `data` does not contain the key", () => {
     const data: { id?: number } = {};
     const expected = {};
     const evolver = { id: add(1) };
@@ -38,7 +38,7 @@ describe("data first", () => {
     expect(result).toEqual(expected);
   });
 
-  it("is not destructive and is immutable", function () {
+  it("is not destructive and is immutable", () => {
     const evolver = { n: add(1) };
     const data = { n: 100 };
     const expected = { n: 101 };
@@ -49,7 +49,7 @@ describe("data first", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("is recursive", function () {
+  it("is recursive", () => {
     const evolver = { nested: { second: add(-1), third: add(1) } };
     const data = { first: 1, nested: { second: 2, third: 3 } };
     const expected = { first: 1, nested: { second: 1, third: 4 } };
@@ -58,11 +58,11 @@ describe("data first", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("ignores undefined transformations", function () {
+  it("ignores undefined transformations", () => {
     expect(evolve({ n: 0 }, {})).toEqual({ n: 0 });
   });
 
-  it("can handle data that is complex nested objects", function () {
+  it("can handle data that is complex nested objects", () => {
     const evolver = {
       array: (array: ReadonlyArray<string>) => array.length,
       nestedObj: { a: set<{ b: string }, "b">("b", "Set") },
@@ -90,7 +90,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", function () {
+  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     const evolver = {
       id: add(1),
       quartile: sum,
@@ -111,7 +111,7 @@ describe("data last", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("does not invoke function if `data` does not contain the key", function () {
+  it("does not invoke function if `data` does not contain the key", () => {
     const data: { id?: number } = {};
     const expected = {};
     const evolver = { id: add(1) };
@@ -120,7 +120,7 @@ describe("data last", () => {
     expect(result).toEqual(expected);
   });
 
-  it("is not destructive and is immutable", function () {
+  it("is not destructive and is immutable", () => {
     const evolver = { n: add(1) };
     const data = { n: 100 };
     const expected = { n: 101 };
@@ -131,7 +131,7 @@ describe("data last", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("is recursive", function () {
+  it("is recursive", () => {
     const evolver = { nested: { second: add(-1), third: add(1) } };
     const data = { first: 1, nested: { second: 2, third: 3 } };
     const expected = { first: 1, nested: { second: 1, third: 4 } };
@@ -140,14 +140,14 @@ describe("data last", () => {
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("ignores undefined transformations", function () {
+  it("ignores undefined transformations", () => {
     const expected = { n: 0 };
     const result = pipe({ n: 0 }, evolve({}));
     expect(result).toEqual(expected);
     expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
-  it("can handle data that is complex nested objects", function () {
+  it("can handle data that is complex nested objects", () => {
     const result = pipe(
       {
         array: ["1", "2", "3"],
@@ -176,11 +176,11 @@ describe("data last", () => {
 describe("typing", () => {
   describe("data first", () => {
     describe("type reflection", (): void => {
-      interface Data {
+      type Data = {
         id: number;
         quartile: Array<number>;
         time?: { elapsed: number; remaining?: number };
-      }
+      };
       const data: Data = {
         id: 1,
         quartile: [1, 2, 3, 4],
@@ -188,7 +188,7 @@ describe("typing", () => {
       };
       const expected = data;
 
-      it("can reflect type of data to function of evolver object", function () {
+      it("can reflect type of data to function of evolver object", () => {
         const result = evolve(data, {
           count: (x: number) => x, // type of parameter is required because `count` property is not defined in data
           quartile: (x) => x,
@@ -198,7 +198,7 @@ describe("typing", () => {
         expectTypeOf(result).toEqualTypeOf<typeof expected>();
       });
 
-      it("can reflect type of data to function of nested evolver object", function () {
+      it("can reflect type of data to function of nested evolver object", () => {
         const result = evolve(data, {
           count: (x: number) => x, // type of parameter is required because `count` property is not defined in data
           quartile: (x) => x,
@@ -209,7 +209,7 @@ describe("typing", () => {
       });
     });
 
-    it("can detect mismatch of parameters and arguments", function () {
+    it("can detect mismatch of parameters and arguments", () => {
       evolve(
         {
           number: "1",
@@ -233,7 +233,7 @@ describe("typing", () => {
       );
     });
 
-    it("does not accept the input value that is not Array and Object", function () {
+    it("does not accept the input value that is not Array and Object", () => {
       const evolver = { a: add(1) };
       // Type check only
       () => {
@@ -248,7 +248,7 @@ describe("typing", () => {
       };
     });
 
-    it("does not accept function that require multiple arguments", function () {
+    it("does not accept function that require multiple arguments", () => {
       evolve(
         {
           requiring2Args: 1,
@@ -264,7 +264,7 @@ describe("typing", () => {
       );
     });
 
-    it("accept function whose second and subsequent arguments are optional", function () {
+    it("accept function whose second and subsequent arguments are optional", () => {
       const result = evolve(
         {
           arg2Optional: 1,
@@ -286,7 +286,7 @@ describe("typing", () => {
       }>();
     });
 
-    it("can not handle function arrays.", function () {
+    it("can not handle function arrays.", () => {
       evolve(
         {
           quartile: [1, 2],
@@ -300,8 +300,8 @@ describe("typing", () => {
   });
 
   describe("data last", () => {
-    describe("it can detect mismatch of parameters and arguments", function () {
-      it('detect property "number" are incompatible', function () {
+    describe("it can detect mismatch of parameters and arguments", () => {
+      it('detect property "number" are incompatible', () => {
         const evolver = {
           number: add(1),
           array: (array: ReadonlyArray<number>) => array.length,
@@ -315,7 +315,7 @@ describe("typing", () => {
           evolve(evolver),
         );
       });
-      it('detect property "array" are incompatible', function () {
+      it('detect property "array" are incompatible', () => {
         const evolver = {
           number: add(1),
           array: (array: ReadonlyArray<number>) => array.length,
@@ -331,7 +331,7 @@ describe("typing", () => {
       });
     });
 
-    it("does not accept the input value that is not Array and Object", function () {
+    it("does not accept the input value that is not Array and Object", () => {
       const evolver = { a: add(1) };
       // Type check only
       () => {
@@ -346,7 +346,7 @@ describe("typing", () => {
       };
     });
 
-    it("does not accept function that require multiple arguments", function () {
+    it("does not accept function that require multiple arguments", () => {
       pipe(
         {
           requiring2Args: 1,
@@ -359,7 +359,7 @@ describe("typing", () => {
       );
     });
 
-    it("accept function whose second and subsequent arguments are optional", function () {
+    it("accept function whose second and subsequent arguments are optional", () => {
       const result = pipe(
         {
           arg2Optional: 1,
@@ -381,7 +381,7 @@ describe("typing", () => {
       }>();
     });
 
-    it("can not handle function arrays.", function () {
+    it("can not handle function arrays.", () => {
       pipe(
         {
           quartile: [1, 2],

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -6,7 +6,7 @@ import { toPairs } from "./toPairs";
  * basic structure of `evolver` parameter of the function `evolve`.
  */
 type GenericEvolver = {
-  readonly [P in string]: ((data: unknown) => unknown) | GenericEvolver;
+  readonly [P in string]: GenericEvolver | ((data: unknown) => unknown);
 };
 
 /**
@@ -34,8 +34,8 @@ type Evolver<T> = T extends object
     ? never
     : {
         readonly [K in keyof T]?:
-          | ((data: Required<T>[K]) => unknown)
-          | Evolver<T[K]>;
+          | Evolver<T[K]>
+          | ((data: Required<T>[K]) => unknown);
       }
   : never;
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,7 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 import { _toLazyIndexed } from "./_toLazyIndexed";
 
 /**
@@ -54,34 +55,28 @@ export function filter() {
 
 const _filter =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
-    return _reduceLazy(
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
+    _reduceLazy(
       array,
       indexed ? filter.lazyIndexed(fn) : filter.lazy(fn),
       indexed,
     );
-  };
 
 const _lazy =
   (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (
-      value: T,
-      index?: number,
-      array?: ReadonlyArray<T>,
-    ): LazyResult<T> => {
-      const valid = indexed ? fn(value, index, array) : fn(value);
-      if (valid) {
-        return {
-          done: false,
-          hasNext: true,
-          next: value,
-        };
-      }
+  <T>(fn: PredIndexedOptional<T, boolean>) =>
+  (value: T, index?: number, array?: ReadonlyArray<T>): LazyResult<T> => {
+    const valid = indexed ? fn(value, index, array) : fn(value);
+    if (valid) {
       return {
         done: false,
-        hasNext: false,
+        hasNext: true,
+        next: value,
       };
+    }
+    return {
+      done: false,
+      hasNext: false,
     };
   };
 

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 import { _toLazyIndexed } from "./_toLazyIndexed";
 import { _toSingle } from "./_toSingle";
 
@@ -63,14 +63,13 @@ const _find =
 
 const _lazy =
   (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (value: T, index?: number, array?: Array<T>) => {
-      const valid = indexed ? fn(value, index, array) : fn(value);
-      return {
-        done: valid,
-        hasNext: valid,
-        next: value,
-      };
+  <T>(fn: PredIndexedOptional<T, boolean>) =>
+  (value: T, index?: number, array?: Array<T>) => {
+    const valid = indexed ? fn(value, index, array) : fn(value);
+    return {
+      done: valid,
+      hasNext: valid,
+      next: value,
     };
   };
 

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 import { _toLazyIndexed } from "./_toLazyIndexed";
 import { _toSingle } from "./_toSingle";
 

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -1,4 +1,4 @@
-import { Pred, PredIndexed, PredIndexedOptional } from "./_types";
+import type { Pred, PredIndexed, PredIndexedOptional } from "./_types";
 import { purry } from "./purry";
 
 /**

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
  * Returns the index of the last element in the array where predicate is true, and -1 otherwise.

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -4,7 +4,7 @@ import { first } from "./first";
 import { pipe } from "./pipe";
 
 function defaultTo<T>(d: T) {
-  return function (v: T | undefined | null) {
+  return function (v: T | null | undefined) {
     return v == null ? d : v;
   };
 }
@@ -143,7 +143,7 @@ describe("strict typing", () => {
   test("tuple with last", () => {
     const arr: [...Array<string>, number] = ["a", 1];
     const result = first(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number>();
+    expectTypeOf(result).toEqualTypeOf<number | string>();
     expect(result).toEqual("a");
   });
 
@@ -199,7 +199,7 @@ describe("strict typing", () => {
   test("readonly tuple with last", () => {
     const arr: readonly [...Array<string>, number] = ["a", 1];
     const result = first(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number>();
+    expectTypeOf(result).toEqualTypeOf<number | string>();
     expect(result).toEqual("a");
   });
 });

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 type First<T extends IterableContainer> = T extends []
@@ -6,7 +6,7 @@ type First<T extends IterableContainer> = T extends []
   : T extends readonly [unknown, ...Array<unknown>]
     ? T[0]
     : T extends readonly [...infer Pre, infer Last]
-      ? Pre[0] | Last
+      ? Last | Pre[0]
       : T[0] | undefined;
 
 /**
@@ -55,13 +55,11 @@ function _first<T>([first]: ReadonlyArray<T>) {
 
 export namespace first {
   export function lazy<T>() {
-    return (value: T) => {
-      return {
-        done: true,
-        hasNext: true,
-        next: value,
-      };
-    };
+    return (value: T) => ({
+      done: true,
+      hasNext: true,
+      next: value,
+    });
   }
 
   export namespace lazy {

--- a/src/firstBy.test.ts
+++ b/src/firstBy.test.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 import { firstBy } from "./firstBy";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/src/firstBy.ts
+++ b/src/firstBy.ts
@@ -1,4 +1,5 @@
-import { OrderRule, purryOrderRules } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRules } from "./_purryOrderRules";
 import type {
   CompareFunction,
   IterableContainer,

--- a/src/flatMap.ts
+++ b/src/flatMap.ts
@@ -54,7 +54,7 @@ export namespace flatMap {
           done: false,
           hasNext: true,
           hasMany: true,
-          next: next,
+          next,
         };
       }
       return {

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -1,4 +1,4 @@
-import { PredIndexedOptional } from "./_types";
+import type { PredIndexedOptional } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -65,18 +65,14 @@ const _flatMapToObj =
       T,
       ReadonlyArray<[key: PropertyKey, value: unknown]>
     >,
-  ) => {
-    return array.reduce<Record<PropertyKey, unknown>>(
-      (result, element, index) => {
-        const items = indexed ? fn(element, index, array) : fn(element);
-        items.forEach(([key, value]) => {
-          result[key] = value;
-        });
-        return result;
-      },
-      {},
-    );
-  };
+  ) =>
+    array.reduce<Record<PropertyKey, unknown>>((result, element, index) => {
+      const items = indexed ? fn(element, index, array) : fn(element);
+      items.forEach(([key, value]) => {
+        result[key] = value;
+      });
+      return result;
+    }, {});
 
 export namespace flatMapToObj {
   export function indexed<T, K extends PropertyKey, V>(

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,4 +1,5 @@
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { purry } from "./purry";
 
 type Flatten<T> = T extends ReadonlyArray<infer K> ? K : T;
@@ -50,7 +51,7 @@ export namespace flatten {
           done: false,
           hasNext: true,
           hasMany: true,
-          next: next,
+          next,
         };
       }
       return {

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return -- FIXME! */
 
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { purry } from "./purry";
 
 type FlattenDeep<T> = T extends ReadonlyArray<infer K> ? FlattenDeep2<K> : T;
@@ -46,7 +47,7 @@ function _flattenDeep<T>(items: Array<T>): Array<FlattenDeep<T>> {
   return _reduceLazy(items, flattenDeep.lazy());
 }
 
-function _flattenDeepValue<T>(value: T | Array<T>): T | Array<FlattenDeep<T>> {
+function _flattenDeepValue<T>(value: Array<T> | T): Array<FlattenDeep<T>> | T {
   if (!Array.isArray(value)) {
     return value;
   }
@@ -70,7 +71,7 @@ export namespace flattenDeep {
           done: false,
           hasNext: true,
           hasMany: true,
-          next: next,
+          next,
         };
       }
       return {

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -1,7 +1,8 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { _toLazyIndexed } from "./_toLazyIndexed";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
  * Iterate an array using a defined callback function. The original array is returned instead of `void`.
@@ -62,32 +63,26 @@ export function forEach() {
 
 const _forEach =
   (indexed: boolean) =>
-  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) => {
-    return _reduceLazy(
+  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) =>
+    _reduceLazy(
       array,
       indexed ? forEach.lazyIndexed(fn) : forEach.lazy(fn),
       indexed,
     );
-  };
 
 const _lazy =
   (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, void>) => {
-    return (
-      value: T,
-      index?: number,
-      array?: ReadonlyArray<T>,
-    ): LazyResult<T> => {
-      if (indexed) {
-        fn(value, index, array);
-      } else {
-        fn(value);
-      }
-      return {
-        done: false,
-        hasNext: true,
-        next: value,
-      };
+  <T>(fn: PredIndexedOptional<T, void>) =>
+  (value: T, index?: number, array?: ReadonlyArray<T>): LazyResult<T> => {
+    if (indexed) {
+      fn(value, index, array);
+    } else {
+      fn(value);
+    }
+    return {
+      done: false,
+      hasNext: true,
+      next: value,
     };
   };
 

--- a/src/forEachObj.ts
+++ b/src/forEachObj.ts
@@ -68,8 +68,11 @@ const _forEachObj =
     for (const key in data) {
       if (Object.prototype.hasOwnProperty.call(data, key)) {
         const val = data[key];
-        if (indexed) fn(val, key, data);
-        else fn(val);
+        if (indexed) {
+          fn(val, key, data);
+        } else {
+          fn(val);
+        }
       }
     }
     return data;

--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -22,11 +22,11 @@ describe("typings", () => {
     assertType<Record<string, number>>(actual);
   });
   test("arrays with mixed type value", () => {
-    const actual = fromPairs<string | number>([
+    const actual = fromPairs<number | string>([
       ["a", 2],
       ["b", "c"],
     ]);
-    assertType<Record<string, string | number>>(actual);
+    assertType<Record<string, number | string>>(actual);
   });
 });
 
@@ -126,7 +126,7 @@ describe("Strict (with readonly inputs)", () => {
     > = [["a", 1]];
     const result = fromPairs.strict(arr);
     expectTypeOf(result).toMatchTypeOf<
-      { a?: 1 } & Partial<Record<`testing_${string}`, boolean>>
+      Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
     >();
     expect(result).toStrictEqual({ a: 1 });
   });
@@ -243,7 +243,7 @@ describe("Strict (with non-readonly inputs)", () => {
     const arr: Array<["a", 1] | [`testing_${string}`, boolean]> = [["a", 1]];
     const result = fromPairs.strict(arr);
     expectTypeOf(result).toMatchTypeOf<
-      { a?: 1 } & Partial<Record<`testing_${string}`, boolean>>
+      Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
     >();
     expect(result).toStrictEqual({ a: 1 });
   });

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 type Entry<Key extends PropertyKey = PropertyKey, Value = unknown> = readonly [
@@ -85,15 +85,13 @@ function fromPairsImplementation(
 
 // Redefining the fromPairs function to allow stricter pairs arrays and fine-
 // grained handling of partiality of the output.
-type Strict = {
+type Strict = // ) => StrictOut<Entries>;
+  //   entries: Entries,
+  // (): <Entries extends IterableContainer<Entry>>(
+  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
   <Entries extends IterableContainer<Entry>>(
     entries: Entries,
-  ): StrictOut<Entries>;
-  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-  // (): <Entries extends IterableContainer<Entry>>(
-  //   entries: Entries,
-  // ) => StrictOut<Entries>;
-};
+  ) => StrictOut<Entries>;
 
 // The 2 kinds of arrays we accept result in different kinds of outputs:
 // 1. If the input is a *tuple*, we know exactly what pairs it would hold,

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 import { groupBy } from "./groupBy";
 import { pipe } from "./pipe";
 
@@ -70,8 +70,8 @@ describe("Result key types", () => {
     assertType<Record<number, NonEmptyArray<Array2Item>>>(data);
   });
   test("string | number", () => {
-    const data = groupBy.strict(array2, (x): string | number => x.b);
-    assertType<Record<string | number, NonEmptyArray<Array2Item>>>(data);
+    const data = groupBy.strict(array2, (x): number | string => x.b);
+    assertType<Record<number | string, NonEmptyArray<Array2Item>>>(data);
   });
 });
 

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { NonEmptyArray, PredIndexedOptional, PredIndexed } from "./_types";
+import type { NonEmptyArray, PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
  * Splits a collection into sets, grouped by the result of running each value through `fn`.
@@ -66,7 +66,7 @@ const _groupBy =
 
 // Redefining the groupBy API with a stricter return type. This API is accessed
 // via `groupBy.strict`
-interface Strict {
+type Strict = {
   // Data-First
   <Value, Key extends PropertyKey = PropertyKey>(
     items: ReadonlyArray<Value>,
@@ -90,7 +90,7 @@ interface Strict {
       fn: PredIndexed<Value, Key | undefined>,
     ): (items: ReadonlyArray<Value>) => StrictOut<Value, Key>;
   };
-}
+};
 
 // Records keyed with generic `string` and `number` have different semantics
 // to those with a a union of literal values (e.g. 'cat' | 'dog') when using

--- a/src/hasAtLeast.ts
+++ b/src/hasAtLeast.ts
@@ -1,4 +1,4 @@
-import { ReadonlyTuple } from "./_types";
+import type { ReadonlyTuple } from "./_types";
 import { purry } from "./purry";
 
 type ArrayMinN<T, N extends number> = number extends N

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexedOptional, PredIndexed } from "./_types";
+import type { PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
  * Converts a list of objects into an object indexing the objects by the given key (casted to a string).
@@ -57,14 +57,13 @@ export function indexBy() {
 
 const _indexBy =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) => {
-    return array.reduce<Record<string, T>>((ret, item, index) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) =>
+    array.reduce<Record<string, T>>((ret, item, index) => {
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
       ret[key] = item;
       return ret;
     }, {});
-  };
 
 function indexByStrict<K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
@@ -82,13 +81,12 @@ function indexByStrict() {
 const _indexByStrict = <K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
   fn: (item: T) => K,
-) => {
-  return array.reduce<Partial<Record<K, T>>>((ret, item) => {
+) =>
+  array.reduce<Partial<Record<K, T>>>((ret, item) => {
     const key = fn(item);
     ret[key] = item;
     return ret;
   }, {});
-};
 
 export namespace indexBy {
   export function indexed<T>(

--- a/src/intersection.ts
+++ b/src/intersection.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 /**
  * Returns a list of elements that exist in both array.

--- a/src/intersectionWith.ts
+++ b/src/intersectionWith.ts
@@ -1,4 +1,5 @@
-import { LazyResult, _reduceLazy } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { purry } from "./purry";
 
 type Comparator<TFirst, TSecond> = (a: TFirst, b: TSecond) => boolean;

--- a/src/isArray.test.ts
+++ b/src/isArray.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isArray } from "./isArray";

--- a/src/isArray.ts
+++ b/src/isArray.ts
@@ -1,4 +1,4 @@
-import { NarrowedTo } from "./_types";
+import type { NarrowedTo } from "./_types";
 
 /**
  * A function that checks if the passed parameter is an Array and narrows its type accordingly
@@ -13,7 +13,7 @@ import { NarrowedTo } from "./_types";
  * @category Guard
  */
 export function isArray<T>(
-  data: T | ArrayLike<unknown>,
+  data: ArrayLike<unknown> | T,
 ): data is NarrowedTo<T, ReadonlyArray<unknown>> {
   return Array.isArray(data);
 }

--- a/src/isBoolean.test.ts
+++ b/src/isBoolean.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isBoolean } from "./isBoolean";

--- a/src/isDate.test.ts
+++ b/src/isDate.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isDate } from "./isDate";

--- a/src/isDefined.test.ts
+++ b/src/isDefined.test.ts
@@ -1,8 +1,10 @@
+import type {
+  AllTypesDataProviderTypes,
+  TestClass,
+} from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
-  TestClass,
 } from "../test/types_data_provider";
 import { isDefined } from "./isDefined";
 
@@ -12,22 +14,22 @@ describe("isDefined", () => {
     if (isDefined(data)) {
       expect(data instanceof Date).toEqual(true);
       expectTypeOf(data).toEqualTypeOf<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
       >();
     }
   });
@@ -36,22 +38,22 @@ describe("isDefined", () => {
     expect(data).toHaveLength(16);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
       >
     >();
   });
@@ -63,23 +65,23 @@ describe("strict", () => {
     if (isDefined.strict(data)) {
       expect(data instanceof Date).toEqual(true);
       expectTypeOf(data).toEqualTypeOf<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | null
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
+        | null
       >();
     }
   });
@@ -89,23 +91,23 @@ describe("strict", () => {
     expect(data).toHaveLength(17);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | null
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
+        | null
       >
     >();
   });

--- a/src/isEmpty.test.ts
+++ b/src/isEmpty.test.ts
@@ -84,7 +84,7 @@ describe("strings are narrowed correctly", () => {
   });
 
   test("string literals that CAN be empty", () => {
-    const data = "cat" as "cat" | "dog" | "";
+    const data = "cat" as "" | "cat" | "dog";
     if (isEmpty(data)) {
       expectTypeOf(data).toEqualTypeOf<"">();
     }
@@ -98,7 +98,7 @@ describe("strings are narrowed correctly", () => {
   });
 
   test("string literals that CAN be undefined or empty", () => {
-    const data = "cat" as "cat" | "dog" | "" | undefined;
+    const data = "cat" as "" | "cat" | "dog" | undefined;
     if (isEmpty(data)) {
       expectTypeOf(data).toEqualTypeOf<"" | undefined>();
     }
@@ -113,7 +113,7 @@ describe("strings are narrowed correctly", () => {
   });
 
   test("string templates that CAN be empty", () => {
-    const data = "" as `prefix_${number}` | "";
+    const data = "" as "" | `prefix_${number}`;
     if (isEmpty(data)) {
       expectTypeOf(data).toEqualTypeOf<"">();
     }
@@ -127,7 +127,7 @@ describe("strings are narrowed correctly", () => {
   });
 
   test("string templates that CAN be undefined or empty", () => {
-    const data = "prefix_0" as `prefix_${number}` | "" | undefined;
+    const data = "prefix_0" as "" | `prefix_${number}` | undefined;
     if (isEmpty(data)) {
       expectTypeOf(data).toEqualTypeOf<"" | undefined>();
     }

--- a/src/isError.test.ts
+++ b/src/isError.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isError } from "./isError";

--- a/src/isError.ts
+++ b/src/isError.ts
@@ -11,6 +11,6 @@ type DefinitelyError<T> =
  *    R.isError('somethingElse') //=> false
  * @category Guard
  */
-export function isError<T>(data: T | Error): data is DefinitelyError<T> {
+export function isError<T>(data: Error | T): data is DefinitelyError<T> {
   return data instanceof Error;
 }

--- a/src/isFunction.test.ts
+++ b/src/isFunction.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isFunction } from "./isFunction";

--- a/src/isFunction.ts
+++ b/src/isFunction.ts
@@ -16,7 +16,7 @@ type DefinitelyFunction<T> =
  * @category Guard
  */
 export function isFunction<T>(
-  data: T | Function,
+  data: Function | T,
 ): data is DefinitelyFunction<T> {
   return typeof data === "function";
 }

--- a/src/isNil.test.ts
+++ b/src/isNil.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isNil } from "./isNil";
@@ -17,6 +17,6 @@ describe("isNil", () => {
   it("should work as type guard in filter", () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isNil);
     expect(data.every((c) => c == null)).toEqual(true);
-    expectTypeOf(data).toEqualTypeOf<Array<undefined | null>>();
+    expectTypeOf(data).toEqualTypeOf<Array<null | undefined>>();
   });
 });

--- a/src/isNonNull.test.ts
+++ b/src/isNonNull.test.ts
@@ -1,8 +1,10 @@
+import type {
+  AllTypesDataProviderTypes,
+  TestClass,
+} from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
-  TestClass,
 } from "../test/types_data_provider";
 import { isNonNull } from "./isNonNull";
 
@@ -12,22 +14,22 @@ describe("isNonNull", () => {
     if (isNonNull(data)) {
       expect(data instanceof Date).toEqual(true);
       expectTypeOf(data).toEqualTypeOf<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
         | undefined
       >();
     }
@@ -37,22 +39,22 @@ describe("isNonNull", () => {
     expect(data).toHaveLength(17);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
         | undefined
       >
     >(data);

--- a/src/isNot.test.ts
+++ b/src/isNot.test.ts
@@ -1,8 +1,10 @@
+import type {
+  AllTypesDataProviderTypes,
+  TestClass,
+} from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
-  TestClass,
 } from "../test/types_data_provider";
 import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
@@ -14,22 +16,22 @@ describe("isNot", () => {
     if (isNot(isString)(data)) {
       expect(data instanceof Promise).toEqual(true);
       expectTypeOf(data).toEqualTypeOf<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | null
-        | number
         | Promise<number>
         | RegExp
         | Set<string>
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
+        | null
         | undefined
       >(data);
     }
@@ -40,22 +42,22 @@ describe("isNot", () => {
     expect(data.some((c) => c instanceof Promise)).toEqual(false);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
-        | boolean
         | Date
         | Error
         | Map<string, string>
-        | null
-        | number
         | RegExp
         | Set<string>
-        | string
-        | symbol
         | TestClass
         | Uint8Array
+        | boolean
+        | number
+        | string
+        | symbol
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
+        | null
         | undefined
       >
     >();

--- a/src/isNot.ts
+++ b/src/isNot.ts
@@ -16,7 +16,5 @@ export function isNot<T, S extends T>(
 export function isNot<T>(predicate: (data: T) => boolean): (data: T) => boolean;
 
 export function isNot<T>(predicate: (data: T) => boolean) {
-  return (data: T) => {
-    return !predicate(data);
-  };
+  return (data: T) => !predicate(data);
 }

--- a/src/isNumber.test.ts
+++ b/src/isNumber.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isNumber } from "./isNumber";
@@ -29,9 +29,7 @@ describe("isNumber", () => {
   });
 
   it("should work with literal types", () => {
-    const data = (): 1 | 2 | 3 | string => {
-      return 1;
-    };
+    const data = (): string | 1 | 2 | 3 => 1;
     const x = data();
     if (isNumber(x)) {
       expect(typeof x).toEqual("number");

--- a/src/isObject.test.ts
+++ b/src/isObject.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
   type TestClass,
 } from "../test/types_data_provider";
@@ -12,7 +12,6 @@ describe("isObject", () => {
     if (isObject(data)) {
       expect(typeof data).toEqual("object");
       expectTypeOf(data).toEqualTypeOf<
-        | { readonly a: "asd" }
         | Date
         | Error
         | Map<string, string>
@@ -21,6 +20,7 @@ describe("isObject", () => {
         | Set<string>
         | TestClass
         | Uint8Array
+        | { readonly a: "asd" }
       >();
     }
   });
@@ -56,7 +56,6 @@ describe("isObject", () => {
     ).toEqual(true);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | { readonly a: "asd" }
         | Date
         | Error
         | Map<string, string>
@@ -65,6 +64,7 @@ describe("isObject", () => {
         | Set<string>
         | TestClass
         | Uint8Array
+        | { readonly a: "asd" }
       >
     >(data);
   });

--- a/src/isObject.ts
+++ b/src/isObject.ts
@@ -28,5 +28,5 @@ type DefinitelyObject<T> =
  * @deprecated - The semantics of this guard are confusing. It excludes Arrays but does not exclude other complex objects like Classes or built-in objects (such as Date, Promise, Error, etc.). Instead, consider using `isObjectType` for a more inclusive validation encompassing any JavaScript "object" type, or `isPlainObject` for a more specific validation targeting simple struct/shape/record-like objects. To replicate the existing logic, use: `const isObject = (x) => isObjectType(x) && !Array.isArray(x)`.
  */
 export function isObject<T>(data: T | object): data is DefinitelyObject<T> {
-  return !!data && !Array.isArray(data) && typeof data === "object";
+  return Boolean(data) && !Array.isArray(data) && typeof data === "object";
 }

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
   TestClass,
 } from "../test/types_data_provider";
@@ -78,9 +78,6 @@ describe("typing", () => {
     const data = TYPES_DATA_PROVIDER.object as AllTypesDataProviderTypes;
     if (isObjectType(data)) {
       expectTypeOf(data).toEqualTypeOf<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
         | Date
         | Error
@@ -90,6 +87,9 @@ describe("typing", () => {
         | Set<string>
         | TestClass
         | Uint8Array
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
       >();
     }
   });
@@ -105,9 +105,6 @@ describe("typing", () => {
     const data = ALL_TYPES_DATA_PROVIDER.filter(isObjectType);
     expectTypeOf(data).toEqualTypeOf<
       Array<
-        | (() => void)
-        | [number, number, number]
-        | { readonly a: "asd" }
         | Array<number>
         | Date
         | Error
@@ -117,6 +114,9 @@ describe("typing", () => {
         | Set<string>
         | TestClass
         | Uint8Array
+        | (() => void)
+        | { readonly a: "asd" }
+        | [number, number, number]
       >
     >();
   });

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
   TestClass,
 } from "../test/types_data_provider";

--- a/src/isPlainObject.ts
+++ b/src/isPlainObject.ts
@@ -26,7 +26,7 @@ import type { NarrowedTo } from "./_types";
  * @category Guard
  */
 export function isPlainObject<T>(
-  data: T | Record<PropertyKey, unknown>,
+  data: Record<PropertyKey, unknown> | T,
 ): data is NarrowedTo<T, Record<PropertyKey, unknown>> {
   if (typeof data !== "object" || data === null) {
     return false;

--- a/src/isPromise.test.ts
+++ b/src/isPromise.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isPromise } from "./isPromise";

--- a/src/isString.test.ts
+++ b/src/isString.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isString } from "./isString";
@@ -23,9 +23,7 @@ describe("isString", () => {
   });
 
   it("should work with literal types", () => {
-    const data = (): "a" | "b" | "c" | number => {
-      return "a";
-    };
+    const data = (): number | "a" | "b" | "c" => "a";
     const x = data();
     if (isString(x)) {
       expect(typeof x).toEqual("string");

--- a/src/isSymbol.test.ts
+++ b/src/isSymbol.test.ts
@@ -1,6 +1,6 @@
+import type { AllTypesDataProviderTypes } from "../test/types_data_provider";
 import {
   ALL_TYPES_DATA_PROVIDER,
-  AllTypesDataProviderTypes,
   TYPES_DATA_PROVIDER,
 } from "../test/types_data_provider";
 import { isSymbol } from "./isSymbol";

--- a/src/isTruthy.test.ts
+++ b/src/isTruthy.test.ts
@@ -2,7 +2,7 @@ import { isTruthy } from "./isTruthy";
 
 describe("isTruthy", () => {
   test("isTruthy", () => {
-    const data: false | "" | 0 | { a: string } = { a: "asd" };
+    const data: "" | 0 | false | { a: string } = { a: "asd" };
     if (isTruthy(data)) {
       expect(data).toEqual({ a: "asd" });
       assertType<{ a: string }>(data);

--- a/src/isTruthy.ts
+++ b/src/isTruthy.ts
@@ -15,6 +15,6 @@
  */
 export function isTruthy<T>(
   data: T,
-): data is Exclude<T, null | undefined | false | "" | 0> {
-  return !!data;
+): data is Exclude<T, "" | 0 | false | null | undefined> {
+  return Boolean(data);
 }

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -184,9 +184,9 @@ describe("typing", () => {
         "suffix" | undefined,
       ] = ["prefix", undefined, "suffix"];
       const result = join(array, ",");
-      expectTypeOf(result).toEqualTypeOf<`${"prefix" | ""},${"midfix" | ""},${
-        | "suffix"
-        | ""}`>();
+      expectTypeOf(result).toEqualTypeOf<`${"" | "prefix"},${"" | "midfix"},${
+        | ""
+        | "suffix"}`>();
     });
   });
 });

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 type Joinable = bigint | boolean | number | string | null | undefined;
@@ -24,8 +24,8 @@ export type Joined<T extends IterableContainer, Glue extends string> =
 // the builtin `join` method, they should result in an empty string!
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join#description
 type NullishCoalesce<T, Fallback> = T extends Joinable
-  ? T extends undefined | null
-    ? NonNullable<T> | Fallback
+  ? T extends null | undefined
+    ? Fallback | NonNullable<T>
     : T
   : never;
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -25,7 +25,7 @@ import { purry } from "./purry";
  * @dataFirst
  */
 export function keys(
-  source: Record<PropertyKey, unknown> | ArrayLike<unknown>,
+  source: ArrayLike<unknown> | Record<PropertyKey, unknown>,
 ): Array<string>;
 
 /**
@@ -57,18 +57,16 @@ export function keys() {
   return purry(Object.keys, arguments);
 }
 
-type Strict = {
-  <T extends object>(data: T): Keys<T>;
+type Strict = // (): <T extends object>(data: T) => Keys<T>;
   // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-  // (): <T extends object>(data: T) => Keys<T>;
-};
+  <T extends object>(data: T) => Keys<T>;
 type Keys<T> = T extends IterableContainer ? ArrayKeys<T> : ObjectKeys<T>;
 
 // The keys output can mirror the input when it is an array/tuple. We do this by
 // "mapping" each item "key" (which is actually an index) as its own value. This
 // would maintain the shape, even including labels.
 type ArrayKeys<T extends IterableContainer> = {
-  -readonly [Index in keyof T]: Index extends string | number
+  -readonly [Index in keyof T]: Index extends number | string
     ? // Notice that we coalesce the values as strings, this is because in JS,
       // Object.keys always returns strings, even for arrays.
       `${IsIndexAfterSpread<T, Index> extends true ? number : Index}`
@@ -79,7 +77,7 @@ type ArrayKeys<T extends IterableContainer> = {
 
 type IsIndexAfterSpread<
   T extends IterableContainer,
-  Index extends string | number,
+  Index extends number | string,
 > =
   IndicesAfterSpread<T> extends never
     ? false

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -1,6 +1,6 @@
 import { last } from "./last";
 import { pipe } from "./pipe";
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 
 describe("last", () => {
   describe("data first", () => {

--- a/src/last.ts
+++ b/src/last.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 import { purry } from "./purry";
 
 /**

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -192,7 +192,7 @@ describe("Strict", () => {
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
     const result = map.strict(input, identity);
     expectTypeOf(result).toEqualTypeOf<
-      [...Array<string | number | boolean>, string | number | boolean]
+      [...Array<boolean | number | string>, boolean | number | string]
     >();
     expect(result).toEqual(input);
   });
@@ -296,7 +296,7 @@ describe("Strict Indexed", () => {
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
     const result = map.strict.indexed(input, identity);
     expectTypeOf(result).toEqualTypeOf<
-      [...Array<string | number | boolean>, string | number | boolean]
+      [...Array<boolean | number | string>, boolean | number | string]
     >();
     expect(result).toEqual(input);
   });

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,7 +1,8 @@
 import { purry } from "./purry";
-import { LazyResult, _reduceLazy } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { _toLazyIndexed } from "./_toLazyIndexed";
-import {
+import type {
   IterableContainer,
   Pred,
   PredIndexed,
@@ -56,33 +57,21 @@ export function map() {
 
 const _map =
   (indexed: boolean) =>
-  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) => {
-    return _reduceLazy(
-      array,
-      indexed ? map.lazyIndexed(fn) : map.lazy(fn),
-      indexed,
-    );
-  };
+  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) =>
+    _reduceLazy(array, indexed ? map.lazyIndexed(fn) : map.lazy(fn), indexed);
 
 const _lazy =
   (indexed: boolean) =>
-  <T, K>(fn: PredIndexedOptional<T, K>) => {
-    return (
-      value: T,
-      index?: number,
-      array?: ReadonlyArray<T>,
-    ): LazyResult<K> => {
-      return {
-        done: false,
-        hasNext: true,
-        next: indexed ? fn(value, index, array) : fn(value),
-      };
-    };
-  };
+  <T, K>(fn: PredIndexedOptional<T, K>) =>
+  (value: T, index?: number, array?: ReadonlyArray<T>): LazyResult<K> => ({
+    done: false,
+    hasNext: true,
+    next: indexed ? fn(value, index, array) : fn(value),
+  });
 
 // Redefining the map API with a stricter return type. This API is accessed via
 // `map.strict`
-interface Strict {
+type Strict = {
   <T extends IterableContainer, K>(
     items: T,
     mapper: Pred<T[number], K>,
@@ -102,7 +91,7 @@ interface Strict {
       mapper: PredIndexed<T[number], K>,
     ): (items: T) => StrictOut<T, K>;
   };
-}
+};
 
 type StrictOut<T extends IterableContainer, K> = {
   -readonly [P in keyof T]: K;

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -1,4 +1,4 @@
-import { PredIndexedOptional } from "./_types";
+import type { PredIndexedOptional } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -54,16 +54,12 @@ const _mapToObj =
   (
     array: ReadonlyArray<unknown>,
     fn: PredIndexedOptional<unknown, [PropertyKey, unknown]>,
-  ) => {
-    return array.reduce<Record<PropertyKey, unknown>>(
-      (result, element, index) => {
-        const [key, value] = indexed ? fn(element, index, array) : fn(element);
-        result[key] = value;
-        return result;
-      },
-      {},
-    );
-  };
+  ) =>
+    array.reduce<Record<PropertyKey, unknown>>((result, element, index) => {
+      const [key, value] = indexed ? fn(element, index, array) : fn(element);
+      result[key] = value;
+      return result;
+    }, {});
 
 export namespace mapToObj {
   export function indexed<T, K extends PropertyKey, V>(

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -39,7 +39,7 @@ describe("mapValues key types", () => {
   describe("interface", () => {
     test("should set the type of the key to be the union of the keys of the object", () => {
       mapValues({} as { foo: unknown; bar: unknown }, (_, key) =>
-        expectTypeOf(key).toEqualTypeOf<"foo" | "bar">(),
+        expectTypeOf(key).toEqualTypeOf<"bar" | "foo">(),
       );
     });
 
@@ -47,7 +47,7 @@ describe("mapValues key types", () => {
       const mySymbol = Symbol("mySymbol");
       mapValues(
         {} as { [mySymbol]: unknown; foo: unknown; bar: unknown },
-        (_, key) => expectTypeOf(key).toEqualTypeOf<"foo" | "bar">(),
+        (_, key) => expectTypeOf(key).toEqualTypeOf<"bar" | "foo">(),
       );
     });
   });
@@ -77,22 +77,22 @@ describe("mapValues key types", () => {
 
   describe("indexed signature", () => {
     test("should work with string keys", () => {
-      mapValues({} as { [key: string]: unknown }, (_, key) => {
+      mapValues({} as Record<string, unknown>, (_, key) => {
         expectTypeOf(key).toEqualTypeOf<string>();
       });
     });
     test("should work with number keys", () => {
-      mapValues({} as { [key: number]: unknown }, (_, key) => {
+      mapValues({} as Record<number, unknown>, (_, key) => {
         expectTypeOf(key).toEqualTypeOf<`${number}`>();
       });
     });
     test("should work with template literal string keys", () => {
-      mapValues({} as { [key: `prefix${string}`]: unknown }, (_, key) => {
+      mapValues({} as Record<`prefix${string}`, unknown>, (_, key) => {
         expectTypeOf(key).toEqualTypeOf<`prefix${string}`>();
       });
     });
     test("should not work with symbol keys", () => {
-      mapValues({} as { [key: symbol]: unknown }, (_, key) => {
+      mapValues({} as Record<symbol, unknown>, (_, key) => {
         expectTypeOf(key).toEqualTypeOf<never>();
       });
     });

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -1,4 +1,4 @@
-import { ObjectKeys } from "./_types";
+import type { ObjectKeys } from "./_types";
 import { purry } from "./purry";
 import { toPairs } from "./toPairs";
 

--- a/src/maxBy.ts
+++ b/src/maxBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexed, PredIndexedOptional } from "./_types";
+import type { PredIndexed, PredIndexedOptional } from "./_types";
 
 const _maxBy =
   (indexed: boolean) =>

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexed, PredIndexedOptional } from "./_types";
+import type { PredIndexed, PredIndexedOptional } from "./_types";
 
 const _meanBy =
   (indexed: boolean) =>

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -31,5 +31,5 @@ export function merge() {
 }
 
 function _merge<A, B>(a: A, b: B) {
-  return Object.assign({}, a, b);
+  return { ...a, ...b };
 }

--- a/src/mergeDeep.ts
+++ b/src/mergeDeep.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { MergeDeep } from "./type-fest/merge-deep";
+import type { MergeDeep } from "./type-fest/merge-deep";
 
 /**
  * Merges the `source` object into the `destination` object. The merge is similar to performing `{ ...destination, ... source }` (where disjoint values from each object would be copied as-is, and for any overlapping props the value from `source` would be used); But for *each prop* (`p`), if **both** `destination` and `source` have a **plain-object** as a value, the value would be taken as the result of recursively deepMerging them (`result.p === deepMerge(destination.p, source.p)`).

--- a/src/minBy.ts
+++ b/src/minBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexed, PredIndexedOptional } from "./_types";
+import type { PredIndexed, PredIndexedOptional } from "./_types";
 
 const _minBy =
   (indexed: boolean) =>

--- a/src/nthBy.test.ts
+++ b/src/nthBy.test.ts
@@ -122,6 +122,6 @@ describe("typing", () => {
   it("works with tuples", () => {
     const data: [string, boolean, number] = ["a", true, 1];
     const result = nthBy(data, 1, identity);
-    expectTypeOf(result).toEqualTypeOf<string | number | boolean | undefined>();
+    expectTypeOf(result).toEqualTypeOf<boolean | number | string | undefined>();
   });
 });

--- a/src/nthBy.ts
+++ b/src/nthBy.ts
@@ -1,4 +1,5 @@
-import { OrderRule, purryOrderRulesWithArgument } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRulesWithArgument } from "./_purryOrderRules";
 import { quickSelect } from "./_quickSelect";
 import type {
   CompareFunction,

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -50,11 +50,7 @@ function _omit<T extends object, K extends keyof T>(
     // Only one prop to omit.
 
     const [propName] = propNames;
-    const {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- use destructuring to remove a single key, letting JS optimize here...
-      [propName]: omitted,
-      ...remaining
-    } = data;
+    const { [propName]: omitted, ...remaining } = data;
     return remaining;
   }
 

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -7,7 +7,7 @@ describe("data first", () => {
       { a: 1, b: 2, A: 3, B: 4 },
       (_, key) => key.toUpperCase() === key,
     );
-    assertType<Record<"a" | "b" | "A" | "B", number>>(result);
+    assertType<Record<"A" | "a" | "B" | "b", number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
   });
   test("allow partial type", () => {
@@ -26,7 +26,7 @@ describe("data last", () => {
       { a: 1, b: 2, A: 3, B: 4 },
       omitBy((_, key) => key.toUpperCase() === key),
     );
-    assertType<Record<"a" | "b" | "A" | "B", number>>(result);
+    assertType<Record<"A" | "a" | "B" | "b", number>>(result);
     expect(result).toStrictEqual({ a: 1, b: 2 });
   });
   test("allow partial type", () => {

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -82,7 +82,7 @@ describe("strict typing", () => {
   test("tuple with last", () => {
     const arr: [...Array<string>, number] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 
@@ -103,14 +103,14 @@ describe("strict typing", () => {
   test("tuple with optional and array", () => {
     const arr: [string?, ...Array<number>] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 
   test("tuple with all optional", () => {
     const arr: [string?, number?] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 
@@ -166,21 +166,21 @@ describe("strict typing", () => {
   test("readonly tuple with last", () => {
     const arr: readonly [...Array<string>, number] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 
   test("readonly tuple with optional and array", () => {
     const arr: readonly [string?, ...Array<number>] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 
   test("readonly tuple with all optional", () => {
     const arr: readonly [string?, number?] = ["a", 1];
     const result = only(arr);
-    expectTypeOf(result).toEqualTypeOf<string | number | undefined>();
+    expectTypeOf(result).toEqualTypeOf<number | string | undefined>();
     expect(result).toBeUndefined();
   });
 });

--- a/src/only.ts
+++ b/src/only.ts
@@ -1,11 +1,11 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 type Only<T extends IterableContainer> = T extends
-  | readonly []
-  | readonly [unknown, unknown, ...Array<unknown>]
-  | readonly [unknown, ...Array<unknown>, unknown]
   | readonly [...Array<unknown>, unknown, unknown]
+  | readonly []
+  | readonly [unknown, ...Array<unknown>, unknown]
+  | readonly [unknown, unknown, ...Array<unknown>]
   ? undefined
   : T extends readonly [unknown]
     ? T[number]

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -34,9 +34,7 @@ describe("data first", () => {
   test("partition with type guard in pipe", () => {
     const actual = pipe(
       [1, "a", 2, "b"],
-      partition((value): value is number => {
-        return typeof value === "number";
-      }),
+      partition((value): value is number => typeof value === "number"),
     );
     expect(actual).toEqual([
       [1, 2],

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexedOptional, PredIndexed } from "./_types";
+import type { PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
  * Splits a collection into two groups, the first of which contains elements the `predicate` type guard passes, and the second one containing the rest.

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -1,7 +1,7 @@
 import { pathOr } from "./pathOr";
 import { pipe } from "./pipe";
 
-interface SampleType {
+type SampleType = {
   a: {
     b: {
       c: number;
@@ -11,7 +11,7 @@ interface SampleType {
   };
   x?: number;
   y?: number;
-}
+};
 
 const obj: SampleType = {
   a: {

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -7,7 +7,7 @@ describe("data first", () => {
       { a: 1, b: 2, A: 3, B: 4 },
       (_, key) => key.toUpperCase() === key,
     );
-    assertType<Record<"a" | "b" | "A" | "B", number>>(result);
+    assertType<Record<"A" | "a" | "B" | "b", number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
   });
   test("allow undefined or null", () => {
@@ -30,7 +30,7 @@ describe("data last", () => {
       { a: 1, b: 2, A: 3, B: 4 },
       pickBy((_, key) => key.toUpperCase() === key),
     );
-    assertType<Record<"a" | "b" | "A" | "B", number>>(result);
+    assertType<Record<"A" | "a" | "B" | "b", number>>(result);
     expect(result).toStrictEqual({ A: 3, B: 4 });
   });
   test("allow partial type", () => {

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
 
 /**
  * Perform left-to-right function composition.
@@ -196,7 +196,7 @@ export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
 
 export function pipe(
   input: unknown,
-  ...operations: ReadonlyArray<((value: any) => unknown) | LazyOp>
+  ...operations: ReadonlyArray<LazyOp | ((value: any) => unknown)>
 ): any {
   let output = input;
 
@@ -300,9 +300,8 @@ function _processItem(
           }
         }
         return false;
-      } else {
-        item = lazyResult.next;
       }
+      item = lazyResult.next;
     }
     if (!lazyResult.hasNext) {
       break;

--- a/src/rankBy.ts
+++ b/src/rankBy.ts
@@ -1,4 +1,5 @@
-import { OrderRule, purryOrderRulesWithArgument } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRulesWithArgument } from "./_purryOrderRules";
 import type { CompareFunction, NonEmptyArray } from "./_types";
 
 /**

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -49,13 +49,12 @@ const _reduce =
     items: Array<T>,
     fn: (acc: K, item: T, index?: number, items?: Array<T>) => K,
     initialValue: K,
-  ): K => {
-    return items.reduce(
+  ): K =>
+    items.reduce(
       (acc, item, index) =>
         indexed ? fn(acc, item, index, items) : fn(acc, item),
       initialValue,
     );
-  };
 
 export namespace reduce {
   export function indexed<T, K>(

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -1,6 +1,7 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
-import { Pred, PredIndexedOptional, PredIndexed } from "./_types";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
+import type { Pred, PredIndexedOptional, PredIndexed } from "./_types";
 import { _toLazyIndexed } from "./_toLazyIndexed";
 
 /**
@@ -48,34 +49,28 @@ export function reject() {
 
 const _reject =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
-    return _reduceLazy(
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
+    _reduceLazy(
       array,
       indexed ? reject.lazyIndexed(fn) : reject.lazy(fn),
       indexed,
     );
-  };
 
 const _lazy =
   (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, boolean>) => {
-    return (
-      value: T,
-      index?: number,
-      array?: ReadonlyArray<T>,
-    ): LazyResult<T> => {
-      const valid = indexed ? fn(value, index, array) : fn(value);
-      if (!valid) {
-        return {
-          done: false,
-          hasNext: true,
-          next: value,
-        };
-      }
+  <T>(fn: PredIndexedOptional<T, boolean>) =>
+  (value: T, index?: number, array?: ReadonlyArray<T>): LazyResult<T> => {
+    const valid = indexed ? fn(value, index, array) : fn(value);
+    if (!valid) {
       return {
         done: false,
-        hasNext: false,
+        hasNext: true,
+        next: value,
       };
+    }
+    return {
+      done: false,
+      hasNext: false,
     };
   };
 

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from "./_types";
+import type { NonEmptyArray } from "./_types";
 import { sample } from "./sample";
 
 describe("at runtime", () => {
@@ -154,10 +154,10 @@ describe("typing", () => {
       const result = sample(array, 4);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
         | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -166,10 +166,10 @@ describe("typing", () => {
       const result = sample(array, 4);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
         | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -205,9 +205,9 @@ describe("typing", () => {
         // Only when the tuple has 4 elements then the type of the first and
         // second item should be loosened because we don't know how many items
         // are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -227,9 +227,9 @@ describe("typing", () => {
         // Only when the tuple has 4 elements then the type of the first and
         // second item should be loosened because we don't know how many items
         // are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -286,11 +286,11 @@ describe("typing", () => {
       const result = sample(array, 5);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
-        | [number, number, number, number]
         | [number, number, number, number, number]
+        | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -299,11 +299,11 @@ describe("typing", () => {
       const result = sample(array, 5);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
-        | [number, number, number, number]
         | [number, number, number, number, number]
+        | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -335,10 +335,10 @@ describe("typing", () => {
         // elements. Only when the return tuple has 5 elements then the type of
         // the first and second item should be loosened because we don't know
         // how many items are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
-        | [string | number | boolean, string | boolean, string, string, string]
+        | [boolean | number | string, boolean | string, string, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -358,10 +358,10 @@ describe("typing", () => {
         // elements. Only when the return tuple has 5 elements then the type of
         // the first and second item should be loosened because we don't know
         // how many items are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
-        | [string | number | boolean, string | boolean, string, string, string]
+        | [boolean | number | string, boolean | string, string, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -419,38 +419,38 @@ describe("typing", () => {
       const array: Array<number> = [1, 2, 3, 4, 5];
       const result = sample(array, 10);
       expectTypeOf(result).toEqualTypeOf<
+        | [
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+          ]
+        | [
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+          ]
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
-        | [number, number, number, number]
-        | [number, number, number, number, number]
-        | [number, number, number, number, number, number]
-        | [number, number, number, number, number, number, number]
         | [number, number, number, number, number, number, number, number]
-        | [
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-          ]
-        | [
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-          ]
+        | [number, number, number, number, number, number, number]
+        | [number, number, number, number, number, number]
+        | [number, number, number, number, number]
+        | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -458,38 +458,38 @@ describe("typing", () => {
       const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
       const result = sample(array, 10);
       expectTypeOf(result).toEqualTypeOf<
+        | [
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+          ]
+        | [
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+            number,
+          ]
         | []
-        | [number]
-        | [number, number]
-        | [number, number, number]
-        | [number, number, number, number]
-        | [number, number, number, number, number]
-        | [number, number, number, number, number, number]
-        | [number, number, number, number, number, number, number]
         | [number, number, number, number, number, number, number, number]
-        | [
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-          ]
-        | [
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-            number,
-          ]
+        | [number, number, number, number, number, number, number]
+        | [number, number, number, number, number, number]
+        | [number, number, number, number, number]
+        | [number, number, number, number]
+        | [number, number, number]
+        | [number, number]
+        | [number]
       >();
     });
 
@@ -521,40 +521,10 @@ describe("typing", () => {
         // Only when the return tuple has 10 elements then the type of the first
         // and second item should be loosened because we don't know how many
         // items are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
-        | [string | number | boolean, string | boolean, string, string, string]
         | [
-            string | number | boolean,
-            string | boolean,
+            boolean | number | string,
+            boolean | string,
             string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
-            string,
-            string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
             string,
             string,
             string,
@@ -564,9 +534,8 @@ describe("typing", () => {
             string,
           ]
         | [
-            string | number | boolean,
-            string | boolean,
-            string,
+            boolean | number | string,
+            boolean | string,
             string,
             string,
             string,
@@ -575,6 +544,37 @@ describe("typing", () => {
             string,
             string,
           ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [boolean | number | string, boolean | string, string, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -594,40 +594,10 @@ describe("typing", () => {
         // Only when the return tuple has 10 elements then the type of the first
         // and second item should be loosened because we don't know how many
         // items are in the input.
-        | [string | number | boolean, string | boolean]
-        | [string | number | boolean, string | boolean, string]
-        | [string | number | boolean, string | boolean, string, string]
-        | [string | number | boolean, string | boolean, string, string, string]
         | [
-            string | number | boolean,
-            string | boolean,
+            boolean | number | string,
+            boolean | string,
             string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
-            string,
-            string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-          ]
-        | [
-            string | number | boolean,
-            string | boolean,
             string,
             string,
             string,
@@ -637,9 +607,8 @@ describe("typing", () => {
             string,
           ]
         | [
-            string | number | boolean,
-            string | boolean,
-            string,
+            boolean | number | string,
+            boolean | string,
             string,
             string,
             string,
@@ -648,6 +617,37 @@ describe("typing", () => {
             string,
             string,
           ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [
+            boolean | number | string,
+            boolean | string,
+            string,
+            string,
+            string,
+            string,
+          ]
+        | [boolean | number | string, boolean | string, string, string, string]
+        | [boolean | number | string, boolean | string, string, string]
+        | [boolean | number | string, boolean | string, string]
+        | [boolean | number | string, boolean | string]
       >();
     });
 
@@ -661,6 +661,29 @@ describe("typing", () => {
       ];
       const result = sample(array, 10);
       expectTypeOf(result).toEqualTypeOf<
+        | [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            boolean,
+            number,
+          ]
+        | [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            boolean,
+            number,
+          ]
         | [boolean, number]
         | [string, boolean, number]
         | [string, string, boolean, number]
@@ -668,29 +691,6 @@ describe("typing", () => {
         | [string, string, string, string, boolean, number]
         | [string, string, string, string, string, boolean, number]
         | [string, string, string, string, string, string, boolean, number]
-        | [
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            boolean,
-            number,
-          ]
-        | [
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            boolean,
-            number,
-          ]
       >();
     });
 
@@ -704,6 +704,29 @@ describe("typing", () => {
       ];
       const result = sample(array, 10);
       expectTypeOf(result).toEqualTypeOf<
+        | [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            boolean,
+            number,
+          ]
+        | [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            boolean,
+            number,
+          ]
         | [boolean, number]
         | [string, boolean, number]
         | [string, string, boolean, number]
@@ -711,29 +734,6 @@ describe("typing", () => {
         | [string, string, string, string, boolean, number]
         | [string, string, string, string, string, boolean, number]
         | [string, string, string, string, string, string, boolean, number]
-        | [
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            boolean,
-            number,
-          ]
-        | [
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            string,
-            boolean,
-            number,
-          ]
       >();
     });
   });
@@ -770,37 +770,37 @@ describe("typing", () => {
       const result = sample(array, 5 as number);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [1]
-        | [2]
-        | [3]
-        | [4]
-        | [5]
-        | [1, 2]
-        | [1, 3]
-        | [1, 4]
-        | [1, 5]
-        | [2, 3]
-        | [2, 4]
-        | [2, 5]
-        | [3, 4]
-        | [3, 5]
-        | [4, 5]
-        | [1, 2, 3]
-        | [1, 2, 4]
-        | [1, 2, 5]
-        | [1, 3, 4]
-        | [1, 3, 5]
-        | [1, 4, 5]
-        | [2, 3, 4]
-        | [2, 3, 5]
-        | [2, 4, 5]
-        | [3, 4, 5]
+        | [1, 2, 3, 4, 5]
         | [1, 2, 3, 4]
         | [1, 2, 3, 5]
+        | [1, 2, 3]
         | [1, 2, 4, 5]
+        | [1, 2, 4]
+        | [1, 2, 5]
+        | [1, 2]
         | [1, 3, 4, 5]
+        | [1, 3, 4]
+        | [1, 3, 5]
+        | [1, 3]
+        | [1, 4, 5]
+        | [1, 4]
+        | [1, 5]
+        | [1]
         | [2, 3, 4, 5]
-        | [1, 2, 3, 4, 5]
+        | [2, 3, 4]
+        | [2, 3, 5]
+        | [2, 3]
+        | [2, 4, 5]
+        | [2, 4]
+        | [2, 5]
+        | [2]
+        | [3, 4, 5]
+        | [3, 4]
+        | [3, 5]
+        | [3]
+        | [4, 5]
+        | [4]
+        | [5]
       >();
     });
 
@@ -809,37 +809,37 @@ describe("typing", () => {
       const result = sample(array, 5 as number);
       expectTypeOf(result).toEqualTypeOf<
         | []
-        | [1]
-        | [2]
-        | [3]
-        | [4]
-        | [5]
-        | [1, 2]
-        | [1, 3]
-        | [1, 4]
-        | [1, 5]
-        | [2, 3]
-        | [2, 4]
-        | [2, 5]
-        | [3, 4]
-        | [3, 5]
-        | [4, 5]
-        | [1, 2, 3]
-        | [1, 2, 4]
-        | [1, 2, 5]
-        | [1, 3, 4]
-        | [1, 3, 5]
-        | [1, 4, 5]
-        | [2, 3, 4]
-        | [2, 3, 5]
-        | [2, 4, 5]
-        | [3, 4, 5]
+        | [1, 2, 3, 4, 5]
         | [1, 2, 3, 4]
         | [1, 2, 3, 5]
+        | [1, 2, 3]
         | [1, 2, 4, 5]
+        | [1, 2, 4]
+        | [1, 2, 5]
+        | [1, 2]
         | [1, 3, 4, 5]
+        | [1, 3, 4]
+        | [1, 3, 5]
+        | [1, 3]
+        | [1, 4, 5]
+        | [1, 4]
+        | [1, 5]
+        | [1]
         | [2, 3, 4, 5]
-        | [1, 2, 3, 4, 5]
+        | [2, 3, 4]
+        | [2, 3, 5]
+        | [2, 3]
+        | [2, 4, 5]
+        | [2, 4]
+        | [2, 5]
+        | [2]
+        | [3, 4, 5]
+        | [3, 4]
+        | [3, 5]
+        | [3]
+        | [4, 5]
+        | [4]
+        | [5]
       >();
     });
 
@@ -855,8 +855,8 @@ describe("typing", () => {
       expectTypeOf(result).toEqualTypeOf<
         | Array<string>
         | [boolean, ...Array<string>]
-        | [number, boolean, ...Array<string>]
         | [number, ...Array<string>]
+        | [number, boolean, ...Array<string>]
       >();
     });
 
@@ -871,9 +871,9 @@ describe("typing", () => {
       const result = sample(array, 5 as number);
       expectTypeOf(result).toEqualTypeOf<
         | Array<string>
-        | [number, boolean, ...Array<string>]
         | [boolean, ...Array<string>]
         | [number, ...Array<string>]
+        | [number, boolean, ...Array<string>]
       >();
     });
 
@@ -889,7 +889,7 @@ describe("typing", () => {
       expectTypeOf(result).toEqualTypeOf<
         // TODO: the typing isn't ideal here. I'm not even sure what the type
         // here should be...
-        Array<number | boolean | string>
+        Array<boolean | number | string>
       >();
     });
 
@@ -905,7 +905,7 @@ describe("typing", () => {
       expectTypeOf(result).toEqualTypeOf<
         // TODO: the typing isn't ideal here. I'm not even sure what the type
         // here should be...
-        Array<string | number | boolean>
+        Array<boolean | number | string>
       >();
     });
   });

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 type Sampled<T extends IterableContainer, N extends number> =
@@ -18,7 +18,7 @@ type SampledGeneric<T extends IterableContainer> =
     : // As long as the tuple has non-rest elements we continue expanding the type
       // by both taking the item, and not taking it.
       T extends readonly [infer First, ...infer Rest]
-      ? [First, ...SampledGeneric<Rest>] | SampledGeneric<Rest>
+      ? SampledGeneric<Rest> | [First, ...SampledGeneric<Rest>]
       : // Stop the recursion also when we have an array, or the rest element of the
         // tuple
         Array<T[number]>;
@@ -43,8 +43,8 @@ type SampledLiteral<
         : // If the input is an array, or a tuple's rest-element we need to split the
           // recursion in 2, one type adds an element to the output, and the other
           // skips it, just like the sample method itself.
-          | [T[number], ...SampledLiteral<T, N, [unknown, ...Iteration]>]
-            | SampledLiteral<T, N, [unknown, ...Iteration]>;
+          | SampledLiteral<T, N, [unknown, ...Iteration]>
+            | [T[number], ...SampledLiteral<T, N, [unknown, ...Iteration]>];
 
 /**
  * Returns a random subset of size `sampleSize` from `array`.

--- a/src/setPath.test.ts
+++ b/src/setPath.test.ts
@@ -2,7 +2,7 @@ import { pipe } from "./pipe";
 import { setPath } from "./setPath";
 import { stringToPath } from "./stringToPath";
 
-interface SampleType {
+type SampleType = {
   a: {
     b: {
       c: number;
@@ -13,7 +13,7 @@ interface SampleType {
   };
   x?: number;
   y?: number;
-}
+};
 
 const obj: SampleType = {
   a: {

--- a/src/setPath.ts
+++ b/src/setPath.ts
@@ -1,5 +1,5 @@
-import { Narrow } from "./_narrow";
-import { Path, SupportsValueAtPath, ValueAtPath } from "./_paths";
+import type { Narrow } from "./_narrow";
+import type { Path, SupportsValueAtPath, ValueAtPath } from "./_paths";
 import { purry } from "./purry";
 
 /**

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -84,9 +84,9 @@ describe("strict", () => {
     const result = sort.strict(array, () => 1);
     expectTypeOf(result).toEqualTypeOf<
       [
-        number | string | boolean,
-        number | string | boolean,
-        number | string | boolean,
+        boolean | number | string,
+        boolean | number | string,
+        boolean | number | string,
       ]
     >();
   });

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -57,7 +57,7 @@ function _sort<T>(items: Array<T>, cmp: (a: T, b: T) => number) {
   return ret;
 }
 
-interface Strict {
+type Strict = {
   <T extends IterableContainer>(
     items: T,
     cmp: (a: T[number], b: T[number]) => number,
@@ -66,7 +66,7 @@ interface Strict {
   <T extends IterableContainer>(
     cmp: (a: T[number], b: T[number]) => number,
   ): (items: T) => Sorted<T>;
-}
+};
 
 type Sorted<T extends IterableContainer> = {
   -readonly [P in keyof T]: T[number];

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -229,9 +229,9 @@ describe("strict", () => {
     const result = sortBy.strict(array, identity);
     expectTypeOf(result).toEqualTypeOf<
       [
-        number | string | boolean,
-        number | string | boolean,
-        number | string | boolean,
+        boolean | number | string,
+        boolean | number | string,
+        boolean | number | string,
       ]
     >();
   });

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -1,4 +1,5 @@
-import { OrderRule, purryOrderRules } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRules } from "./_purryOrderRules";
 import type {
   CompareFunction,
   IterableContainer,
@@ -108,7 +109,7 @@ const _sortBy = <T>(
   // Sort is done in-place so we need to copy the array.
   [...data].sort(compareFn);
 
-interface Strict {
+type Strict = {
   <T extends IterableContainer>(
     ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
   ): (array: T) => SortedBy<T>;
@@ -117,7 +118,7 @@ interface Strict {
     array: T,
     ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
   ): SortedBy<T>;
-}
+};
 
 type SortedBy<T extends IterableContainer> = {
   -readonly [P in keyof T]: T[number];

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -13,10 +13,12 @@ export function stringToPath<Path extends string>(
 }
 
 function _stringToPath(path: string): Array<string> {
-  if (path.length === 0) return [];
+  if (path.length === 0) {
+    return [];
+  }
 
   const match =
-    path.match(/^\[(.+?)\](.*)$/) ?? path.match(/^\.?([^.[\]]+)(.*)$/);
+    /^\[(.+?)\](.*)$/.exec(path) ?? /^\.?([^.[\]]+)(.*)$/.exec(path);
   if (match) {
     const [, key, rest] = match;
     // @ts-expect-error [ts2322] - Can we improve typing here to assure that `key` and `rest` are defined when the regex matches?

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { PredIndexed, PredIndexedOptional } from "./_types";
+import type { PredIndexed, PredIndexedOptional } from "./_types";
 
 const _sumBy =
   (indexed: boolean) =>

--- a/src/take.ts
+++ b/src/take.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 /**
  * Returns the first `n` elements of `array`.

--- a/src/takeFirstBy.ts
+++ b/src/takeFirstBy.ts
@@ -1,5 +1,6 @@
 import { heapify, heapMaybeInsert } from "./_heap";
-import { OrderRule, purryOrderRulesWithArgument } from "./_purryOrderRules";
+import type { OrderRule } from "./_purryOrderRules";
+import { purryOrderRulesWithArgument } from "./_purryOrderRules";
 import type { CompareFunction, NonEmptyArray } from "./_types";
 
 /**

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -53,11 +53,9 @@ type Pairs<T> = Array<
   { [K in keyof T]-?: [key: K, value: Required<T>[K]] }[keyof T]
 >;
 
-type Strict = {
-  <T extends NonNullable<unknown>>(object: T): Pairs<T>;
+type Strict = // (): <T extends NonNullable<unknown>>(object: T) => Pairs<T>;
   // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-  // (): <T extends NonNullable<unknown>>(object: T) => Pairs<T>;
-};
+  <T extends NonNullable<unknown>>(object: T) => Pairs<T>;
 
 export namespace toPairs {
   export const strict = toPairs as Strict;

--- a/src/type-fest/enforce-optional.ts
+++ b/src/type-fest/enforce-optional.ts
@@ -16,14 +16,14 @@ type OptionalFilter<Type, Key extends keyof Type> = undefined extends Type[Key]
 
 export type EnforceOptional<ObjectType> = Simplify<
   {
-    [Key in keyof ObjectType as RequiredFilter<
-      ObjectType,
-      Key
-    >]: ObjectType[Key];
-  } & {
     [Key in keyof ObjectType as OptionalFilter<ObjectType, Key>]?: Exclude<
       ObjectType[Key],
       undefined
     >;
+  } & {
+    [Key in keyof ObjectType as RequiredFilter<
+      ObjectType,
+      Key
+    >]: ObjectType[Key];
   }
 >;

--- a/src/type-fest/is-any.ts
+++ b/src/type-fest/is-any.ts
@@ -1,1 +1,1 @@
-export type IsAny<T> = 0 extends 1 & T ? true : false;
+export type IsAny<T> = 0 extends T & 1 ? true : false;

--- a/src/type-fest/merge.ts
+++ b/src/type-fest/merge.ts
@@ -3,13 +3,13 @@ import type { OmitIndexSignature } from "./omit-index-signature";
 import type { PickIndexSignature } from "./pick-index-signature";
 
 // Merges two objects without worrying about index signatures.
-type SimpleMerge<Destination, Source> = {
+type SimpleMerge<Destination, Source> = Source & {
   [Key in keyof Destination as Key extends keyof Source
     ? never
     : Key]: Destination[Key];
-} & Source;
+};
 
 export type Merge<Destination, Source> = EnforceOptional<
-  SimpleMerge<PickIndexSignature<Destination>, PickIndexSignature<Source>> &
-    SimpleMerge<OmitIndexSignature<Destination>, OmitIndexSignature<Source>>
+  SimpleMerge<OmitIndexSignature<Destination>, OmitIndexSignature<Source>> &
+    SimpleMerge<PickIndexSignature<Destination>, PickIndexSignature<Source>>
 >;

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 /**
  * Returns a new array containing only one copy of each element in the original list.

--- a/src/uniqBy.ts
+++ b/src/uniqBy.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { _reduceLazy, LazyResult } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 
 export function uniqBy<T, K>(
   array: ReadonlyArray<T>,

--- a/src/uniqWith.ts
+++ b/src/uniqWith.ts
@@ -1,5 +1,6 @@
 import { purry } from "./purry";
-import { LazyResult, _reduceLazy } from "./_reduceLazy";
+import type { LazyResult } from "./_reduceLazy";
+import { _reduceLazy } from "./_reduceLazy";
 import { _toLazyIndexed } from "./_toLazyIndexed";
 
 type IsEquals<T> = (a: T, b: T) => boolean;

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -14,7 +14,7 @@ describe("Runtime", () => {
 
 describe("typing", () => {
   it("should correctly types indexed types", () => {
-    expectTypeOf(values<{ [index: string]: string }>({ a: "b" })).toEqualTypeOf<
+    expectTypeOf(values<Record<string, string>>({ a: "b" })).toEqualTypeOf<
       Array<string>
     >();
   });
@@ -46,6 +46,6 @@ describe("typing", () => {
   it("should correctly type typed objects", () => {
     expectTypeOf(
       values<{ type: "cat" | "dog"; age: number }>({ type: "cat", age: 7 }),
-    ).toEqualTypeOf<Array<"cat" | "dog" | number>>();
+    ).toEqualTypeOf<Array<number | "cat" | "dog">>();
   });
 });

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -41,7 +41,7 @@ describe("dataFirst typings", () => {
     const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
     const actual = zip(firstVariadic, secondVariadic);
-    assertType<Array<[string | number, string | number]>>(actual);
+    assertType<Array<[number | string, number | string]>>(actual);
   });
 });
 
@@ -80,7 +80,7 @@ describe("dataLast typings", () => {
     const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
     const actual = pipe(firstVariadic, zip(secondVariadic));
-    assertType<Array<[string | number, string | number]>>(actual);
+    assertType<Array<[number | string, number | string]>>(actual);
   });
 });
 

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,4 +1,4 @@
-import { IterableContainer } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -58,7 +58,7 @@ function _zip(first: Array<unknown>, second: Array<unknown>) {
   return result;
 }
 
-interface Strict {
+type Strict = {
   <F extends IterableContainer, S extends IterableContainer>(
     first: F,
     second: S,
@@ -67,7 +67,7 @@ interface Strict {
   <S extends IterableContainer>(
     second: S,
   ): <F extends IterableContainer>(first: F) => Zip<F, S>;
-}
+};
 
 type Zip<Left extends IterableContainer, Right extends IterableContainer> =
   // If the array is empty the output is empty, no surprises

--- a/src/zipObj.test.ts
+++ b/src/zipObj.test.ts
@@ -41,7 +41,7 @@ describe("data first typings", () => {
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
     const actual = zipObj(firstVariadic, secondVariadic);
     expectTypeOf(actual).toEqualTypeOf<
-      Record<string | number, number | string>
+      Record<number | string, number | string>
     >();
   });
 });
@@ -82,7 +82,7 @@ describe("data last typings", () => {
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
     const actual = zipObj(secondVariadic)(firstVariadic);
     expectTypeOf(actual).toEqualTypeOf<
-      Record<string | number, string | number>
+      Record<number | string, number | string>
     >();
   });
 });

--- a/src/zipObj.ts
+++ b/src/zipObj.ts
@@ -12,7 +12,7 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Array
  */
-export function zipObj<F extends string | number | symbol, S>(
+export function zipObj<F extends number | string | symbol, S>(
   first: ReadonlyArray<F>,
   second: ReadonlyArray<S>,
 ): Record<F, S>;
@@ -30,7 +30,7 @@ export function zipObj<F extends string | number | symbol, S>(
  */
 export function zipObj<S>(
   second: ReadonlyArray<S>,
-): <F extends string | number | symbol>(
+): <F extends number | string | symbol>(
   first: ReadonlyArray<F>,
 ) => Record<F, S>;
 
@@ -39,12 +39,12 @@ export function zipObj() {
 }
 
 function _zipObj(
-  first: Array<string | number | symbol>,
+  first: Array<number | string | symbol>,
   second: Array<unknown>,
 ) {
   const resultLength =
     first.length > second.length ? second.length : first.length;
-  const result: Record<string | number | symbol, unknown> = {};
+  const result: Record<number | string | symbol, unknown> = {};
   for (let i = 0; i < resultLength; i++) {
     result[first[i]!] = second[i];
   }

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -52,7 +52,7 @@ export function zipWith<F, S, R>(
 ): (first: ReadonlyArray<F>) => Array<R>;
 
 export function zipWith(
-  arg0: ZippingFunction | ReadonlyArray<unknown>,
+  arg0: ReadonlyArray<unknown> | ZippingFunction,
   arg1?: ReadonlyArray<unknown>,
   arg2?: ZippingFunction,
 ): unknown {

--- a/test/types_data_provider.ts
+++ b/test/types_data_provider.ts
@@ -24,7 +24,7 @@ export const TYPES_DATA_PROVIDER = {
   symbol: Symbol("symbol"),
   tuple: [1, 2, 3] as [number, number, number],
   typedArray: new Uint8Array(1),
-  undefined: undefined,
+  undefined,
 } as const;
 
 export const ALL_TYPES_DATA_PROVIDER = Object.values(TYPES_DATA_PROVIDER);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,6 @@
     "lib": ["ES6", "ES2017.Object", "DOM", "DOM.Iterable"],
 
     // COMPLETENESS
-    "skipLibCheck": true,
-  },
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
The more eslint rules we have turned on, the easier it is for contributors to get feedback fast and get PRs reviewed and shipped.

This PR adds a bunch of lint rules from both typescript and eslint which aim to prevent JSisms, and standardize the codebase.