### PR TITLE
fix: add unicorn lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -263,22 +263,21 @@ module.exports = tseslint.config(
       // (We are assuming that the config is extended by unicorns's:
       // flat/recommended extension)
 
+      "unicorn/custom-error-definition": "warn",
+      "unicorn/no-unused-properties": "warn",
+      "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
-      "unicorn/no-useless-undefined": [
-        "error",
-        { checkArguments: false, checkArrowFunctionBody: false },
-      ],
+      "unicorn/filename-case": ["error", { case: "camelCase" }],
 
-      "unicorn/filename-case": "off",
-      "unicorn/prevent-abbreviations": "off",
       "unicorn/no-nested-ternary": "off",
+      "unicorn/prevent-abbreviations": "off",
 
       // TODO: Once we bump our typescript `target` we should enable this rule
       "unicorn/no-array-for-each": "off",
       "unicorn/no-for-loop": "off",
       "unicorn/prefer-at": "off",
-      "unicorn/prefer-spread": "off",
       "unicorn/prefer-number-properties": "off",
+      "unicorn/prefer-spread": "off",
     },
   },
   {
@@ -289,6 +288,7 @@ module.exports = tseslint.config(
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-var-requires": "off",
       "unicorn/prefer-module": "off",
+      "unicorn/filename-case": "off",
     },
   },
   {
@@ -296,14 +296,26 @@ module.exports = tseslint.config(
     rules: {
       // Type-fest uses a lot of "banned" types...
       "@typescript-eslint/ban-types": "off",
+      "unicorn/filename-case": "off",
     },
   },
   {
-    files: ["src/**/*.test.ts", "test/**/*.ts"],
+    files: ["src/**/*.test.ts"],
+    rules: {
+      "unicorn/no-array-callback-reference": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-useless-undefined": [
+        "warn",
+        { checkArguments: false, checkArrowFunctionBody: false },
+      ],
+    },
+  },
+  {
+    files: ["test/**/*.ts"],
     rules: {
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",
-      "unicorn/no-array-callback-reference": "off",
+      "unicorn/filename-case": "off",
       "unicorn/no-null": "off",
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -278,7 +278,39 @@ module.exports = tseslint.config(
       "unicorn/prefer-number-properties": "off",
       "unicorn/prefer-spread": "off",
 
-      "unicorn/prevent-abbreviations": "off",
+      "unicorn/prevent-abbreviations": [
+        "warn",
+        {
+          replacements: {
+            res: {
+              resource: false,
+              response: false,
+            },
+            ret: {
+              out: true,
+              returnValue: false,
+            },
+          },
+          allowList: {
+            arg: true,
+            Arg: true,
+            args: true,
+            Args: true,
+            fn: true,
+            Fn: true,
+            func: true,
+            Func: true,
+            num: true,
+            obj: true,
+            Obj: true,
+            prop: true,
+            Prop: true,
+            props: true,
+            Props: true,
+            str: true,
+          },
+        },
+      ],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -269,15 +269,14 @@ module.exports = tseslint.config(
       "unicorn/switch-case-braces": ["error", "avoid"],
       "unicorn/filename-case": ["error", { case: "camelCase" }],
 
-      "unicorn/no-nested-ternary": "off",
-      "unicorn/prevent-abbreviations": "off",
-
       // TODO: Once we bump our typescript `target` we should enable this rule
       "unicorn/no-array-for-each": "off",
       "unicorn/no-for-loop": "off",
       "unicorn/prefer-at": "off",
       "unicorn/prefer-number-properties": "off",
       "unicorn/prefer-spread": "off",
+
+      "unicorn/prevent-abbreviations": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -263,13 +263,13 @@ module.exports = tseslint.config(
       // (We are assuming that the config is extended by unicorns's:
       // flat/recommended extension)
 
+      "unicorn/consistent-destructuring": "warn",
       "unicorn/custom-error-definition": "warn",
       "unicorn/filename-case": ["error", { case: "camelCase" }],
       "unicorn/no-keyword-prefix": "warn",
       "unicorn/no-unused-properties": "warn",
       "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
-      "unicorn/consistent-destructuring": "warn",
 
       // TODO: Once we bump our typescript `target` we should enable this rule
       "unicorn/no-array-for-each": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -271,12 +271,14 @@ module.exports = tseslint.config(
 
       "unicorn/filename-case": "off",
       "unicorn/prevent-abbreviations": "off",
+      "unicorn/no-nested-ternary": "off",
 
       // TODO: Once we bump our typescript `target` we should enable this rule
       "unicorn/no-array-for-each": "off",
       "unicorn/no-for-loop": "off",
       "unicorn/prefer-at": "off",
       "unicorn/prefer-spread": "off",
+      "unicorn/prefer-number-properties": "off",
     },
   },
   {
@@ -301,6 +303,8 @@ module.exports = tseslint.config(
     rules: {
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",
+      "unicorn/no-array-callback-reference": "off",
+      "unicorn/no-null": "off",
     },
   },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,8 +58,7 @@ module.exports = tseslint.config(
       "no-duplicate-imports": "off",
       "@typescript-eslint/consistent-type-imports": ["warn"],
 
-      // TODO: Once we bump our typescript `target` we should enable this rule
-      // "unicorn/no-array-for-each": "off",
+      // TODO: Once we bump our typescript `target` we should enable these rules.
       "unicorn/no-for-loop": "off",
       "unicorn/prefer-at": "off",
       "unicorn/prefer-number-properties": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -258,6 +258,13 @@ module.exports = tseslint.config(
       "no-shadow": "off",
       "@typescript-eslint/no-shadow": "error",
       "@typescript-eslint/no-unsafe-unary-minus": "error",
+
+      // === Unicorn ==========================================================
+      // (We are assuming that the config is extended by unicorns's:
+      // flat/recommended extension)
+
+      "unicorn/filename-case": "off",
+      "unicorn/prevent-abbreviations": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -263,8 +263,20 @@ module.exports = tseslint.config(
       // (We are assuming that the config is extended by unicorns's:
       // flat/recommended extension)
 
+      "unicorn/switch-case-braces": ["error", "avoid"],
+      "unicorn/no-useless-undefined": [
+        "error",
+        { checkArguments: false, checkArrowFunctionBody: false },
+      ],
+
       "unicorn/filename-case": "off",
       "unicorn/prevent-abbreviations": "off",
+
+      // TODO: Once we bump our typescript `target` we should enable this rule
+      "unicorn/no-array-for-each": "off",
+      "unicorn/no-for-loop": "off",
+      "unicorn/prefer-at": "off",
+      "unicorn/prefer-spread": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -277,38 +277,11 @@ module.exports = tseslint.config(
       "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
 
-      // TODO: Enable this in a separate PR so we can run the auto-fix and ship without reviewing every file.
+      // TODO: These rules allow us to really standardize our codebase, but they
+      // also do sweeping changes to the whole codebase which is very noisy. We
+      // should do it in one sweep sometime in the future.
+      "@typescript-eslint/naming-convention": "off",
       "unicorn/prevent-abbreviations": "off",
-      //   "unicorn/prevent-abbreviations": [
-      //     "warn",
-      //     {
-      //       replacements: {
-      //         res: {
-      //           resource: false,
-      //           response: false,
-      //         },
-      //       },
-      //       allowList: {
-      //         arg: true,
-      //         Arg: true,
-      //         args: true,
-      //         Args: true,
-      //         fn: true,
-      //         Fn: true,
-      //         func: true,
-      //         Func: true,
-      //         num: true,
-      //         obj: true,
-      //         Obj: true,
-      //         prop: true,
-      //         Prop: true,
-      //         props: true,
-      //         Props: true,
-      //         ret: true,
-      //         str: true,
-      //       },
-      //     },
-      //   ],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -264,10 +264,12 @@ module.exports = tseslint.config(
       // flat/recommended extension)
 
       "unicorn/custom-error-definition": "warn",
+      "unicorn/filename-case": ["error", { case: "camelCase" }],
+      "unicorn/no-keyword-prefix": "warn",
       "unicorn/no-unused-properties": "warn",
       "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
-      "unicorn/filename-case": ["error", { case: "camelCase" }],
+      "unicorn/consistent-destructuring": "warn",
 
       // TODO: Once we bump our typescript `target` we should enable this rule
       "unicorn/no-array-for-each": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,13 @@ module.exports = tseslint.config(
       "no-duplicate-imports": "off",
       "@typescript-eslint/consistent-type-imports": ["warn"],
 
+      // TODO: Once we bump our typescript `target` we should enable this rule
+      "unicorn/no-array-for-each": "off",
+      "unicorn/no-for-loop": "off",
+      "unicorn/prefer-at": "off",
+      "unicorn/prefer-number-properties": "off",
+      "unicorn/prefer-spread": "off",
+
       // === ESLint ============================================================
       // (We are assuming that the config is extended by eslint's: recommended
       // extension)
@@ -271,46 +278,37 @@ module.exports = tseslint.config(
       "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
 
-      // TODO: Once we bump our typescript `target` we should enable this rule
-      "unicorn/no-array-for-each": "off",
-      "unicorn/no-for-loop": "off",
-      "unicorn/prefer-at": "off",
-      "unicorn/prefer-number-properties": "off",
-      "unicorn/prefer-spread": "off",
-
-      "unicorn/prevent-abbreviations": [
-        "warn",
-        {
-          replacements: {
-            res: {
-              resource: false,
-              response: false,
-            },
-            ret: {
-              out: true,
-              returnValue: false,
-            },
-          },
-          allowList: {
-            arg: true,
-            Arg: true,
-            args: true,
-            Args: true,
-            fn: true,
-            Fn: true,
-            func: true,
-            Func: true,
-            num: true,
-            obj: true,
-            Obj: true,
-            prop: true,
-            Prop: true,
-            props: true,
-            Props: true,
-            str: true,
-          },
-        },
-      ],
+      // TODO: Enable this in a separate PR so we can run the auto-fix and ship without reviewing every file.
+      //   "unicorn/prevent-abbreviations": [
+      //     "warn",
+      //     {
+      //       replacements: {
+      //         res: {
+      //           resource: false,
+      //           response: false,
+      //         },
+      //       },
+      //       allowList: {
+      //         arg: true,
+      //         Arg: true,
+      //         args: true,
+      //         Args: true,
+      //         fn: true,
+      //         Fn: true,
+      //         func: true,
+      //         Func: true,
+      //         num: true,
+      //         obj: true,
+      //         Obj: true,
+      //         prop: true,
+      //         Prop: true,
+      //         props: true,
+      //         Props: true,
+      //         ret: true,
+      //         str: true,
+      //       },
+      //     },
+      //   ],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,7 @@ module.exports = tseslint.config(
       "@typescript-eslint/consistent-type-imports": ["warn"],
 
       // TODO: Once we bump our typescript `target` we should enable this rule
-      "unicorn/no-array-for-each": "off",
+      // "unicorn/no-array-for-each": "off",
       "unicorn/no-for-loop": "off",
       "unicorn/prefer-at": "off",
       "unicorn/prefer-number-properties": "off",
@@ -279,6 +279,7 @@ module.exports = tseslint.config(
       "unicorn/switch-case-braces": ["error", "avoid"],
 
       // TODO: Enable this in a separate PR so we can run the auto-fix and ship without reviewing every file.
+      "unicorn/prevent-abbreviations": "off",
       //   "unicorn/prevent-abbreviations": [
       //     "warn",
       //     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,8 @@
 const js = require("@eslint/js");
 const tseslint = require("typescript-eslint");
+// @ts-expect-error [ts7016] - Unicorn not supporting CommonJS-based flat configs.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Unicorn doesn't support CommonJS-based flat configs.
+const eslintPluginUnicorn = require("eslint-plugin-unicorn");
 
 module.exports = tseslint.config(
   {
@@ -8,6 +11,8 @@ module.exports = tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- Unicorn doesn't support CommonJS-based flat configs.
+  eslintPluginUnicorn.configs["flat/recommended"],
   {
     languageOptions: {
       parserOptions: {
@@ -262,6 +267,7 @@ module.exports = tseslint.config(
       "@typescript-eslint/no-require-imports": "off",
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-var-requires": "off",
+      "unicorn/prefer-module": "off",
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import core from "@eslint/js";
+import prettierConfig from "eslint-config-prettier";
 // @ts-expect-error [ts7016] -- I don't know why typing is broken here...
 import { configs as unicornConfigs } from "eslint-plugin-unicorn";
 import { config, configs as typescriptConfigs } from "typescript-eslint";
@@ -12,6 +13,7 @@ export default config(
   ...typescriptConfigs.stylisticTypeChecked,
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- I don't know why typing is broken for unicorn...
   unicornConfigs["flat/recommended"],
+  prettierConfig,
   {
     languageOptions: {
       parserOptions: {
@@ -213,13 +215,6 @@ export default config(
           allowNumber: false,
           allowNullableObject: false,
         },
-      ],
-      // @see https://github.com/prettier/eslint-config-prettier#forbid-unnecessary-backticks
-      quotes: "off",
-      "@typescript-eslint/quotes": [
-        "warn",
-        "double",
-        { avoidEscape: true, allowTemplateLiterals: false },
       ],
 
       // Security & Correctness

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,17 @@
-const js = require("@eslint/js");
-const tseslint = require("typescript-eslint");
-// @ts-expect-error [ts7016] - Unicorn not supporting CommonJS-based flat configs.
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Unicorn doesn't support CommonJS-based flat configs.
-const eslintPluginUnicorn = require("eslint-plugin-unicorn");
+import core from "@eslint/js";
+// @ts-expect-error [ts7016] -- I don't know why typing is broken here...
+import { configs as unicornConfigs } from "eslint-plugin-unicorn";
+import { config, configs as typescriptConfigs } from "typescript-eslint";
 
-module.exports = tseslint.config(
+export default config(
   {
     ignores: ["dist", "docs", "examples"],
   },
-  js.configs.recommended,
-  ...tseslint.configs.strictTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- Unicorn doesn't support CommonJS-based flat configs.
-  eslintPluginUnicorn.configs["flat/recommended"],
+  core.configs.recommended,
+  ...typescriptConfigs.strictTypeChecked,
+  ...typescriptConfigs.stylisticTypeChecked,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- I don't know why typing is broken for unicorn...
+  unicornConfigs["flat/recommended"],
   {
     languageOptions: {
       parserOptions: {
@@ -285,13 +284,8 @@ module.exports = tseslint.config(
     },
   },
   {
-    files: ["*.config.js"],
+    files: ["*.config.mjs"],
     rules: {
-      "no-undef": "off",
-      "@typescript-eslint/no-require-imports": "off",
-      "@typescript-eslint/no-unsafe-call": "off",
-      "@typescript-eslint/no-var-requires": "off",
-      "unicorn/prefer-module": "off",
       "unicorn/filename-case": "off",
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,12 @@ export default config(
       "unicorn/prefer-number-properties": "off",
       "unicorn/prefer-spread": "off",
 
+      // TODO: These rules allow us to really standardize our codebase, but they
+      // also do sweeping changes to the whole codebase which is very noisy. We
+      // should do it in one sweep sometime in the future.
+      "@typescript-eslint/naming-convention": "off",
+      "unicorn/prevent-abbreviations": "off",
+
       // === ESLint ============================================================
       // (We are assuming that the config is extended by eslint's: recommended
       // extension)
@@ -275,12 +281,6 @@ export default config(
       "unicorn/no-unused-properties": "warn",
       "unicorn/no-useless-undefined": ["warn", { checkArguments: false }],
       "unicorn/switch-case-braces": ["error", "avoid"],
-
-      // TODO: These rules allow us to really standardize our codebase, but they
-      // also do sweeping changes to the whole codebase which is very noisy. We
-      // should do it in one sweep sometime in the future.
-      "@typescript-eslint/naming-convention": "off",
-      "unicorn/prevent-abbreviations": "off",
     },
   },
   {

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,8 +1,9 @@
-module.exports = {
+export default {
   // The Typescript compiler can't type-check a single file, it needs to run on
   // the whole project. To do that we use a function (instead of a string or
   // array) so that no matter what file or how many, we will always run the same
   // command.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types -- this is stupid...
   "*.ts?(x)": () => "tsc -p tsconfig.json --noEmit",
 
   // Javascript and Typescript (including commonJs and esm variants)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
       "devDependencies": {
         "@eslint/js": "^8.57.0",
         "@types/eslint__js": "^8.42.3",
+        "@types/eslint-config-prettier": "^6.11.3",
         "@vitest/coverage-v8": "^1.3.1",
         "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-unicorn": "^51.0.1",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
@@ -1406,6 +1408,12 @@
       "dependencies": {
         "@types/eslint": "*"
       }
+    },
+    "node_modules/@types/eslint-config-prettier": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-config-prettier/-/eslint-config-prettier-6.11.3.tgz",
+      "integrity": "sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -2902,6 +2910,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/eslint__js": "^8.42.3",
         "@vitest/coverage-v8": "^1.3.1",
         "eslint": "^8.57.0",
+        "eslint-plugin-unicorn": "^51.0.1",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
@@ -1986,6 +1987,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2003,6 +2048,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001594",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
+      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -2057,6 +2122,42 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/clean-stack": {
@@ -2450,6 +2551,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js-compat": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.0.tgz",
+      "integrity": "sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.22.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2627,6 +2741,12 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.692",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.692.tgz",
+      "integrity": "sha512-d5rZRka9n2Y3MkWRN74IoAsxR0HK3yaAt7T50e3iT9VZmCCQDT3geXUO5ZRMhDToa1pkCeQXuNo+0g+NfDOVPA==",
+      "dev": true
+    },
     "node_modules/emoji-regex": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
@@ -2782,6 +2902,186 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "51.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-51.0.1.tgz",
+      "integrity": "sha512-MuR/+9VuB0fydoI0nIn2RDA5WISRn4AsJyNSaNKLVwie9/ONvQhxOBbkfSICBPnzKrB77Fh6CZZXjgTt/4Latw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@eslint/eslintrc": "^2.1.4",
+        "ci-info": "^4.0.0",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.34.0",
+        "esquery": "^1.5.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.2.1",
+        "jsesc": "^3.0.2",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.10.0",
+        "semver": "^7.5.4",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eslint-scope": {
@@ -3550,6 +3850,21 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -3761,6 +4076,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -4295,6 +4622,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4395,6 +4731,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.0",
@@ -7644,6 +7986,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -7787,6 +8135,15 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -8031,6 +8388,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
@@ -8043,6 +8409,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/regjsparser": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+      "integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
+      "dev": true,
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8050,6 +8437,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -8660,6 +9064,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8713,6 +9129,18 @@
       },
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/temp-dir": {
@@ -9018,6 +9446,36 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/eslint__js": "^8.42.3",
     "@vitest/coverage-v8": "^1.3.1",
     "eslint": "^8.57.0",
+    "eslint-plugin-unicorn": "^51.0.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
   "devDependencies": {
     "@eslint/js": "^8.57.0",
     "@types/eslint__js": "^8.42.3",
+    "@types/eslint-config-prettier": "^6.11.3",
     "@vitest/coverage-v8": "^1.3.1",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-unicorn": "^51.0.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,2 +1,2 @@
 /** @type {import('prettier').Config} */
-module.exports = {};
+export default {};

--- a/src/_quickSelect.ts
+++ b/src/_quickSelect.ts
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/prevent-abbreviations -- It's fine, this is a pure algo */
+
 /**
  * A simple implementation of the *QuickSelect* algorithm.
  * @see https://en.wikipedia.org/wiki/Quickselect

--- a/src/_quickSelect.ts
+++ b/src/_quickSelect.ts
@@ -27,7 +27,7 @@ export const quickSelect = <T>(
       undefined
     : quickSelectImplementation(
         // We need to clone the array because quickSelect mutates it in-place.
-        [...data],
+        data.slice(),
         0 /* left */,
         data.length - 1 /* right */,
         index,

--- a/src/_quickSelect.ts
+++ b/src/_quickSelect.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/prevent-abbreviations -- It's fine, this is a pure algo */
-
 /**
  * A simple implementation of the *QuickSelect* algorithm.
  * @see https://en.wikipedia.org/wiki/Quickselect

--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -5,16 +5,16 @@ export function _reduceLazy<T, K>(
   lazy: LazyEvaluator<T, K>,
   isIndexed = false,
 ): Array<K> {
-  const newArray: Array<K> = [];
+  const out: Array<K> = [];
 
   // We intentionally use a for loop here instead of reduce for performance reasons. See https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/ for more info
   for (let index = 0; index < array.length; index++) {
     const item = array[index]!;
     const result = isIndexed ? lazy(item, index, array) : lazy(item);
     if (result.hasMany === true) {
-      newArray.push(...result.next);
+      out.push(...result.next);
     } else if (result.hasNext) {
-      newArray.push(result.next);
+      out.push(result.next);
     }
 
     if (result.done) {
@@ -22,5 +22,5 @@ export function _reduceLazy<T, K>(
     }
   }
 
-  return newArray;
+  return out;
 }

--- a/src/_swapInPlace.ts
+++ b/src/_swapInPlace.ts
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/prevent-abbreviations -- This is fine... */
+
 /**
  * An efficient hack to swap the values at two indices in an array *in-place*.
  */

--- a/src/_swapInPlace.ts
+++ b/src/_swapInPlace.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/prevent-abbreviations -- This is fine... */
-
 /**
  * An efficient hack to swap the values at two indices in an array *in-place*.
  */

--- a/src/ceil.test.ts
+++ b/src/ceil.test.ts
@@ -3,24 +3,27 @@ import { ceil } from "./ceil";
 describe("data-first", () => {
   test("should work with positive precision", () => {
     expect(ceil(8123.4317, 3)).toEqual(8123.432);
-    expect(ceil(483.22243, 1)).toEqual(483.3);
+    expect(ceil(483.222_43, 1)).toEqual(483.3);
     expect(ceil(123.4317, 5)).toEqual(123.4317);
   });
 
   test("should work with negative precision", () => {
     expect(ceil(8123.4317, -2)).toEqual(8200);
-    expect(ceil(8123.4317, -4)).toEqual(10000);
+    expect(ceil(8123.4317, -4)).toEqual(10_000);
   });
 
   test("should work with precision = 0", () => {
     expect(ceil(8123.4317, 0)).toEqual(8124);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => ceil(1, val)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => ceil(1, val)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => ceil(1, 21.37)).toThrowError(
@@ -37,7 +40,7 @@ describe("data-first", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
@@ -50,24 +53,27 @@ describe("data-first", () => {
 describe("data-last", () => {
   test("should work with positive precision", () => {
     expect(ceil(3)(8123.4317)).toEqual(8123.432);
-    expect(ceil(1)(483.22243)).toEqual(483.3);
+    expect(ceil(1)(483.222_43)).toEqual(483.3);
     expect(ceil(5)(123.4317)).toEqual(123.4317);
   });
 
   test("should work with negative precision", () => {
     expect(ceil(-2)(8123.4317)).toEqual(8200);
-    expect(ceil(-4)(8123.4317)).toEqual(10000);
+    expect(ceil(-4)(8123.4317)).toEqual(10_000);
   });
 
   test("should work with precision = 0", () => {
     expect(ceil(0)(8123.4317)).toEqual(8124);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => ceil(val)(1)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => ceil(val)(1)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => ceil(21.37)(1)).toThrowError(
@@ -84,7 +90,7 @@ describe("data-last", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {

--- a/src/clamp.ts
+++ b/src/clamp.ts
@@ -40,15 +40,11 @@ export function clamp(): unknown {
 }
 
 function _clamp(value: number, limits: Limits): number {
-  if (limits.min !== undefined) {
-    if (limits.min > value) {
-      return limits.min;
-    }
+  if (limits.min !== undefined && limits.min > value) {
+    return limits.min;
   }
-  if (limits.max !== undefined) {
-    if (limits.max < value) {
-      return limits.max;
-    }
+  if (limits.max !== undefined && limits.max < value) {
+    return limits.max;
   }
   return value;
 }

--- a/src/clamp.ts
+++ b/src/clamp.ts
@@ -39,12 +39,10 @@ export function clamp(): unknown {
   return purry(_clamp, arguments);
 }
 
-function _clamp(value: number, limits: Limits): number {
-  if (limits.min !== undefined && limits.min > value) {
-    return limits.min;
-  }
-  if (limits.max !== undefined && limits.max < value) {
-    return limits.max;
-  }
-  return value;
+function _clamp(value: number, { min, max }: Limits): number {
+  return min !== undefined && value < min
+    ? min
+    : max !== undefined && value > max
+      ? max
+      : value;
 }

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -6,7 +6,7 @@ const eq = (a: any, b: any): void => {
   expect(a).toEqual(b);
 };
 
-const fn = (x: number) => x + x;
+const fn = (x: number): number => x + x;
 
 describe("deep clone integers, strings and booleans", () => {
   it("clones integers", () => {

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -6,6 +6,8 @@ const eq = (a: any, b: any): void => {
   expect(a).toEqual(b);
 };
 
+const fn = (x: number) => x + x;
+
 describe("deep clone integers, strings and booleans", () => {
   it("clones integers", () => {
     eq(clone(-4), -4);
@@ -86,7 +88,6 @@ describe("deep clone arrays", () => {
 
 describe("deep clone functions", () => {
   it("keep reference to function", () => {
-    const fn = (x: number) => x + x;
     const list = [{ a: fn }] as const;
 
     const cloned = clone(list);

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -109,19 +109,18 @@ describe("built-in types", () => {
     eq(cloned.getDay(), 5); // friday
   });
 
-  it("clones RegExp object", () => {
-    [/x/u, /x/gu, /x/iu, /x/mu, /x/giu, /x/gmu, /x/imu, /x/gimu].forEach(
-      (pattern) => {
-        const cloned = clone(pattern);
-        assert.notStrictEqual(cloned, pattern);
-        eq(cloned.constructor, RegExp);
-        eq(cloned.source, pattern.source);
-        eq(cloned.global, pattern.global);
-        eq(cloned.ignoreCase, pattern.ignoreCase);
-        eq(cloned.multiline, pattern.multiline);
-      },
-    );
-  });
+  it.each([/x/u, /x/gu, /x/iu, /x/mu, /x/giu, /x/gmu, /x/imu, /x/gimu])(
+    "clones RegExp object",
+    (pattern) => {
+      const cloned = clone(pattern);
+      assert.notStrictEqual(cloned, pattern);
+      eq(cloned.constructor, RegExp);
+      eq(cloned.source, pattern.source);
+      eq(cloned.global, pattern.global);
+      eq(cloned.ignoreCase, pattern.ignoreCase);
+      eq(cloned.multiline, pattern.multiline);
+    },
+  );
 });
 
 describe("deep clone deep nested mixed objects", () => {

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -9,12 +9,12 @@ const eq = (a: any, b: any): void => {
 describe("deep clone integers, strings and booleans", () => {
   it("clones integers", () => {
     eq(clone(-4), -4);
-    eq(clone(9007199254740991), 9007199254740991);
+    eq(clone(9_007_199_254_740_991), 9_007_199_254_740_991);
   });
 
   it("clones floats", () => {
     eq(clone(-4.5), -4.5);
-    eq(clone(0.0), 0.0);
+    eq(clone(0), 0);
   });
 
   it("clones strings", () => {

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,4 +1,4 @@
-/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types, unicorn/no-null -- FIXME! */
+/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types, unicorn/no-null, unicorn/prevent-abbreviations -- FIXME! */
 
 // from https://github.com/ramda/ramda/blob/master/source/internal/_clone.js
 

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,4 +1,4 @@
-/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types, unicorn/no-null, unicorn/prevent-abbreviations -- FIXME! */
+/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types, unicorn/no-null -- FIXME! */
 
 // from https://github.com/ramda/ramda/blob/master/source/internal/_clone.js
 

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,4 +1,4 @@
-/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types -- FIXME! */
+/* eslint-disable eqeqeq, guard-for-in, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/prefer-destructuring, @typescript-eslint/prefer-readonly-parameter-types, unicorn/no-null -- FIXME! */
 
 // from https://github.com/ramda/ramda/blob/master/source/internal/_clone.js
 

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -1,9 +1,11 @@
 import { isTruthy } from "./isTruthy";
 
 /**
- * Filter out all falsey values. The values `false`, `null`, `0`, `""`, `undefined`, and `NaN` are falsey.
+ * Filter out all falsy values. The values `false`, `null`, `0`, `""`,
+ * `undefined`, and `NaN` are falsy.
  *
- * **DEPRECATED: equivalent to `R.filter(R.isTruthy)` and so will be removed in v2.**
+ * **DEPRECATED: equivalent to `R.filter(R.isTruthy)` and so will be removed in
+ * v2.**
  *
  * @param items the array to compact
  * @signature
@@ -16,6 +18,6 @@ import { isTruthy } from "./isTruthy";
 export function compact<T>(
   items: ReadonlyArray<T | "" | 0 | false | null | undefined>,
 ): Array<T> {
-  // TODO: Make lazy version
+  // eslint-disable-next-line unicorn/no-array-callback-reference -- This is incorrect, we use isTruthy as a type predicate here so it has to be called directly.
   return items.filter(isTruthy);
 }

--- a/src/countBy.ts
+++ b/src/countBy.ts
@@ -3,11 +3,16 @@ import type { Pred, PredIndexed, PredIndexedOptional } from "./_types";
 
 const _countBy =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
-    array.reduce((ret, item, index) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
+    let out = 0;
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our TypeScript target above ES5 we can use Array.prototype.entries to iterate over the indices and values at the same time.
+      const item = array[index]!;
       const value = indexed ? fn(item, index, array) : fn(item);
-      return ret + (value ? 1 : 0);
-    }, 0);
+      out += value ? 1 : 0;
+    }
+    return out;
+  };
 
 /**
  * Counts how many values of the collection pass the specified predicate.

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -421,7 +421,7 @@ describe("typing", () => {
   test("argument typing to be good (with rest param)", async () => {
     const debouncer = debounce(
       (a: string, ...flags: ReadonlyArray<boolean>) =>
-        `${a}${flags.map((flag) => (flag ? "y" : "n")).join()}`,
+        `${a}${flags.map((flag) => (flag ? "y" : "n")).join(",")}`,
       { timing: "leading" },
     );
     // @ts-expect-error [ts2554]: Expected 3 arguments, but got 1.

--- a/src/drop.test.ts
+++ b/src/drop.test.ts
@@ -15,7 +15,7 @@ describe("data first", () => {
     expect(drop(array, 0)).toEqual(array);
     expect(drop(array, -0)).toEqual(array);
     expect(drop(array, -1)).toEqual(array);
-    expect(drop(array, NaN)).toEqual(array);
+    expect(drop(array, Number.NaN)).toEqual(array);
   });
 
   test("should return a new array even if there was no drop", () => {

--- a/src/dropFirstBy.ts
+++ b/src/dropFirstBy.ts
@@ -60,7 +60,7 @@ function dropFirstByImplementation<T>(
   }
 
   if (n <= 0) {
-    return [...data];
+    return data.slice();
   }
 
   const heap = data.slice(0, n);

--- a/src/dropLast.test.ts
+++ b/src/dropLast.test.ts
@@ -10,7 +10,7 @@ test("should not drop last", () => {
   expect(dropLast(arr, 0)).toEqual(arr);
   expect(dropLast(arr, -0)).toEqual(arr);
   expect(dropLast(arr, -1)).toEqual(arr);
-  expect(dropLast(arr, NaN)).toEqual(arr);
+  expect(dropLast(arr, Number.NaN)).toEqual(arr);
 });
 
 test("should return a new array even if there was no drop", () => {

--- a/src/dropLast.ts
+++ b/src/dropLast.ts
@@ -31,7 +31,7 @@ export function dropLast(): unknown {
 }
 
 function _dropLast<T>(array: ReadonlyArray<T>, n: number): Array<T> {
-  const copy = [...array];
+  const copy = array.slice();
   if (n > 0) {
     copy.splice(-n);
   }

--- a/src/equals.test.ts
+++ b/src/equals.test.ts
@@ -84,8 +84,8 @@ const tests = [
       },
       {
         description: "NaN and NaN are equal",
-        value1: NaN,
-        value2: NaN,
+        value1: Number.NaN,
+        value2: Number.NaN,
         equal: true,
       },
       {
@@ -96,14 +96,14 @@ const tests = [
       },
       {
         description: "Infinity and Infinity are equal",
-        value1: Infinity,
-        value2: Infinity,
+        value1: Number.POSITIVE_INFINITY,
+        value2: Number.POSITIVE_INFINITY,
         equal: true,
       },
       {
         description: "Infinity and -Infinity are not equal",
-        value1: Infinity,
-        value2: -Infinity,
+        value1: Number.POSITIVE_INFINITY,
+        value2: Number.NEGATIVE_INFINITY,
         equal: false,
       },
     ],

--- a/src/equals.test.ts
+++ b/src/equals.test.ts
@@ -1,389 +1,5 @@
 import { equals } from "./equals";
 
-const tests = [
-  {
-    description: "scalars",
-    tests: [
-      {
-        description: "equal numbers",
-        value1: 1,
-        value2: 1,
-        equal: true,
-      },
-      {
-        description: "not equal numbers",
-        value1: 1,
-        value2: 2,
-        equal: false,
-      },
-      {
-        description: "number and array are not equal",
-        value1: 1,
-        value2: [],
-        equal: false,
-      },
-      {
-        description: "0 and null are not equal",
-        value1: 0,
-        value2: null,
-        equal: false,
-      },
-      {
-        description: "equal strings",
-        value1: "a",
-        value2: "a",
-        equal: true,
-      },
-      {
-        description: "not equal strings",
-        value1: "a",
-        value2: "b",
-        equal: false,
-      },
-      {
-        description: "empty string and null are not equal",
-        value1: "",
-        value2: null,
-        equal: false,
-      },
-      {
-        description: "null is equal to null",
-        value1: null,
-        value2: null,
-        equal: true,
-      },
-      {
-        description: "equal booleans (true)",
-        value1: true,
-        value2: true,
-        equal: true,
-      },
-      {
-        description: "equal booleans (false)",
-        value1: false,
-        value2: false,
-        equal: true,
-      },
-      {
-        description: "not equal booleans",
-        value1: true,
-        value2: false,
-        equal: false,
-      },
-      {
-        description: "1 and true are not equal",
-        value1: 1,
-        value2: true,
-        equal: false,
-      },
-      {
-        description: "0 and false are not equal",
-        value1: 0,
-        value2: false,
-        equal: false,
-      },
-      {
-        description: "NaN and NaN are equal",
-        value1: Number.NaN,
-        value2: Number.NaN,
-        equal: true,
-      },
-      {
-        description: "0 and -0 are equal",
-        value1: 0,
-        value2: -0,
-        equal: true,
-      },
-      {
-        description: "Infinity and Infinity are equal",
-        value1: Number.POSITIVE_INFINITY,
-        value2: Number.POSITIVE_INFINITY,
-        equal: true,
-      },
-      {
-        description: "Infinity and -Infinity are not equal",
-        value1: Number.POSITIVE_INFINITY,
-        value2: Number.NEGATIVE_INFINITY,
-        equal: false,
-      },
-    ],
-  },
-
-  {
-    description: "objects",
-    tests: [
-      {
-        description: "empty objects are equal",
-        value1: {},
-        value2: {},
-        equal: true,
-      },
-      {
-        description: 'equal objects (same properties "order")',
-        value1: { a: 1, b: "2" },
-        value2: { a: 1, b: "2" },
-        equal: true,
-      },
-      {
-        description: 'equal objects (different properties "order")',
-        value1: { a: 1, b: "2" },
-        value2: { b: "2", a: 1 },
-        equal: true,
-      },
-      {
-        description: "not equal objects (extra property)",
-        value1: { a: 1, b: "2" },
-        value2: { a: 1, b: "2", c: [] },
-        equal: false,
-      },
-      {
-        description: "not equal objects (different properties)",
-        value1: { a: 1, b: "2", c: 3 },
-        value2: { a: 1, b: "2", d: 3 },
-        equal: false,
-      },
-      {
-        description: "not equal objects (different properties)",
-        value1: { a: 1, b: "2", c: 3 },
-        value2: { a: 1, b: "2", d: 3 },
-        equal: false,
-      },
-      {
-        description: "equal objects (same sub-properties)",
-        value1: { a: [{ b: "c" }] },
-        value2: { a: [{ b: "c" }] },
-        equal: true,
-      },
-      {
-        description: "not equal objects (different sub-property value)",
-        value1: { a: [{ b: "c" }] },
-        value2: { a: [{ b: "d" }] },
-        equal: false,
-      },
-      {
-        description: "not equal objects (different sub-property)",
-        value1: { a: [{ b: "c" }] },
-        value2: { a: [{ c: "c" }] },
-        equal: false,
-      },
-      {
-        description: "empty array and empty object are not equal",
-        value1: {},
-        value2: [],
-        equal: false,
-      },
-      {
-        description: "object with extra undefined properties are not equal #1",
-        value1: {},
-        value2: { foo: undefined },
-        equal: false,
-      },
-      {
-        description: "object with extra undefined properties are not equal #2",
-        value1: { foo: undefined },
-        value2: {},
-        equal: false,
-      },
-      {
-        description: "object with extra undefined properties are not equal #3",
-        value1: { foo: undefined },
-        value2: { bar: undefined },
-        equal: false,
-      },
-      {
-        description: "nulls are equal",
-        value1: null,
-        value2: null,
-        equal: true,
-      },
-      {
-        description: "null and undefined are not equal",
-        value1: null,
-        value2: undefined,
-        equal: false,
-      },
-      {
-        description: "null and empty object are not equal",
-        value1: null,
-        value2: {},
-        equal: false,
-      },
-      {
-        description: "undefined and empty object are not equal",
-        value1: undefined,
-        value2: {},
-        equal: false,
-      },
-    ],
-  },
-
-  {
-    description: "arrays",
-    tests: [
-      {
-        description: "two empty arrays are equal",
-        value1: [],
-        value2: [],
-        equal: true,
-      },
-      {
-        description: "equal arrays",
-        value1: [1, 2, 3],
-        value2: [1, 2, 3],
-        equal: true,
-      },
-      {
-        description: "not equal arrays (different item)",
-        value1: [1, 2, 3],
-        value2: [1, 2, 4],
-        equal: false,
-      },
-      {
-        description: "not equal arrays (different length)",
-        value1: [1, 2, 3],
-        value2: [1, 2],
-        equal: false,
-      },
-      {
-        description: "equal arrays of objects",
-        value1: [{ a: "a" }, { b: "b" }],
-        value2: [{ a: "a" }, { b: "b" }],
-        equal: true,
-      },
-      {
-        description: "not equal arrays of objects",
-        value1: [{ a: "a" }, { b: "b" }],
-        value2: [{ a: "a" }, { b: "c" }],
-        equal: false,
-      },
-      {
-        description: "pseudo array and equivalent array are not equal",
-        value1: { "0": 0, "1": 1, length: 2 },
-        value2: [0, 1],
-        equal: false,
-      },
-    ],
-  },
-  {
-    description: "Date objects",
-    tests: [
-      {
-        description: "equal date objects",
-        value1: new Date("2017-06-16T21:36:48.362Z"),
-        value2: new Date("2017-06-16T21:36:48.362Z"),
-        equal: true,
-      },
-      {
-        description: "not equal date objects",
-        value1: new Date("2017-06-16T21:36:48.362Z"),
-        value2: new Date("2017-01-01T00:00:00.000Z"),
-        equal: false,
-      },
-      {
-        description: "date and string are not equal",
-        value1: new Date("2017-06-16T21:36:48.362Z"),
-        value2: "2017-06-16T21:36:48.362Z",
-        equal: false,
-      },
-      {
-        description: "date and object are not equal",
-        value1: new Date("2017-06-16T21:36:48.362Z"),
-        value2: {},
-        equal: false,
-      },
-    ],
-  },
-  {
-    description: "RegExp objects",
-    tests: [
-      {
-        description: "equal RegExp objects",
-        value1: /foo/u,
-        value2: /foo/u,
-        equal: true,
-      },
-      {
-        description: "not equal RegExp objects (different pattern)",
-        value1: /foo/u,
-        value2: /bar/u,
-        equal: false,
-      },
-      {
-        description: "not equal RegExp objects (different flags)",
-        value1: /foo/u,
-        value2: /foo/iu,
-        equal: false,
-      },
-      {
-        description: "RegExp and string are not equal",
-        value1: /foo/u,
-        value2: "foo",
-        equal: false,
-      },
-      {
-        description: "RegExp and object are not equal",
-        value1: /foo/u,
-        value2: {},
-        equal: false,
-      },
-    ],
-  },
-  {
-    description: "functions",
-    tests: [
-      {
-        description: "same function is equal",
-        value1: func1,
-        value2: func1,
-        equal: true,
-      },
-      {
-        description: "different functions are not equal",
-        value1: func1,
-        value2: func2,
-        equal: false,
-      },
-    ],
-  },
-  {
-    description: "sample objects",
-    tests: [
-      {
-        description: "big object",
-        value1: {
-          prop1: "value1",
-          prop2: "value2",
-          prop3: "value3",
-          prop4: {
-            subProp1: "sub value1",
-            subProp2: {
-              subSubProp1: "sub sub value1",
-              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
-            },
-          },
-          prop5: 1000,
-          prop6: new Date(2016, 2, 10),
-        },
-        value2: {
-          prop5: 1000,
-          prop3: "value3",
-          prop1: "value1",
-          prop2: "value2",
-          prop6: new Date("2016/03/10"),
-          prop4: {
-            subProp2: {
-              subSubProp1: "sub sub value1",
-              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
-            },
-            subProp1: "sub value1",
-          },
-        },
-        equal: true,
-      },
-    ],
-  },
-];
-
 function func1(): void {
   // (intentionally empty)
 }
@@ -391,14 +7,395 @@ function func2(): void {
   // (intentionally empty)
 }
 
-describe("equal", () => {
-  tests.forEach((suite) => {
-    describe(suite.description, () => {
-      suite.tests.forEach((test) => {
-        it(test.description, () => {
-          expect(equals(test.value1, test.value2)).toEqual(test.equal);
-        });
-      });
-    });
+describe("scalars", () => {
+  test.each([
+    {
+      description: "equal numbers",
+      value1: 1,
+      value2: 1,
+      equal: true,
+    },
+    {
+      description: "not equal numbers",
+      value1: 1,
+      value2: 2,
+      equal: false,
+    },
+    {
+      description: "number and array are not equal",
+      value1: 1,
+      value2: [],
+      equal: false,
+    },
+    {
+      description: "0 and null are not equal",
+      value1: 0,
+      value2: null,
+      equal: false,
+    },
+    {
+      description: "equal strings",
+      value1: "a",
+      value2: "a",
+      equal: true,
+    },
+    {
+      description: "not equal strings",
+      value1: "a",
+      value2: "b",
+      equal: false,
+    },
+    {
+      description: "empty string and null are not equal",
+      value1: "",
+      value2: null,
+      equal: false,
+    },
+    {
+      description: "null is equal to null",
+      value1: null,
+      value2: null,
+      equal: true,
+    },
+    {
+      description: "equal booleans (true)",
+      value1: true,
+      value2: true,
+      equal: true,
+    },
+    {
+      description: "equal booleans (false)",
+      value1: false,
+      value2: false,
+      equal: true,
+    },
+    {
+      description: "not equal booleans",
+      value1: true,
+      value2: false,
+      equal: false,
+    },
+    {
+      description: "1 and true are not equal",
+      value1: 1,
+      value2: true,
+      equal: false,
+    },
+    {
+      description: "0 and false are not equal",
+      value1: 0,
+      value2: false,
+      equal: false,
+    },
+    {
+      description: "NaN and NaN are equal",
+      value1: Number.NaN,
+      value2: Number.NaN,
+      equal: true,
+    },
+    {
+      description: "0 and -0 are equal",
+      value1: 0,
+      value2: -0,
+      equal: true,
+    },
+    {
+      description: "Infinity and Infinity are equal",
+      value1: Number.POSITIVE_INFINITY,
+      value2: Number.POSITIVE_INFINITY,
+      equal: true,
+    },
+    {
+      description: "Infinity and -Infinity are not equal",
+      value1: Number.POSITIVE_INFINITY,
+      value2: Number.NEGATIVE_INFINITY,
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("objects", () => {
+  test.each([
+    {
+      description: "empty objects are equal",
+      value1: {},
+      value2: {},
+      equal: true,
+    },
+    {
+      description: 'equal objects (same properties "order")',
+      value1: { a: 1, b: "2" },
+      value2: { a: 1, b: "2" },
+      equal: true,
+    },
+    {
+      description: 'equal objects (different properties "order")',
+      value1: { a: 1, b: "2" },
+      value2: { b: "2", a: 1 },
+      equal: true,
+    },
+    {
+      description: "not equal objects (extra property)",
+      value1: { a: 1, b: "2" },
+      value2: { a: 1, b: "2", c: [] },
+      equal: false,
+    },
+    {
+      description: "not equal objects (different properties)",
+      value1: { a: 1, b: "2", c: 3 },
+      value2: { a: 1, b: "2", d: 3 },
+      equal: false,
+    },
+    {
+      description: "not equal objects (different properties)",
+      value1: { a: 1, b: "2", c: 3 },
+      value2: { a: 1, b: "2", d: 3 },
+      equal: false,
+    },
+    {
+      description: "equal objects (same sub-properties)",
+      value1: { a: [{ b: "c" }] },
+      value2: { a: [{ b: "c" }] },
+      equal: true,
+    },
+    {
+      description: "not equal objects (different sub-property value)",
+      value1: { a: [{ b: "c" }] },
+      value2: { a: [{ b: "d" }] },
+      equal: false,
+    },
+    {
+      description: "not equal objects (different sub-property)",
+      value1: { a: [{ b: "c" }] },
+      value2: { a: [{ c: "c" }] },
+      equal: false,
+    },
+    {
+      description: "empty array and empty object are not equal",
+      value1: {},
+      value2: [],
+      equal: false,
+    },
+    {
+      description: "object with extra undefined properties are not equal #1",
+      value1: {},
+      value2: { foo: undefined },
+      equal: false,
+    },
+    {
+      description: "object with extra undefined properties are not equal #2",
+      value1: { foo: undefined },
+      value2: {},
+      equal: false,
+    },
+    {
+      description: "object with extra undefined properties are not equal #3",
+      value1: { foo: undefined },
+      value2: { bar: undefined },
+      equal: false,
+    },
+    {
+      description: "nulls are equal",
+      value1: null,
+      value2: null,
+      equal: true,
+    },
+    {
+      description: "null and undefined are not equal",
+      value1: null,
+      value2: undefined,
+      equal: false,
+    },
+    {
+      description: "null and empty object are not equal",
+      value1: null,
+      value2: {},
+      equal: false,
+    },
+    {
+      description: "undefined and empty object are not equal",
+      value1: undefined,
+      value2: {},
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("arrays", () => {
+  test.each([
+    {
+      description: "two empty arrays are equal",
+      value1: [],
+      value2: [],
+      equal: true,
+    },
+    {
+      description: "equal arrays",
+      value1: [1, 2, 3],
+      value2: [1, 2, 3],
+      equal: true,
+    },
+    {
+      description: "not equal arrays (different item)",
+      value1: [1, 2, 3],
+      value2: [1, 2, 4],
+      equal: false,
+    },
+    {
+      description: "not equal arrays (different length)",
+      value1: [1, 2, 3],
+      value2: [1, 2],
+      equal: false,
+    },
+    {
+      description: "equal arrays of objects",
+      value1: [{ a: "a" }, { b: "b" }],
+      value2: [{ a: "a" }, { b: "b" }],
+      equal: true,
+    },
+    {
+      description: "not equal arrays of objects",
+      value1: [{ a: "a" }, { b: "b" }],
+      value2: [{ a: "a" }, { b: "c" }],
+      equal: false,
+    },
+    {
+      description: "pseudo array and equivalent array are not equal",
+      value1: { "0": 0, "1": 1, length: 2 },
+      value2: [0, 1],
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("Date objects", () => {
+  test.each([
+    {
+      description: "equal date objects",
+      value1: new Date("2017-06-16T21:36:48.362Z"),
+      value2: new Date("2017-06-16T21:36:48.362Z"),
+      equal: true,
+    },
+    {
+      description: "not equal date objects",
+      value1: new Date("2017-06-16T21:36:48.362Z"),
+      value2: new Date("2017-01-01T00:00:00.000Z"),
+      equal: false,
+    },
+    {
+      description: "date and string are not equal",
+      value1: new Date("2017-06-16T21:36:48.362Z"),
+      value2: "2017-06-16T21:36:48.362Z",
+      equal: false,
+    },
+    {
+      description: "date and object are not equal",
+      value1: new Date("2017-06-16T21:36:48.362Z"),
+      value2: {},
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("RegExp objects", () => {
+  test.each([
+    {
+      description: "equal RegExp objects",
+      value1: /foo/u,
+      value2: /foo/u,
+      equal: true,
+    },
+    {
+      description: "not equal RegExp objects (different pattern)",
+      value1: /foo/u,
+      value2: /bar/u,
+      equal: false,
+    },
+    {
+      description: "not equal RegExp objects (different flags)",
+      value1: /foo/u,
+      value2: /foo/iu,
+      equal: false,
+    },
+    {
+      description: "RegExp and string are not equal",
+      value1: /foo/u,
+      value2: "foo",
+      equal: false,
+    },
+    {
+      description: "RegExp and object are not equal",
+      value1: /foo/u,
+      value2: {},
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("functions", () => {
+  test.each([
+    {
+      description: "same function is equal",
+      value1: func1,
+      value2: func1,
+      equal: true,
+    },
+    {
+      description: "different functions are not equal",
+      value1: func1,
+      value2: func2,
+      equal: false,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
+  });
+});
+
+describe("sample objects", () => {
+  test.each([
+    {
+      description: "big object",
+      value1: {
+        prop1: "value1",
+        prop2: "value2",
+        prop3: "value3",
+        prop4: {
+          subProp1: "sub value1",
+          subProp2: {
+            subSubProp1: "sub sub value1",
+            subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
+          },
+        },
+        prop5: 1000,
+        prop6: new Date(2016, 2, 10),
+      },
+      value2: {
+        prop5: 1000,
+        prop3: "value3",
+        prop1: "value1",
+        prop2: "value2",
+        prop6: new Date("2016/03/10"),
+        prop4: {
+          subProp2: {
+            subSubProp1: "sub sub value1",
+            subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
+          },
+          subProp1: "sub value1",
+        },
+      },
+      equal: true,
+    },
+  ])("$description", ({ value1, value2, equal }) => {
+    expect(equals(value1, value2)).toEqual(equal);
   });
 });

--- a/src/equals.test.ts
+++ b/src/equals.test.ts
@@ -8,394 +8,232 @@ function func2(): void {
 }
 
 describe("scalars", () => {
-  test.each([
-    {
-      description: "equal numbers",
-      value1: 1,
-      value2: 1,
-      equal: true,
-    },
-    {
-      description: "not equal numbers",
-      value1: 1,
-      value2: 2,
-      equal: false,
-    },
-    {
-      description: "number and array are not equal",
-      value1: 1,
-      value2: [],
-      equal: false,
-    },
-    {
-      description: "0 and null are not equal",
-      value1: 0,
-      value2: null,
-      equal: false,
-    },
-    {
-      description: "equal strings",
-      value1: "a",
-      value2: "a",
-      equal: true,
-    },
-    {
-      description: "not equal strings",
-      value1: "a",
-      value2: "b",
-      equal: false,
-    },
-    {
-      description: "empty string and null are not equal",
-      value1: "",
-      value2: null,
-      equal: false,
-    },
-    {
-      description: "null is equal to null",
-      value1: null,
-      value2: null,
-      equal: true,
-    },
-    {
-      description: "equal booleans (true)",
-      value1: true,
-      value2: true,
-      equal: true,
-    },
-    {
-      description: "equal booleans (false)",
-      value1: false,
-      value2: false,
-      equal: true,
-    },
-    {
-      description: "not equal booleans",
-      value1: true,
-      value2: false,
-      equal: false,
-    },
-    {
-      description: "1 and true are not equal",
-      value1: 1,
-      value2: true,
-      equal: false,
-    },
-    {
-      description: "0 and false are not equal",
-      value1: 0,
-      value2: false,
-      equal: false,
-    },
-    {
-      description: "NaN and NaN are equal",
-      value1: Number.NaN,
-      value2: Number.NaN,
-      equal: true,
-    },
-    {
-      description: "0 and -0 are equal",
-      value1: 0,
-      value2: -0,
-      equal: true,
-    },
-    {
-      description: "Infinity and Infinity are equal",
-      value1: Number.POSITIVE_INFINITY,
-      value2: Number.POSITIVE_INFINITY,
-      equal: true,
-    },
-    {
-      description: "Infinity and -Infinity are not equal",
-      value1: Number.POSITIVE_INFINITY,
-      value2: Number.NEGATIVE_INFINITY,
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("equal numbers", () => {
+    expect(equals(1, 1)).toBe(true);
+  });
+  test("not equal numbers", () => {
+    expect(equals(1, 2)).toBe(false);
+  });
+  test("number and array are not equal", () => {
+    expect(equals(1, [])).toBe(false);
+  });
+  test("0 and null are not equal", () => {
+    expect(equals(0, null)).toBe(false);
+  });
+  test("equal strings", () => {
+    expect(equals("a", "a")).toBe(true);
+  });
+  test("not equal strings", () => {
+    expect(equals("a", "b")).toBe(false);
+  });
+  test("empty string and null are not equal", () => {
+    expect(equals("", null)).toBe(false);
+  });
+  test("null is equal to null", () => {
+    expect(equals(null, null)).toBe(true);
+  });
+  test("equal booleans (true)", () => {
+    expect(equals(true, true)).toBe(true);
+  });
+  test("equal booleans (false)", () => {
+    expect(equals(false, false)).toBe(true);
+  });
+  test("not equal booleans", () => {
+    expect(equals(true, false)).toBe(false);
+  });
+  test("1 and true are not equal", () => {
+    expect(equals(1, true)).toBe(false);
+  });
+  test("0 and false are not equal", () => {
+    expect(equals(0, false)).toBe(false);
+  });
+  test("NaN and NaN are equal", () => {
+    expect(equals(Number.NaN, Number.NaN)).toBe(true);
+  });
+  test("0 and -0 are equal", () => {
+    expect(equals(0, -0)).toBe(true);
+  });
+  test("Infinity and Infinity are equal", () => {
+    expect(equals(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(
+      true,
+    );
+  });
+  test("Infinity and -Infinity are not equal", () => {
+    expect(equals(Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY)).toBe(
+      false,
+    );
   });
 });
 
 describe("objects", () => {
-  test.each([
-    {
-      description: "empty objects are equal",
-      value1: {},
-      value2: {},
-      equal: true,
-    },
-    {
-      description: 'equal objects (same properties "order")',
-      value1: { a: 1, b: "2" },
-      value2: { a: 1, b: "2" },
-      equal: true,
-    },
-    {
-      description: 'equal objects (different properties "order")',
-      value1: { a: 1, b: "2" },
-      value2: { b: "2", a: 1 },
-      equal: true,
-    },
-    {
-      description: "not equal objects (extra property)",
-      value1: { a: 1, b: "2" },
-      value2: { a: 1, b: "2", c: [] },
-      equal: false,
-    },
-    {
-      description: "not equal objects (different properties)",
-      value1: { a: 1, b: "2", c: 3 },
-      value2: { a: 1, b: "2", d: 3 },
-      equal: false,
-    },
-    {
-      description: "not equal objects (different properties)",
-      value1: { a: 1, b: "2", c: 3 },
-      value2: { a: 1, b: "2", d: 3 },
-      equal: false,
-    },
-    {
-      description: "equal objects (same sub-properties)",
-      value1: { a: [{ b: "c" }] },
-      value2: { a: [{ b: "c" }] },
-      equal: true,
-    },
-    {
-      description: "not equal objects (different sub-property value)",
-      value1: { a: [{ b: "c" }] },
-      value2: { a: [{ b: "d" }] },
-      equal: false,
-    },
-    {
-      description: "not equal objects (different sub-property)",
-      value1: { a: [{ b: "c" }] },
-      value2: { a: [{ c: "c" }] },
-      equal: false,
-    },
-    {
-      description: "empty array and empty object are not equal",
-      value1: {},
-      value2: [],
-      equal: false,
-    },
-    {
-      description: "object with extra undefined properties are not equal #1",
-      value1: {},
-      value2: { foo: undefined },
-      equal: false,
-    },
-    {
-      description: "object with extra undefined properties are not equal #2",
-      value1: { foo: undefined },
-      value2: {},
-      equal: false,
-    },
-    {
-      description: "object with extra undefined properties are not equal #3",
-      value1: { foo: undefined },
-      value2: { bar: undefined },
-      equal: false,
-    },
-    {
-      description: "nulls are equal",
-      value1: null,
-      value2: null,
-      equal: true,
-    },
-    {
-      description: "null and undefined are not equal",
-      value1: null,
-      value2: undefined,
-      equal: false,
-    },
-    {
-      description: "null and empty object are not equal",
-      value1: null,
-      value2: {},
-      equal: false,
-    },
-    {
-      description: "undefined and empty object are not equal",
-      value1: undefined,
-      value2: {},
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("empty objects are equal", () => {
+    expect(equals({}, {})).toBe(true);
+  });
+  test('equal objects (same properties "order")', () => {
+    expect(equals({ a: 1, b: "2" }, { a: 1, b: "2" })).toBe(true);
+  });
+  test('equal objects (different properties "order")', () => {
+    expect(equals({ a: 1, b: "2" }, { b: "2", a: 1 })).toBe(true);
+  });
+  test("not equal objects (extra property)", () => {
+    expect(equals({ a: 1, b: "2" }, { a: 1, b: "2", c: [] })).toBe(false);
+  });
+  test("not equal objects (different properties) #1", () => {
+    expect(equals({ a: 1, b: "2", c: 3 }, { a: 1, b: "2", d: 3 })).toBe(false);
+  });
+  test("not equal objects (different properties) #2", () => {
+    expect(equals({ a: 1, b: "2", c: 3 }, { a: 1, b: "2", d: 3 })).toBe(false);
+  });
+  test("equal objects (same sub-properties)", () => {
+    expect(equals({ a: [{ b: "c" }] }, { a: [{ b: "c" }] })).toBe(true);
+  });
+  test("not equal objects (different sub-property value)", () => {
+    expect(equals({ a: [{ b: "c" }] }, { a: [{ b: "d" }] })).toBe(false);
+  });
+  test("not equal objects (different sub-property)", () => {
+    expect(equals({ a: [{ b: "c" }] }, { a: [{ c: "c" }] })).toBe(false);
+  });
+  test("empty array and empty object are not equal", () => {
+    expect(equals({}, [])).toBe(false);
+  });
+  test("object with extra undefined properties are not equal #1", () => {
+    expect(equals({}, { foo: undefined })).toBe(false);
+  });
+  test("object with extra undefined properties are not equal #2", () => {
+    expect(equals({ foo: undefined }, {})).toBe(false);
+  });
+  test("object with extra undefined properties are not equal #3", () => {
+    expect(equals({ foo: undefined }, { bar: undefined })).toBe(false);
+  });
+  test("nulls are equal", () => {
+    expect(equals(null, null)).toBe(true);
+  });
+  test("null and undefined are not equal", () => {
+    expect(equals(null, undefined)).toBe(false);
+  });
+  test("null and empty object are not equal", () => {
+    expect(equals(null, {})).toBe(false);
+  });
+  test("undefined and empty object are not equal", () => {
+    expect(equals(undefined, {})).toBe(false);
   });
 });
 
 describe("arrays", () => {
-  test.each([
-    {
-      description: "two empty arrays are equal",
-      value1: [],
-      value2: [],
-      equal: true,
-    },
-    {
-      description: "equal arrays",
-      value1: [1, 2, 3],
-      value2: [1, 2, 3],
-      equal: true,
-    },
-    {
-      description: "not equal arrays (different item)",
-      value1: [1, 2, 3],
-      value2: [1, 2, 4],
-      equal: false,
-    },
-    {
-      description: "not equal arrays (different length)",
-      value1: [1, 2, 3],
-      value2: [1, 2],
-      equal: false,
-    },
-    {
-      description: "equal arrays of objects",
-      value1: [{ a: "a" }, { b: "b" }],
-      value2: [{ a: "a" }, { b: "b" }],
-      equal: true,
-    },
-    {
-      description: "not equal arrays of objects",
-      value1: [{ a: "a" }, { b: "b" }],
-      value2: [{ a: "a" }, { b: "c" }],
-      equal: false,
-    },
-    {
-      description: "pseudo array and equivalent array are not equal",
-      value1: { "0": 0, "1": 1, length: 2 },
-      value2: [0, 1],
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("two empty arrays are equal", () => {
+    expect(equals([], [])).toBe(true);
+  });
+  test("equal arrays", () => {
+    expect(equals([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+  test("not equal arrays (different item)", () => {
+    expect(equals([1, 2, 3], [1, 2, 4])).toBe(false);
+  });
+  test("not equal arrays (different length)", () => {
+    expect(equals([1, 2, 3], [1, 2])).toBe(false);
+  });
+  test("equal arrays of objects", () => {
+    expect(equals([{ a: "a" }, { b: "b" }], [{ a: "a" }, { b: "b" }])).toBe(
+      true,
+    );
+  });
+  test("not equal arrays of objects", () => {
+    expect(equals([{ a: "a" }, { b: "b" }], [{ a: "a" }, { b: "c" }])).toBe(
+      false,
+    );
+  });
+  test("pseudo array and equivalent array are not equal", () => {
+    expect(equals({ "0": 0, "1": 1, length: 2 }, [0, 1])).toBe(false);
   });
 });
 
 describe("Date objects", () => {
-  test.each([
-    {
-      description: "equal date objects",
-      value1: new Date("2017-06-16T21:36:48.362Z"),
-      value2: new Date("2017-06-16T21:36:48.362Z"),
-      equal: true,
-    },
-    {
-      description: "not equal date objects",
-      value1: new Date("2017-06-16T21:36:48.362Z"),
-      value2: new Date("2017-01-01T00:00:00.000Z"),
-      equal: false,
-    },
-    {
-      description: "date and string are not equal",
-      value1: new Date("2017-06-16T21:36:48.362Z"),
-      value2: "2017-06-16T21:36:48.362Z",
-      equal: false,
-    },
-    {
-      description: "date and object are not equal",
-      value1: new Date("2017-06-16T21:36:48.362Z"),
-      value2: {},
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("equal date objects", () => {
+    expect(
+      equals(
+        new Date("2017-06-16T21:36:48.362Z"),
+        new Date("2017-06-16T21:36:48.362Z"),
+      ),
+    ).toBe(true);
+  });
+  test("not equal date objects", () => {
+    expect(
+      equals(
+        new Date("2017-06-16T21:36:48.362Z"),
+        new Date("2017-01-01T00:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+  test("date and string are not equal", () => {
+    expect(
+      equals(new Date("2017-06-16T21:36:48.362Z"), "2017-06-16T21:36:48.362Z"),
+    ).toBe(false);
+  });
+  test("date and object are not equal", () => {
+    expect(equals(new Date("2017-06-16T21:36:48.362Z"), {})).toBe(false);
   });
 });
 
 describe("RegExp objects", () => {
-  test.each([
-    {
-      description: "equal RegExp objects",
-      value1: /foo/u,
-      value2: /foo/u,
-      equal: true,
-    },
-    {
-      description: "not equal RegExp objects (different pattern)",
-      value1: /foo/u,
-      value2: /bar/u,
-      equal: false,
-    },
-    {
-      description: "not equal RegExp objects (different flags)",
-      value1: /foo/u,
-      value2: /foo/iu,
-      equal: false,
-    },
-    {
-      description: "RegExp and string are not equal",
-      value1: /foo/u,
-      value2: "foo",
-      equal: false,
-    },
-    {
-      description: "RegExp and object are not equal",
-      value1: /foo/u,
-      value2: {},
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("equal RegExp objects", () => {
+    expect(equals(/foo/u, /foo/u)).toBe(true);
+  });
+  test("not equal RegExp objects (different pattern)", () => {
+    expect(equals(/foo/u, /bar/u)).toBe(false);
+  });
+  test("not equal RegExp objects (different flags)", () => {
+    expect(equals(/foo/u, /foo/iu)).toBe(false);
+  });
+  test("RegExp and string are not equal", () => {
+    expect(equals(/foo/u, "foo")).toBe(false);
+  });
+  test("RegExp and object are not equal", () => {
+    expect(equals(/foo/u, {})).toBe(false);
   });
 });
 
 describe("functions", () => {
-  test.each([
-    {
-      description: "same function is equal",
-      value1: func1,
-      value2: func1,
-      equal: true,
-    },
-    {
-      description: "different functions are not equal",
-      value1: func1,
-      value2: func2,
-      equal: false,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+  test("same function is equal", () => {
+    expect(equals(func1, func1)).toBe(true);
+  });
+  test("different functions are not equal", () => {
+    expect(equals(func1, func2)).toBe(false);
   });
 });
 
 describe("sample objects", () => {
-  test.each([
-    {
-      description: "big object",
-      value1: {
-        prop1: "value1",
-        prop2: "value2",
-        prop3: "value3",
-        prop4: {
-          subProp1: "sub value1",
-          subProp2: {
-            subSubProp1: "sub sub value1",
-            subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
+  test("big object", () => {
+    expect(
+      equals(
+        {
+          prop1: "value1",
+          prop2: "value2",
+          prop3: "value3",
+          prop4: {
+            subProp1: "sub value1",
+            subProp2: {
+              subSubProp1: "sub sub value1",
+              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
+            },
+          },
+          prop5: 1000,
+          prop6: new Date(2016, 2, 10),
+        },
+        {
+          prop5: 1000,
+          prop3: "value3",
+          prop1: "value1",
+          prop2: "value2",
+          prop6: new Date("2016/03/10"),
+          prop4: {
+            subProp2: {
+              subSubProp1: "sub sub value1",
+              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
+            },
+            subProp1: "sub value1",
           },
         },
-        prop5: 1000,
-        prop6: new Date(2016, 2, 10),
-      },
-      value2: {
-        prop5: 1000,
-        prop3: "value3",
-        prop1: "value1",
-        prop2: "value2",
-        prop6: new Date("2016/03/10"),
-        prop4: {
-          subProp2: {
-            subSubProp1: "sub sub value1",
-            subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5],
-          },
-          subProp1: "sub value1",
-        },
-      },
-      equal: true,
-    },
-  ])("$description", ({ value1, value2, equal }) => {
-    expect(equals(value1, value2)).toEqual(equal);
+      ),
+    ).toBe(true);
   });
 });

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -140,16 +140,17 @@ function _evolve(data: unknown, evolver: GenericEvolver): unknown {
   if (typeof data !== "object" || data === null) {
     return data;
   }
-  return toPairs.strict(evolver).reduce<Record<string, unknown>>(
-    (result, [key, value]) => {
-      if (key in result) {
-        result[key] =
-          typeof value === "function"
-            ? value(result[key])
-            : _evolve(result[key], value);
-      }
-      return result;
-    },
-    { ...data },
-  );
+
+  const out: Record<string, unknown> = { ...data };
+
+  for (const [key, value] of toPairs.strict(evolver)) {
+    if (key in out) {
+      out[key] =
+        typeof value === "function"
+          ? value(out[key])
+          : _evolve(out[key], value);
+    }
+  }
+
+  return out;
 }

--- a/src/find.ts
+++ b/src/find.ts
@@ -54,13 +54,10 @@ export function find(): unknown {
 
 const _find =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
-    if (indexed) {
-      return array.find(fn);
-    }
-
-    return array.find((x) => fn(x));
-  };
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
+    array.find((item, index, input) =>
+      indexed ? fn(item, index, input) : fn(item),
+    );
 
 const _lazy =
   (indexed: boolean) =>

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -63,12 +63,13 @@ const _findIndex =
 const _lazy =
   (indexed: boolean) =>
   <T>(fn: PredIndexedOptional<T, boolean>): LazyEvaluator<T, number> => {
-    let i = 0;
+    // TODO: We use the `actualIndex` here because we can't trust the index coming from pipe. This is due to the fact that the `indexed` abstraction might turn off incrementing the index or not send it at all. Once we simplify the code base by removing the non-indexed versions, we can remove this.
+    let actualIndex = 0;
     return (value, index, array) => {
       if (indexed ? fn(value, index, array) : fn(value)) {
-        return { done: true, hasNext: true, next: i };
+        return { done: true, hasNext: true, next: actualIndex };
       }
-      i += 1;
+      actualIndex += 1;
       return { done: false, hasNext: false };
     };
   };

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -55,13 +55,10 @@ export function findIndex(): unknown {
 
 const _findIndex =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
-    if (indexed) {
-      return array.findIndex(fn);
-    }
-
-    return array.findIndex((x) => fn(x));
-  };
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
+    array.findIndex((item, index, input) =>
+      indexed ? fn(item, index, input) : fn(item),
+    );
 
 const _lazy =
   (indexed: boolean) =>

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -59,7 +59,7 @@ const _findLast =
         return array[i];
       }
     }
-    return undefined;
+    return;
   };
 
 export namespace findLast {

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -65,14 +65,18 @@ const _flatMapToObj =
       T,
       ReadonlyArray<readonly [key: PropertyKey, value: unknown]>
     >,
-  ) =>
-    array.reduce<Record<PropertyKey, unknown>>((result, element, index) => {
+  ) => {
+    const out: Record<PropertyKey, unknown> = {};
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump the TypeScript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value at the same time.
+      const element = array[index]!;
       const items = indexed ? fn(element, index, array) : fn(element);
       items.forEach(([key, value]) => {
-        result[key] = value;
+        out[key] = value;
       });
-      return result;
-    }, {});
+    }
+    return out;
+  };
 
 export namespace flatMapToObj {
   export function indexed<T, K extends PropertyKey, V>(

--- a/src/flatMapToObj.ts
+++ b/src/flatMapToObj.ts
@@ -71,9 +71,10 @@ const _flatMapToObj =
       // TODO: Once we bump the TypeScript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value at the same time.
       const element = array[index]!;
       const items = indexed ? fn(element, index, array) : fn(element);
-      items.forEach(([key, value]) => {
+
+      for (const [key, value] of items) {
         out[key] = value;
-      });
+      }
     }
     return out;
   };

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -46,6 +46,7 @@ function _flatten<T>(items: ReadonlyArray<T>): Array<Flatten<T>> {
 export namespace flatten {
   export const lazy =
     <T>(): LazyEvaluator<T, Flatten<T>> =>
+    // eslint-disable-next-line unicorn/consistent-function-scoping -- I tried pulling the function out but I couldn't get the `<T>` to get inferred correctly.
     (item) =>
       // @ts-expect-error [ts2322] - We need to make LazyMany better so it accommodate the typing here...
       Array.isArray(item)

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -65,6 +65,7 @@ function _flattenDeepValue<T>(value: Array<T> | T): Array<FlattenDeep<T>> | T {
 export namespace flattenDeep {
   export const lazy =
     <T>(): LazyEvaluator<T, any> =>
+    // eslint-disable-next-line unicorn/consistent-function-scoping -- I tried pulling the function out but I couldn't get the `<T>` to get inferred correctly.
     (value) => {
       const next = _flattenDeepValue(value);
       return Array.isArray(next)

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -52,13 +52,15 @@ function _flattenDeepValue<T>(value: Array<T> | T): Array<FlattenDeep<T>> | T {
     return value;
   }
   const ret: Array<any> = [];
-  value.forEach((item) => {
+
+  for (const item of value) {
     if (Array.isArray(item)) {
       ret.push(...flattenDeep(item));
     } else {
       ret.push(item);
     }
-  });
+  }
+
   return ret;
 }
 

--- a/src/floor.test.ts
+++ b/src/floor.test.ts
@@ -3,7 +3,7 @@ import { floor } from "./floor";
 describe("data-first", () => {
   test("should work with positive precision", () => {
     expect(floor(8123.4317, 3)).toEqual(8123.431);
-    expect(floor(483.22243, 1)).toEqual(483.2);
+    expect(floor(483.222_43, 1)).toEqual(483.2);
     expect(floor(123.4317, 5)).toEqual(123.4317);
   });
 
@@ -16,11 +16,14 @@ describe("data-first", () => {
     expect(floor(8123.4317, 0)).toEqual(8123);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => floor(1, val)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => floor(1, val)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => floor(1, 21.37)).toThrowError(
@@ -37,7 +40,7 @@ describe("data-first", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
@@ -50,7 +53,7 @@ describe("data-first", () => {
 describe("data-last", () => {
   test("should work with positive precision", () => {
     expect(floor(3)(8123.4317)).toEqual(8123.431);
-    expect(floor(1)(483.22243)).toEqual(483.2);
+    expect(floor(1)(483.222_43)).toEqual(483.2);
     expect(floor(5)(123.4317)).toEqual(123.4317);
   });
 
@@ -63,11 +66,14 @@ describe("data-last", () => {
     expect(floor(0)(8123.4317)).toEqual(8123);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => floor(val)(1)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => floor(val)(1)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => floor(21.37)(1)).toThrowError(
@@ -84,7 +90,7 @@ describe("data-last", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -49,7 +49,10 @@ const _groupBy =
     fn: PredIndexedOptional<T, Key | undefined>,
   ) => {
     const ret: Record<string, Array<T>> = {};
-    array.forEach((item, index) => {
+
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
       const key = indexed ? fn(item, index, array) : fn(item);
       if (key !== undefined) {
         const actualKey = String(key);
@@ -61,7 +64,8 @@ const _groupBy =
         }
         items.push(item);
       }
-    });
+    }
+
     return ret;
   };
 

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -57,13 +57,17 @@ export function indexBy(): unknown {
 
 const _indexBy =
   (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) =>
-    array.reduce<Record<string, T>>((ret, item, index) => {
+  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) => {
+    const out: Record<string, T> = {};
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target version we can use Array.prototype.entries to iterate over the elements and index at the same time.
+      const item = array[index]!;
       const value = indexed ? fn(item, index, array) : fn(item);
       const key = String(value);
-      ret[key] = item;
-      return ret;
-    }, {});
+      out[key] = item;
+    }
+    return out;
+  };
 
 function indexByStrict<K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
@@ -78,15 +82,19 @@ function indexByStrict(): unknown {
   return purry(_indexByStrict, arguments);
 }
 
-const _indexByStrict = <K extends PropertyKey, T>(
+function _indexByStrict<K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
   fn: (item: T) => K,
-): Partial<Record<K, T>> =>
-  array.reduce<Partial<Record<K, T>>>((ret, item) => {
+): Partial<Record<K, T>> {
+  const out: Partial<Record<K, T>> = {};
+
+  for (const item of array) {
     const key = fn(item);
-    ret[key] = item;
-    return ret;
-  }, {});
+    out[key] = item;
+  }
+
+  return out;
+}
 
 export namespace indexBy {
   export function indexed<T>(

--- a/src/isDefined.ts
+++ b/src/isDefined.ts
@@ -16,7 +16,7 @@
  * @strict
  */
 export function isDefined<T>(data: T): data is NonNullable<T> {
-  return typeof data !== "undefined" && data !== null;
+  return data !== undefined && data !== null;
 }
 
 export namespace isDefined {

--- a/src/isError.test.ts
+++ b/src/isError.test.ts
@@ -5,6 +5,13 @@ import {
 } from "../test/types_data_provider";
 import { isError } from "./isError";
 
+class MyError extends Error {
+  constructor() {
+    super();
+    this.name = "MyError";
+  }
+}
+
 describe("isError", () => {
   it("should work as type guard", () => {
     const data = TYPES_DATA_PROVIDER.error as AllTypesDataProviderTypes;
@@ -12,8 +19,6 @@ describe("isError", () => {
       expect(data instanceof Error).toEqual(true);
       expectTypeOf(data).toEqualTypeOf<Error>();
     }
-
-    class MyError extends Error {}
 
     let maybeError: MyError | undefined;
     if (isError(maybeError)) {

--- a/src/isNumber.test.ts
+++ b/src/isNumber.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../test/types_data_provider";
 import { isNumber } from "./isNumber";
 
+const dataFunction = (): string | 1 | 2 | 3 => 1;
+
 describe("isNumber", () => {
   it("should work as type guard", () => {
     const data = TYPES_DATA_PROVIDER.number as AllTypesDataProviderTypes;
@@ -29,8 +31,7 @@ describe("isNumber", () => {
   });
 
   it("should work with literal types", () => {
-    const data = (): string | 1 | 2 | 3 => 1;
-    const x = data();
+    const x = dataFunction();
     if (isNumber(x)) {
       expect(typeof x).toEqual("number");
       expectTypeOf(x).toEqualTypeOf<1 | 2 | 3>(x);

--- a/src/isString.test.ts
+++ b/src/isString.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../test/types_data_provider";
 import { isString } from "./isString";
 
+const dataFunction = (): number | "a" | "b" | "c" => "a";
+
 describe("isString", () => {
   it("should work as type guard", () => {
     const data = TYPES_DATA_PROVIDER.string as AllTypesDataProviderTypes;
@@ -23,8 +25,7 @@ describe("isString", () => {
   });
 
   it("should work with literal types", () => {
-    const data = (): number | "a" | "b" | "c" => "a";
-    const x = data();
+    const x = dataFunction();
     if (isString(x)) {
       expect(typeof x).toEqual("string");
       expectTypeOf(x).toEqualTypeOf<"a" | "b" | "c">();

--- a/src/isTruthy.ts
+++ b/src/isTruthy.ts
@@ -13,6 +13,7 @@
  *    R.isTruthy('') //=> false
  * @category Guard
  */
+// eslint-disable-next-line unicorn/prefer-native-coercion-functions -- This is not entirely correct, our isTruthy also coerces the type.
 export function isTruthy<T>(
   data: T,
 ): data is Exclude<T, "" | 0 | false | null | undefined> {

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -54,12 +54,19 @@ const _mapToObj =
   (
     array: ReadonlyArray<unknown>,
     fn: PredIndexedOptional<unknown, [PropertyKey, unknown]>,
-  ) =>
-    array.reduce<Record<PropertyKey, unknown>>((result, element, index) => {
+  ) => {
+    const out: Record<PropertyKey, unknown> = {};
+
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Use Array.prototype.entries once we bump the Typescript target version to iterate over the elements and index at the same time.
+      // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+      const element = array[index];
       const [key, value] = indexed ? fn(element, index, array) : fn(element);
-      result[key] = value;
-      return result;
-    }, {});
+      out[key] = value;
+    }
+
+    return out;
+  };
 
 export namespace mapToObj {
   export function indexed<T, K extends PropertyKey, V>(

--- a/src/maxBy.ts
+++ b/src/maxBy.ts
@@ -4,8 +4,8 @@ import type { PredIndexed, PredIndexedOptional } from "./_types";
 const _maxBy =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
-    let ret: T | undefined = undefined;
-    let retMax: number | undefined = undefined;
+    let ret: T | undefined;
+    let retMax: number | undefined;
     array.forEach((item, i) => {
       const max = indexed ? fn(item, i, array) : fn(item);
       if (retMax === undefined || max > retMax) {

--- a/src/maxBy.ts
+++ b/src/maxBy.ts
@@ -6,13 +6,16 @@ const _maxBy =
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
     let ret: T | undefined;
     let retMax: number | undefined;
-    array.forEach((item, i) => {
-      const max = indexed ? fn(item, i, array) : fn(item);
+
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
+      const max = indexed ? fn(item, index, array) : fn(item);
       if (retMax === undefined || max > retMax) {
         ret = item;
         retMax = max;
       }
-    });
+    }
 
     return ret;
   };

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -5,7 +5,7 @@ const _meanBy =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
     if (array.length === 0) {
-      return NaN;
+      return Number.NaN;
     }
 
     let sum = 0;

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -5,7 +5,7 @@ const _meanBy =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
     if (array.length === 0) {
-      return Number.NaN;
+      return NaN;
     }
 
     let sum = 0;

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -9,9 +9,12 @@ const _meanBy =
     }
 
     let sum = 0;
-    array.forEach((item, i) => {
-      sum += indexed ? fn(item, i, array) : fn(item);
-    });
+
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
+      sum += indexed ? fn(item, index, array) : fn(item);
+    }
 
     return sum / array.length;
   };

--- a/src/mergeAll.ts
+++ b/src/mergeAll.ts
@@ -19,5 +19,11 @@ export function mergeAll<A, B, C, D, E>(
 export function mergeAll(array: ReadonlyArray<object>): object;
 
 export function mergeAll(items: ReadonlyArray<object>): object {
-  return items.reduce((acc, x) => ({ ...acc, ...x }), {});
+  let out = {};
+
+  for (const item of items) {
+    out = { ...out, ...item };
+  }
+
+  return out;
 }

--- a/src/minBy.ts
+++ b/src/minBy.ts
@@ -6,13 +6,16 @@ const _minBy =
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
     let ret: T | undefined;
     let retMin: number | undefined;
-    array.forEach((item, i) => {
-      const min = indexed ? fn(item, i, array) : fn(item);
+
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
+      const min = indexed ? fn(item, index, array) : fn(item);
       if (retMin === undefined || min < retMin) {
         ret = item;
         retMin = min;
       }
-    });
+    }
 
     return ret;
   };

--- a/src/minBy.ts
+++ b/src/minBy.ts
@@ -4,8 +4,8 @@ import type { PredIndexed, PredIndexedOptional } from "./_types";
 const _minBy =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
-    let ret: T | undefined = undefined;
-    let retMin: number | undefined = undefined;
+    let ret: T | undefined;
+    let retMin: number | undefined;
     array.forEach((item, i) => {
       const min = indexed ? fn(item, i, array) : fn(item);
       if (retMin === undefined || min < retMin) {

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -41,10 +41,13 @@ function _omitBy<T>(
     return object;
   }
 
-  return keys.strict(object).reduce<Partial<T>>((acc, key) => {
+  const out: Partial<T> = {};
+
+  for (const key of keys.strict(object)) {
     if (!fn(object[key], key)) {
-      acc[key] = object[key];
+      out[key] = object[key];
     }
-    return acc;
-  }, {});
+  }
+
+  return out;
 }

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -1,3 +1,4 @@
+import { isNumber } from "./isNumber";
 import { partition } from "./partition";
 import { pipe } from "./pipe";
 
@@ -21,8 +22,6 @@ describe("data first", () => {
     expect(partition(array, (x) => x.a === 1)).toEqual(expected);
   });
   test("partition with type guard", () => {
-    const isNumber = (value: unknown): value is number =>
-      typeof value === "number";
     const actual = partition([1, "a", 2, "b"], isNumber);
     expect(actual).toEqual([
       [1, 2],

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -77,10 +77,12 @@ const _partition =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) => {
     const ret: [Array<T>, Array<T>] = [[], []];
-    array.forEach((item, index) => {
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
       const matches = indexed ? fn(item, index, array) : fn(item);
       ret[matches ? 0 : 1].push(item);
-    });
+    }
     return ret;
   };
 

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -36,11 +36,12 @@ function _pick<T extends object, K extends keyof T>(
   object: T,
   names: ReadonlyArray<K>,
 ): Pick<T, K> {
-  // @ts-expect-error [ts2322] - We build the type incrementally, there's no way to make typescript infer that we "finished" building the object and to treat it as such.
-  return names.reduce<Partial<Pick<T, K>>>((acc, name) => {
+  const out: Partial<Pick<T, K>> = {};
+  for (const name of names) {
     if (name in object) {
-      acc[name] = object[name];
+      out[name] = object[name];
     }
-    return acc;
-  }, {});
+  }
+  // @ts-expect-error [ts2322] - We build the type incrementally, there's no way to make typescript infer that we "finished" building the object and to treat it as such.
+  return out;
 }

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -41,10 +41,13 @@ function _pickBy<T>(
     return {};
   }
 
-  return keys.strict(data).reduce<Partial<T>>((acc, key) => {
+  const out: Partial<T> = {};
+
+  for (const key of keys.strict(data)) {
     if (fn(data[key], key)) {
-      acc[key] = data[key];
+      out[key] = data[key];
     }
-    return acc;
-  }, {});
+  }
+
+  return out;
 }

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -287,11 +287,7 @@ export function pipe(
     }
 
     const { isSingle } = lazySequence[lazySequence.length - 1]!;
-    if (isSingle) {
-      output = accumulator[0];
-    } else {
-      output = accumulator;
-    }
+    output = isSingle ? accumulator[0] : accumulator;
     operationIndex += lazySequence.length;
   }
   return output;

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -252,9 +252,9 @@ export function pipe(
     }
 
     const lazySequence: Array<PreparedLazyOperation> = [];
-    for (let j = operationIndex; j < operations.length; j++) {
+    for (let index = operationIndex; index < operations.length; index++) {
       // eslint-disable-next-line @typescript-eslint/prefer-destructuring
-      const lazyOp = lazyOperations[j];
+      const lazyOp = lazyOperations[index];
       if (lazyOp === undefined) {
         break;
       }
@@ -319,8 +319,13 @@ function _processItem(
 
   let lazyResult: LazyResult<any> = { done: false, hasNext: false };
   let isDone = false;
-  for (let i = 0; i < lazySequence.length; i++) {
-    const lazyFn = lazySequence[i]!;
+  for (
+    let operationsIndex = 0;
+    operationsIndex < lazySequence.length;
+    operationsIndex++
+  ) {
+    // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+    const lazyFn = lazySequence[operationsIndex]!;
     const { isIndexed, index, items } = lazyFn;
     items.push(currentItem);
     lazyResult = isIndexed
@@ -333,7 +338,7 @@ function _processItem(
           const subResult = _processItem(
             subItem,
             accumulator,
-            lazySequence.slice(i + 1),
+            lazySequence.slice(operationsIndex + 1),
           );
           if (subResult) {
             return true;

--- a/src/purry.test.ts
+++ b/src/purry.test.ts
@@ -4,24 +4,19 @@ function sub(a: number, b: number): number {
   return a - b;
 }
 
+function fn(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sub, args);
+}
+
 test("all arguments", () => {
-  function fn(...args: ReadonlyArray<unknown>): unknown {
-    return purry(sub, args);
-  }
   expect(fn(10, 5)).toEqual(5);
 });
 
 test("1 missing", () => {
-  function fn(...args: ReadonlyArray<unknown>): unknown {
-    return purry(sub, args);
-  }
   const purried = fn(5) as (...args: ReadonlyArray<unknown>) => unknown;
   expect(purried(10)).toEqual(5);
 });
 
 test("wrong number of arguments", () => {
-  function fn(...args: ReadonlyArray<unknown>): unknown {
-    return purry(sub, args);
-  }
   expect(() => fn(5, 10, 40)).toThrowError("Wrong number of arguments");
 });

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -50,6 +50,7 @@ const _reduce =
     fn: (acc: K, item: T, index?: number, items?: ReadonlyArray<T>) => K,
     initialValue: K,
   ): K =>
+    // eslint-disable-next-line unicorn/no-array-reduce -- Our function wraps the built-in reduce.
     items.reduce(
       (acc, item, index) =>
         indexed ? fn(acc, item, index, items) : fn(acc, item),

--- a/src/round.test.ts
+++ b/src/round.test.ts
@@ -3,24 +3,27 @@ import { round } from "./round";
 describe("data-first", () => {
   test("should work with positive precision", () => {
     expect(round(8123.4317, 3)).toEqual(8123.432);
-    expect(round(483.22243, 1)).toEqual(483.2);
+    expect(round(483.222_43, 1)).toEqual(483.2);
     expect(round(123.4317, 5)).toEqual(123.4317);
   });
 
   test("should work with negative precision", () => {
     expect(round(8123.4317, -2)).toEqual(8100);
-    expect(round(8123.4317, -4)).toEqual(10000);
+    expect(round(8123.4317, -4)).toEqual(10_000);
   });
 
   test("should work with precision = 0", () => {
     expect(round(8123.4317, 0)).toEqual(8123);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => round(1, val)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => round(1, val)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => round(1, 21.37)).toThrowError(
@@ -37,7 +40,7 @@ describe("data-first", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
@@ -50,24 +53,27 @@ describe("data-first", () => {
 describe("data-last", () => {
   test("should work with positive precision", () => {
     expect(round(3)(8123.4317)).toEqual(8123.432);
-    expect(round(1)(483.22243)).toEqual(483.2);
+    expect(round(1)(483.222_43)).toEqual(483.2);
     expect(round(5)(123.4317)).toEqual(123.4317);
   });
 
   test("should work with negative precision", () => {
     expect(round(-2)(8123.4317)).toEqual(8100);
-    expect(round(-4)(8123.4317)).toEqual(10000);
+    expect(round(-4)(8123.4317)).toEqual(10_000);
   });
 
   test("should work with precision = 0", () => {
     expect(round(0)(8123.4317)).toEqual(8123);
   });
 
-  test.each([NaN, Infinity])("should throw for %d precision", (val) => {
-    expect(() => round(val)(1)).toThrowError(
-      `precision must be an integer: ${val}`,
-    );
-  });
+  test.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw for %d precision",
+    (val) => {
+      expect(() => round(val)(1)).toThrowError(
+        `precision must be an integer: ${val}`,
+      );
+    },
+  );
 
   test("should throw for non integer precision", () => {
     expect(() => round(21.37)(1)).toThrowError(
@@ -84,7 +90,7 @@ describe("data-last", () => {
     );
   });
 
-  test.each([NaN, Infinity, -Infinity])(
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -47,11 +47,12 @@ describe("at runtime", () => {
 
       // Scan the result array and make sure each item is after the previous one
       // in the input array.
-      result.reduce((lastInputIndex, item) => {
+      let lastInputIndex = -1; /* outside of the array */
+      for (const item of result) {
         const currentInputIndex = array.indexOf(item);
         expect(currentInputIndex).toBeGreaterThan(lastInputIndex);
-        return currentInputIndex;
-      }, -1 /* outside of the array */);
+        lastInputIndex = currentInputIndex;
+      }
     });
   });
 
@@ -918,7 +919,7 @@ describe("typing", () => {
 const generateRandomArray = (): NonEmptyArray<number> =>
   // We use a set to remove duplicates, as it allows us to simplify our tests
   // @ts-expect-error [ts2322]: we know this array isn't empty!
-  Array.from(new Set(Array.from({ length: 100 }).map(Math.random)));
+  Array.from(new Set(Array.from({ length: 100 }).map(() => Math.random())));
 
 const allIndices = (array: ReadonlyArray<unknown>): Array<number> =>
   array.map((_, index) => index);

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -45,10 +45,11 @@ describe("at runtime", () => {
     it.each(allIndices(array))("doesn't reorder items", (sampleSize) => {
       const result = sample(array, sampleSize);
 
-      // Scan the result array and make sure each item is after the previous one
-      // in the input array.
-      let lastInputIndex = -1; /* outside of the array */
+      let lastInputIndex = -1; // outside of the array
       for (const item of result) {
+        // Scan the result array and make sure each item is after the previous one
+        // in the input array.
+
         const currentInputIndex = array.indexOf(item);
         expect(currentInputIndex).toBeGreaterThan(lastInputIndex);
         lastInputIndex = currentInputIndex;

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -117,7 +117,7 @@ function sampleImplementation<T>(
 
   if (sampleSize >= data.length) {
     // Trivial
-    return [...data];
+    return data.slice();
   }
 
   if (sampleSize === 0) {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -55,7 +55,7 @@ function _sort<T>(
   items: ReadonlyArray<T>,
   cmp: (a: T, b: T) => number,
 ): Array<T> {
-  const ret = [...items];
+  const ret = items.slice();
   ret.sort(cmp);
   return ret;
 }

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -107,7 +107,7 @@ const _sortBy = <T>(
   compareFn: CompareFunction<T>,
 ): Array<T> =>
   // Sort is done in-place so we need to copy the array.
-  [...data].sort(compareFn);
+  data.slice().sort(compareFn);
 
 type Strict = {
   <T extends IterableContainer>(

--- a/src/splice.ts
+++ b/src/splice.ts
@@ -51,7 +51,7 @@ function _splice<T>(
   deleteCount: number,
   replacement: ReadonlyArray<T>,
 ): Array<T> {
-  const result = [...items];
+  const result = items.slice();
   result.splice(start, deleteCount, ...replacement);
   return result;
 }

--- a/src/splitAt.ts
+++ b/src/splitAt.ts
@@ -41,7 +41,7 @@ function _splitAt<T>(
   array: ReadonlyArray<T>,
   index: number,
 ): [Array<T>, Array<T>] {
-  const copy = [...array];
+  const copy = array.slice();
   const tail = copy.splice(index);
   return [copy, tail];
 }

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -48,5 +48,5 @@ function _splitWhen<T>(
     }
   }
 
-  return [[...array], []];
+  return [array.slice(), []];
 }

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -5,10 +5,12 @@ const _sumBy =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, number>) => {
     let sum = 0;
-    array.forEach((item, i) => {
-      const summand = indexed ? fn(item, i, array) : fn(item);
+    for (let index = 0; index < array.length; index++) {
+      // TODO: Once we bump our Typescript target above ES5 we can use Array.prototype.entries to iterate over both the index and the value.
+      const item = array[index]!;
+      const summand = indexed ? fn(item, index, array) : fn(item);
       sum += summand;
-    });
+    }
     return sum;
   };
 

--- a/src/swapIndices.ts
+++ b/src/swapIndices.ts
@@ -75,10 +75,10 @@ type SwapArray<
   K1 extends number,
   K2 extends number,
 > =
-  // TODO [typescript@>4.6]: Because of limitations on the typescript version
-  // used in Remeda we can't build a proper Absolute number type so we can't
-  // implement proper typing for negative indices and have to opt for a less-
-  // strict type instead.
+  // TODO: Because of limitations on the typescript version used in Remeda we
+  // can't build a proper Absolute number type so we can't implement proper
+  // typing for negative indices and have to opt for a less- strict type
+  // instead.
   // Check out the history for the PR that introduced this TODO to see how it
   // could be implemented.
   IsNonNegative<K1> extends false

--- a/src/takeFirstBy.ts
+++ b/src/takeFirstBy.ts
@@ -60,7 +60,7 @@ function takeFirstByImplementation<T>(
   }
 
   if (n >= data.length) {
-    return [...data];
+    return data.slice();
   }
 
   const heap = data.slice(0, n);

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -5,6 +5,11 @@ import { tap } from "./tap";
 
 const DATA = [1] as const;
 
+// (same as console.log)
+function foo(x: unknown): unknown {
+  return x;
+}
+
 describe("data first", () => {
   it("should call function with input value", () => {
     const fn = vi.fn();
@@ -50,11 +55,6 @@ describe("data last", () => {
   });
 
   it("should infer types after tapping function reference with parameter type any", () => {
-    // (same as console.log)
-    function foo(x: unknown): unknown {
-      return x;
-    }
-
     expect(
       pipe(
         [-1, 2],

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -1,22 +1,24 @@
 import { times } from "./times";
 
+const noop = () => undefined;
+const one = () => 1;
+const mul1 = (idx: number) => idx;
+const mul2 = (idx: number) => idx * 2;
+
 describe("times", () => {
   describe("data_first", () => {
     it("throws error on invalid idx", () => {
-      const noop = () => undefined;
       expect(() => times(-1, noop)).toThrow();
       expect(() => times(-1000, noop)).toThrow();
       expect(() => times(Number.MIN_SAFE_INTEGER, noop)).toThrow();
     });
 
     it("returns empty array", () => {
-      const noop = () => undefined;
       const res = times(0, noop);
       expect(res).toEqual([]);
     });
 
     it("returns arr with fn result", () => {
-      const one = () => 1;
       expect(times(1, one)).toEqual([1]);
       expect(times(5, one)).toEqual([1, 1, 1, 1, 1]);
     });
@@ -32,17 +34,13 @@ describe("times", () => {
     });
 
     it("returns fn results as arr", () => {
-      const mul1 = (idx: number) => idx;
       expect(times(5, mul1)).toEqual([0, 1, 2, 3, 4]);
-
-      const mul2 = (idx: number) => idx * 2;
       expect(times(5, mul2)).toEqual([0, 2, 4, 6, 8]);
     });
   });
 
   describe("data_last", () => {
     it("throws error on invalid idx", () => {
-      const noop = () => undefined;
       const noopTimes = times(noop);
       expect(() => noopTimes(-1)).toThrow();
       expect(() => noopTimes(-1000)).toThrow();
@@ -50,13 +48,11 @@ describe("times", () => {
     });
 
     it("returns empty array", () => {
-      const noop = () => undefined;
       const res = times(noop)(0);
       expect(res).toEqual([]);
     });
 
     it("returns arr with fn result", () => {
-      const one = () => 1;
       const oneTime = times(one);
       expect(oneTime(1)).toEqual([1]);
       expect(oneTime(5)).toEqual([1, 1, 1, 1, 1]);
@@ -73,10 +69,7 @@ describe("times", () => {
     });
 
     it("returns fn results as arr", () => {
-      const mul1 = (idx: number) => idx;
       expect(times(mul1)(5)).toEqual([0, 1, 2, 3, 4]);
-
-      const mul2 = (idx: number) => idx * 2;
       expect(times(mul2)(5)).toEqual([0, 2, 4, 6, 8]);
     });
   });

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -1,9 +1,9 @@
 import { times } from "./times";
 
-const noop = () => undefined;
-const one = () => 1;
-const mul1 = (idx: number) => idx;
-const mul2 = (idx: number) => idx * 2;
+const noop = (): undefined => undefined;
+const one = () => 1 as const;
+const mul1 = (idx: number): number => idx;
+const mul2 = (idx: number): number => idx * 2;
 
 describe("times", () => {
   describe("data_first", () => {

--- a/src/type.test.ts
+++ b/src/type.test.ts
@@ -25,7 +25,7 @@ it('"String" if given a String literal', () => {
 });
 
 it('"String" if given a String object', () => {
-  // eslint-disable-next-line no-new-wrappers -- Intentional
+  // eslint-disable-next-line no-new-wrappers, unicorn/new-for-builtins -- Intentional
   expect(type(new String("I am a String object"))).toEqual("String");
 });
 

--- a/src/type.test.ts
+++ b/src/type.test.ts
@@ -17,7 +17,7 @@ it('"Number" if given a numeric value', () => {
 });
 
 it('"Number" if given the NaN value', () => {
-  expect(type(NaN)).toEqual("Number");
+  expect(type(Number.NaN)).toEqual("Number");
 });
 
 it('"String" if given a String literal', () => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -19,7 +19,8 @@
 export function type(val: unknown): string {
   return val === null
     ? "Null"
-    : val === undefined
+    : // eslint-disable-next-line unicorn/no-nested-ternary -- I don't understand what makes the rule fire here...
+      val === undefined
       ? "Undefined"
       : Object.prototype.toString.call(val).slice(8, -1);
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -19,8 +19,7 @@
 export function type(val: unknown): string {
   return val === null
     ? "Null"
-    : // eslint-disable-next-line unicorn/no-nested-ternary -- I don't understand what makes the rule fire here...
-      val === undefined
+    : val === undefined
       ? "Undefined"
       : Object.prototype.toString.call(val).slice(8, -1);
 }

--- a/src/uniqBy.test.ts
+++ b/src/uniqBy.test.ts
@@ -41,7 +41,7 @@ describe("uniqBy", () => {
   });
 
   it("returns people with uniq first letter of name", () => {
-    expect(uniqBy(people, (p) => p.name.substring(0, 1))).toEqual([
+    expect(uniqBy(people, (p) => p.name.slice(0, 1))).toEqual([
       { name: "John", age: 42 },
       { name: "Sarah", age: 33 },
       { name: "Kim", age: 22 },

--- a/test/types_data_provider.ts
+++ b/test/types_data_provider.ts
@@ -15,6 +15,7 @@ export const TYPES_DATA_PROVIDER = {
   },
   instance: new TestClass(),
   map: new Map<string, string>(),
+
   null: null,
   number: 5 as number,
   object: { a: "asd" },

--- a/test/types_data_provider.ts
+++ b/test/types_data_provider.ts
@@ -15,7 +15,6 @@ export const TYPES_DATA_PROVIDER = {
   },
   instance: new TestClass(),
   map: new Map<string, string>(),
-
   null: null,
   number: 5 as number,
   object: { a: "asd" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
 
-  "include": ["src", "test", "*.config.js", "*.config.ts"],
+  "include": ["src", "test", "*.config.mjs", "*.config.ts"],
 
   "compilerOptions": {
     // TYPE CHECKING


### PR DESCRIPTION
Unicorn provides even more "best practices" lint rules, which allow us to standardize our codebase and move faster.

There are quite a few runtime changes in this PR, mainly removing reduce and forEach loops in favor of for loops, which might even improve performance.

I also noticed that cloning arrays in ES5 using a spread causes typescript to add a polyfill to each function that requires it. Until we move to ES6+, we should use an array.slice() instead to reduce the need to include the polyfill.

This PR will be followed by another one that defines our allowed abbreviations and fix any errors throughout the code.

*Don't be alarmed by the number of lines in this PR, most of them are just restructuring the equals.test file!*

IMPORTANT: This PR relies on #555 