### PR TITLE
feat(values,keys,fromPairs,toPairs): Remove dataLast impls (reverts #531)

### DIFF
--- a/src/fromPairs.test.ts
+++ b/src/fromPairs.test.ts
@@ -1,5 +1,4 @@
 import { fromPairs } from "./fromPairs";
-import { pipe } from "./pipe";
 
 const tuples: Array<[string, number]> = [
   ["a", 1],
@@ -10,35 +9,6 @@ const tuples: Array<[string, number]> = [
 describe("runtime", () => {
   test("dataFirst", () => {
     expect(fromPairs(tuples)).toEqual({
-      a: 1,
-      b: 2,
-      c: 3,
-    });
-  });
-
-  test("dataLast", () => {
-    expect(fromPairs()(tuples)).toEqual({
-      a: 1,
-      b: 2,
-      c: 3,
-    });
-  });
-
-  test("dataLast pipe", () => {
-    expect(pipe(tuples, fromPairs())).toEqual({
-      a: 1,
-      b: 2,
-      c: 3,
-    });
-  });
-
-  test('"headless" dataLast', () => {
-    // Older versions of Remeda didn't provide a native dataLast impl and
-    // suggested users use a "headless" version of the dataFirst impl to get the
-    // dataLast behavior.
-    // TODO: Remove this test once we release Remeda v2 where we won't
-    // officially continue to support this.
-    expect(pipe(tuples, fromPairs)).toEqual({
       a: 1,
       b: 2,
       c: 3,
@@ -57,12 +27,6 @@ describe("typings", () => {
       ["b", "c"],
     ]);
     assertType<Record<string, string | number>>(actual);
-  });
-
-  test("narrow types are widened by non-strict dataLast call", () => {
-    const data = [["a", 1]] as const;
-    expectTypeOf(fromPairs(data)).toEqualTypeOf<Record<string, 1>>();
-    expectTypeOf(pipe(data, fromPairs())).toEqualTypeOf<Record<string, 1>>();
   });
 });
 

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -20,6 +20,14 @@ type Entry<Key extends PropertyKey = PropertyKey, Value = unknown> = readonly [
  * @example
  *   R.fromPairs([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'} (type: Record<string, string>)
  *   R.fromPairs.strict(['a', 1] as const) // => {a: 1} (type: {a: 1})
+ *   R.pipe(
+ *     [['a', 'b'], ['c', 'd']],
+ *     R.fromPairs,
+ *   ); // => {a: 'b', c: 'd'} (type: Record<string, string>)
+ *   R.pipe(
+ *     ['a', 1] as const,
+ *     R.fromPairs.strict,
+ *   ); // => {a: 1} (type: {a: 1})
  * @category Object
  * @strict
  * @dataFirst

--- a/src/fromPairs.ts
+++ b/src/fromPairs.ts
@@ -55,9 +55,10 @@ export function fromPairs<V>(
  * @strict
  * @dataLast
  */
-export function fromPairs(): <K extends PropertyKey, V>(
-  pairs: ReadonlyArray<Entry<K, V>>,
-) => Record<K extends string ? string : K extends number ? number : never, V>;
+// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+// export function fromPairs(): <K extends PropertyKey, V>(
+//   pairs: ReadonlyArray<Entry<K, V>>,
+// ) => Record<K extends string ? string : K extends number ? number : never, V>;
 
 export function fromPairs() {
   // TODO: When we bump the typescript target beyond ES2019 we can use Object.fromEntries directly here instead of our user-space implementation.
@@ -80,9 +81,10 @@ type Strict = {
   <Entries extends IterableContainer<Entry>>(
     entries: Entries,
   ): StrictOut<Entries>;
-  (): <Entries extends IterableContainer<Entry>>(
-    entries: Entries,
-  ) => StrictOut<Entries>;
+  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+  // (): <Entries extends IterableContainer<Entry>>(
+  //   entries: Entries,
+  // ) => StrictOut<Entries>;
 };
 
 // The 2 kinds of arrays we accept result in different kinds of outputs:

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -1,5 +1,4 @@
 import { keys } from "./keys";
-import { pipe } from "./pipe";
 
 describe("runtime", () => {
   describe("dataFirst", () => {
@@ -17,45 +16,6 @@ describe("runtime", () => {
         "b",
         "c",
       ]);
-    });
-  });
-
-  describe("dataLast", () => {
-    it("work with arrays", () => {
-      expect(keys()(["x", "y", "z"])).toEqual(["0", "1", "2"]);
-    });
-
-    it("work with objects", () => {
-      expect(keys()({ a: "x", b: "y", c: "z" })).toEqual(["a", "b", "c"]);
-    });
-
-    it("should return strict types", () => {
-      expect(keys.strict()({ 5: "x", b: "y", c: "z" } as const)).toEqual([
-        "5",
-        "b",
-        "c",
-      ]);
-    });
-
-    it("should work in pipes", () => {
-      expect(pipe({ a: "x", b: "y", c: "z" }, keys())).toEqual(["a", "b", "c"]);
-    });
-
-    it("should work in pipes with strict", () => {
-      expect(pipe({ a: "x", b: "y", c: "z" }, keys.strict())).toEqual([
-        "a",
-        "b",
-        "c",
-      ]);
-    });
-
-    test('"headless" dataLast', () => {
-      // Older versions of Remeda didn't provide a native dataLast impl and
-      // suggested users use a "headless" version of the dataFirst impl to get the
-      // dataLast behavior.
-      // TODO: Remove this test once we release Remeda v2 where we won't
-      // officially continue to support this.
-      expect(pipe({ a: "x", b: "y", c: "z" }, keys)).toEqual(["a", "b", "c"]);
     });
   });
 });

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -40,9 +40,10 @@ export function keys(
  * @category Object
  * @dataLast
  */
-export function keys(): (
-  source: Record<PropertyKey, unknown> | ArrayLike<unknown>,
-) => Array<string>;
+// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+// export function keys(): (
+//   source: Record<PropertyKey, unknown> | ArrayLike<unknown>,
+// ) => Array<string>;
 
 export function keys() {
   return purry(Object.keys, arguments);
@@ -50,7 +51,8 @@ export function keys() {
 
 type Strict = {
   <T extends object>(data: T): Keys<T>;
-  (): <T extends object>(data: T) => Keys<T>;
+  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+  // (): <T extends object>(data: T) => Keys<T>;
 };
 type Keys<T> = T extends IterableContainer ? ArrayKeys<T> : ObjectKeys<T>;
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -11,6 +11,14 @@ import { purry } from "./purry";
  *    R.keys(['x', 'y', 'z']) // => ['0', '1', '2']
  *    R.keys({ a: 'x', b: 'y', c: 'z' }) // => ['a', 'b', 'c']
  *    R.keys.strict({ a: 'x', b: 'y', 5: 'z' } as const ) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
+ *    R.pipe(['x', 'y', 'z'], R.keys) // => ['0', '1', '2']
+ *    R.pipe({ a: 'x', b: 'y', c: 'z' }, R.keys) // => ['a', 'b', 'c']
+ *    R.pipe(
+ *      { a: 'x', b: 'y', c: 'z' },
+ *      R.keys,
+ *      R.first(),
+ *    ) // => 'a'
+ *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys.strict) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
  * @pipeable
  * @strict
  * @category Object

--- a/src/randomString.ts
+++ b/src/randomString.ts
@@ -12,6 +12,7 @@ const ALPHABET =
  *   R.randomString(length)
  * @example
  *   R.randomString(5) // => aB92J
+ *   R.pipe(5, R.randomString) // => aB92J
  * @category String
  * @dataFirst
  */

--- a/src/randomString.ts
+++ b/src/randomString.ts
@@ -28,7 +28,8 @@ export function randomString(length: number): string;
  * @category String
  * @dataLast
  */
-export function randomString(): (length: number) => string;
+// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+// export function randomString(): (length: number) => string;
 
 export function randomString() {
   return purry(randomStringImplementation, arguments);

--- a/src/toPairs.test.ts
+++ b/src/toPairs.test.ts
@@ -1,30 +1,8 @@
-import { pipe } from "./pipe";
 import { toPairs } from "./toPairs";
 
 describe("runtime", () => {
   test("dataFirst", () => {
     expect(toPairs({ a: 1, b: 2, c: 3 })).toEqual([
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ]);
-  });
-
-  test("dataLast", () => {
-    expect(toPairs()({ a: 1, b: 2, c: 3 })).toEqual([
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ]);
-  });
-
-  test('"headless" dataLast', () => {
-    // Older versions of Remeda didn't provide a native dataLast impl and
-    // suggested users use a "headless" version of the dataFirst impl to get the
-    // dataLast behavior.
-    // TODO: Remove this test once we release Remeda v2 where we won't
-    // officially continue to support this.
-    expect(pipe({ a: 1, b: 2, c: 3 }, toPairs)).toEqual([
       ["a", 1],
       ["b", 2],
       ["c", 3],

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -9,6 +9,14 @@ import { purry } from "./purry";
  * @example
  *    R.toPairs({ a: 1, b: 2, c: 3 }) // => [['a', 1], ['b', 2], ['c', 3]]
  *    R.toPairs.strict({ a: 1 } as const) // => [['a', 1]] typed Array<['a', 1]>
+ *    R.pipe(
+ *      { a: 1, b: 2, c: 3 },
+ *      toPairs,
+ *    ); // => [['a', 1], ['b', 2], ['c', 3]]
+ *    R.pipe(
+ *      { a: 1 } as const,
+ *      toPairs.strict,
+ *    ); // => [['a', 1]] typed Array<['a', 1]>
  * @strict
  * @category Object
  * @dataFirst

--- a/src/toPairs.ts
+++ b/src/toPairs.ts
@@ -34,7 +34,8 @@ export function toPairs<T>(object: Record<string, T>): Array<[string, T]>;
  * @category Object
  * @dataLast
  */
-export function toPairs(): <T>(object: Record<string, T>) => Array<[string, T]>;
+// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+// export function toPairs(): <T>(object: Record<string, T>) => Array<[string, T]>;
 
 export function toPairs() {
   return purry(Object.entries, arguments);
@@ -46,7 +47,8 @@ type Pairs<T> = Array<
 
 type Strict = {
   <T extends NonNullable<unknown>>(object: T): Pairs<T>;
-  (): <T extends NonNullable<unknown>>(object: T) => Pairs<T>;
+  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+  // (): <T extends NonNullable<unknown>>(object: T) => Pairs<T>;
 };
 
 export namespace toPairs {

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -1,4 +1,3 @@
-import { pipe } from "./pipe";
 import { values } from "./values";
 
 describe("Runtime", () => {
@@ -9,34 +8,6 @@ describe("Runtime", () => {
 
     it("should return values of object", () => {
       expect(values({ a: "x", b: "y", c: "z" })).toEqual(["x", "y", "z"]);
-    });
-  });
-
-  describe("dataLast", () => {
-    it("works with arrays", () => {
-      expect(values()(["x", "y", "z"])).toEqual(["x", "y", "z"]);
-    });
-
-    it("works with objects", () => {
-      expect(values()({ a: "x", b: "y", c: "z" })).toEqual(["x", "y", "z"]);
-    });
-
-    it("works with pipes", () => {
-      expect(pipe(["x", "y", "z"], values())).toEqual(["x", "y", "z"]);
-      expect(pipe({ a: "x", b: "y", c: "z" }, values())).toEqual([
-        "x",
-        "y",
-        "z",
-      ]);
-    });
-
-    test('"headless" dataLast', () => {
-      // Older versions of Remeda didn't provide a native dataLast impl and
-      // suggested users use a "headless" version of the dataFirst impl to get the
-      // dataLast behavior.
-      // TODO: Remove this test once we release Remeda v2 where we won't
-      // officially continue to support this.
-      expect(pipe({ a: "x", b: "y", c: "z" }, values)).toEqual(["x", "y", "z"]);
     });
   });
 });

--- a/src/values.ts
+++ b/src/values.ts
@@ -35,7 +35,8 @@ export function values<T extends object>(data: T): Values<T>;
  * @category Object
  * @dataLast
  */
-export function values(): <T extends object>(data: T) => Values<T>;
+// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
+// export function values(): <T extends object>(data: T) => Values<T>;
 
 export function values() {
   return purry(Object.values, arguments);

--- a/src/values.ts
+++ b/src/values.ts
@@ -12,6 +12,13 @@ type Values<T extends object> = T extends ReadonlyArray<unknown> | []
  * @example
  *    R.values(['x', 'y', 'z']) // => ['x', 'y', 'z']
  *    R.values({ a: 'x', b: 'y', c: 'z' }) // => ['x', 'y', 'z']
+ *    R.pipe(['x', 'y', 'z'], R.values) // => ['x', 'y', 'z']
+ *    R.pipe({ a: 'x', b: 'y', c: 'z' }, R.values) // => ['x', 'y', 'z']
+ *    R.pipe(
+ *      { a: 'x', b: 'y', c: 'z' },
+ *      R.values,
+ *      R.first,
+ *    ) // => 'x'
  * @pipeable
  * @category Object
  * @dataFirst


### PR DESCRIPTION
I can't think of a way to support the headless versions in tandem with adding the dataLast implementations, typescript considers the function a completely different "thing" once we have the dataLast overload and doesn't fallback to the dataFirst variant inside the pipes.

Blamed on #531
Fixes #539