### PR TITLE
fix(merge): Allow overriding types

### DIFF
--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -1,23 +1,162 @@
 import { merge } from "./merge";
 
-const a = {
-  x: 1,
-  y: 2,
-};
-
-const b = {
-  y: 10,
-  z: 2,
-};
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+interface FooInterface {
+  [x: string]: unknown;
+  [x: number]: unknown;
+  foo: string;
+  bar: symbol;
+}
 
 describe("data first", () => {
   test("should merge", () => {
-    expect(merge(a, b)).toEqual({ x: 1, y: 10, z: 2 });
+    expect(merge({ x: 1, y: 2 }, { y: 10, z: 2 })).toEqual({
+      x: 1,
+      y: 10,
+      z: 2,
+    });
   });
 });
 
 describe("data last", () => {
   test("should merge", () => {
-    expect(merge(b)(a)).toEqual({ x: 1, y: 10, z: 2 });
+    expect(merge({ y: 10, z: 2 })({ x: 1, y: 2 })).toEqual({
+      x: 1,
+      y: 10,
+      z: 2,
+    });
+  });
+});
+
+describe("typing", () => {
+  test("source type overrides destination type", () => {
+    expectTypeOf(merge({ a: 1, b: "hello" }, { b: 2 })).toEqualTypeOf<{
+      a: number;
+      b: number;
+    }>();
+  });
+
+  it("works with interfaces", () => {
+    expectTypeOf(
+      merge(
+        {} as FooInterface,
+        {} as {
+          [x: number]: number;
+          [x: symbol]: boolean;
+          bar: Date;
+          baz: boolean;
+        },
+      ),
+    ).toEqualTypeOf<{
+      [x: string]: unknown;
+      [x: number]: number;
+      [x: symbol]: boolean;
+      foo: string;
+      bar: Date;
+      baz: boolean;
+    }>();
+  });
+
+  test("a property can be replaced by another property that is not of the same type", () => {
+    expectTypeOf(
+      merge(
+        { stripUndefinedValues: false } as { stripUndefinedValues: false },
+        { stripUndefinedValues: true } as { stripUndefinedValues: true },
+      ),
+    ).toEqualTypeOf<{ stripUndefinedValues: true }>();
+  });
+
+  test("optional keys are enforced", () => {
+    expectTypeOf(
+      merge(
+        {} as {
+          [x: string]: unknown;
+          [x: number]: unknown;
+          a: string;
+          b?: string;
+          c: undefined;
+          d: string;
+          e: number | undefined;
+        },
+        {} as {
+          [x: number]: number;
+          [x: symbol]: boolean;
+          a?: string;
+          b: string;
+          d?: string;
+          f: number | undefined;
+          g: undefined;
+        },
+      ),
+    ).toEqualTypeOf<{
+      // Note that `c` and `g` is not marked as optional and this is deliberate, as this is the behaviour expected by the older version of Merge. This may change in a later version.
+      [x: number]: number;
+      [x: symbol]: boolean;
+      [x: string]: unknown;
+      a?: string;
+      b: string;
+      c: undefined;
+      d?: string;
+      e: number | undefined;
+      f: number | undefined;
+      g: undefined;
+    }>();
+  });
+
+  test("indexed key type can be overwritten", () => {
+    expectTypeOf(
+      merge(
+        {} as {
+          [x: string]: unknown;
+          [x: number]: boolean;
+          [x: symbol]: number;
+          foo: boolean;
+          fooBar: boolean;
+        },
+        {} as {
+          [x: string]: boolean | number | string;
+          [x: number]: number | string;
+          [x: symbol]: symbol;
+          bar: string;
+          fooBar: string;
+        },
+      ),
+    ).toEqualTypeOf<{
+      [x: string]: boolean | number | string;
+      [x: number]: number | string;
+      [x: symbol]: symbol;
+      foo: boolean;
+      bar: string;
+      fooBar: string;
+    }>();
+  });
+
+  test("destination with any", () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any -- Intentional! */
+    expectTypeOf(
+      merge({} as { foo?: any }, {} as { bar: true }),
+    ).toEqualTypeOf<{ foo?: any; bar: true }>();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+
+  test("source with any", () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any -- Intentional! */
+    expectTypeOf(
+      merge({} as { foo: true }, {} as { bar?: any }),
+    ).toEqualTypeOf<{ foo: true; bar?: any }>();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+
+  test("Type-fest issue #601?", () => {
+    // Test for issue https://github.com/sindresorhus/type-fest/issues/601
+    expectTypeOf(
+      merge(
+        {} as Pick<
+          { t1?: number; t2?: number; t3?: number; t4?: number },
+          "t2" | "t4"
+        >,
+        {} as { list: Array<string> },
+      ),
+    ).toEqualTypeOf<{ t2?: number; t4?: number; list: Array<string> }>();
   });
 });

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -5,7 +5,8 @@ import type { Merge } from "./type-fest/merge";
  * Spreads the properties of the second object into the first object, overriding
  * any existing properties; equivalent to `{ ...data, ...other }`.
  * @param data the first object, shared props will be overridden.
- * @param other the second object.
+ * @param other the second object, this object would be fully contained within
+ * the result object.
  * @signature
  *    R.merge(data, other)
  * @example
@@ -19,7 +20,8 @@ export function merge<T, S>(data: T, other: S): Merge<T, S>;
  * Spreads the properties of the second object into the first object, overriding
  * any existing properties; equivalent to `{ ...data, ...other }`.
  * @param data the first object, shared props will be overridden.
- * @param other the second object.
+ * @param other the second object, this object would be fully contained within
+ * the result object.
  * @signature
  *    R.merge(other)(data)
  * @example

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -16,7 +16,7 @@ import type { Merge } from "./type-fest/merge";
  * new object. If properties in this object share keys with properties in the
  * destination object, the values from the source object will be used in the
  * new object.
- * @returns An object fully-containing `source`, and any properties from `data`
+ * @returns An object fully containing `source`, and any properties from `data`
  * that don't share a name with any property in `source`.
  * @signature
  *    R.merge(data, source)
@@ -42,7 +42,7 @@ export function merge<T, Source>(data: T, source: Source): Merge<T, Source>;
  * new object. If properties in this object share keys with properties in the
  * destination object, the values from the source object will be used in the
  * new object.
- * @returns An object fully-containing `source`, and any properties from `data`
+ * @returns An object fully containing `source`, and any properties from `data`
  * that don't share a name with any property in `source`.
  * @signature
  *    R.merge(source)(data)

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -10,7 +10,7 @@ import type { Merge } from "./type-fest/merge";
  * Equivalent to `{ ...data, ...source }`.
  *
  * @param data - The destination object, serving as the basis for the merge.
- * Properties from this object are included in the new object, but may be
+ * Properties from this object are included in the new object, but will be
  * overwritten by properties from the source object with matching keys.
  * @param source - The source object, whose properties will be included in the
  * new object. If properties in this object share keys with properties in the
@@ -36,7 +36,7 @@ export function merge<T, Source>(data: T, source: Source): Merge<T, Source>;
  * Equivalent to `{ ...data, ...source }`.
  *
  * @param data - The destination object, serving as the basis for the merge.
- * Properties from this object are included in the new object, but may be
+ * Properties from this object are included in the new object, but will be
  * overwritten by properties from the source object with matching keys.
  * @param source - The source object, whose properties will be included in the
  * new object. If properties in this object share keys with properties in the

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -4,8 +4,9 @@ import type { Merge } from "./type-fest/merge";
 /**
  * Spreads the properties of the second object into the first object, overriding
  * any existing properties; equivalent to `{ ...data, ...other }`.
- * @param data the first object, shared props will be overridden.
- * @param other the second object, this object would be fully contained within
+ *
+ * @param data - The first object, shared props will be overridden.
+ * @param other - The second object, this object would be fully contained within
  * the result object.
  * @signature
  *    R.merge(data, other)
@@ -19,8 +20,9 @@ export function merge<T, S>(data: T, other: S): Merge<T, S>;
 /**
  * Spreads the properties of the second object into the first object, overriding
  * any existing properties; equivalent to `{ ...data, ...other }`.
- * @param data the first object, shared props will be overridden.
- * @param other the second object, this object would be fully contained within
+ *
+ * @param data - The first object, shared props will be overridden.
+ * @param other - The second object, this object would be fully contained within
  * the result object.
  * @signature
  *    R.merge(other)(data)

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -3,40 +3,43 @@ import type { Merge } from "./type-fest/merge";
 
 /**
  * Spreads the properties of the second object into the first object, overriding
- * any existing properties; equivalent to `{ ...data, ...other }`.
+ * any existing properties; equivalent to `{ ...data, ...source }`.
  *
- * @param data - The first object, shared props will be overridden.
- * @param other - The second object, this object would be fully contained within
- * the result object.
+ * @param data - The destination object, shared props will be overridden.
+ * @param source - The source object, this object would be fully contained
+ * within the result object.
  * @signature
- *    R.merge(data, other)
+ *    R.merge(data, source)
  * @example
  *    R.merge({ x: 1, y: 2 }, { y: 10, z: 2 }) // => { x: 1, y: 10, z: 2 }
  * @dataFirst
  * @category Object
  */
-export function merge<T, S>(data: T, other: S): Merge<T, S>;
+export function merge<T, Source>(data: T, source: Source): Merge<T, Source>;
 
 /**
  * Spreads the properties of the second object into the first object, overriding
- * any existing properties; equivalent to `{ ...data, ...other }`.
+ * any existing properties; equivalent to `{ ...data, ...source }`.
  *
- * @param data - The first object, shared props will be overridden.
- * @param other - The second object, this object would be fully contained within
- * the result object.
+ * @param data - The destination object, shared props will be overridden.
+ * @param source - The source object, this object would be fully contained
+ * within the result object.
  * @signature
- *    R.merge(other)(data)
+ *    R.merge(source)(data)
  * @example
- *    R.pipe({ x: 1, y: 2 }, R.merge({ y: 10, z: 2 })) // => { x: 1, y: 10, z: 2 }
+ *    R.pipe(
+ *      { x: 1, y: 2 },
+ *      R.merge({ y: 10, z: 2 }),
+ *    ); // => { x: 1, y: 10, z: 2 }
  * @dataLast
  * @category Object
  */
-export function merge<S>(other: S): <T>(data: T) => Merge<T, S>;
+export function merge<Source>(source: Source): <T>(data: T) => Merge<T, Source>;
 
 export function merge(): unknown {
   return purry(_merge, arguments);
 }
 
-function _merge<T, S>(data: T, other: S): Merge<T, S> {
-  return { ...data, ...other };
+function _merge<T, Source>(data: T, source: Source): Merge<T, Source> {
+  return { ...data, ...source };
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,37 +1,38 @@
 import { purry } from "./purry";
+import type { Merge } from "./type-fest/merge";
 
 /**
- * Merges two objects. The same as `Object.assign`.
- * `b` object will override properties of `a`.
- *
- * @param a - The first object.
- * @param b - The second object.
+ * Spreads the properties of the second object into the first object, overriding
+ * any existing properties; equivalent to `{ ...data, ...other }`.
+ * @param data the first object, shared props will be overridden.
+ * @param other the second object.
  * @signature
- *    R.merge(a, b)
+ *    R.merge(data, other)
  * @example
  *    R.merge({ x: 1, y: 2 }, { y: 10, z: 2 }) // => { x: 1, y: 10, z: 2 }
  * @dataFirst
  * @category Object
  */
-export function merge<A, B>(a: A, b: B): A & B;
+export function merge<T, S>(data: T, other: S): Merge<T, S>;
 
 /**
- * Merges two objects. The same as `Object.assign`. `b` object will override properties of `a`.
- *
- * @param b - The second object.
+ * Spreads the properties of the second object into the first object, overriding
+ * any existing properties; equivalent to `{ ...data, ...other }`.
+ * @param data the first object, shared props will be overridden.
+ * @param other the second object.
  * @signature
- *    R.merge(b)(a)
+ *    R.merge(other)(data)
  * @example
- *    R.merge({ y: 10, z: 2 })({ x: 1, y: 2 }) // => { x: 1, y: 10, z: 2 }
+ *    R.pipe({ x: 1, y: 2 }, R.merge({ y: 10, z: 2 })) // => { x: 1, y: 10, z: 2 }
  * @dataLast
  * @category Object
  */
-export function merge<A, B>(b: B): (a: A) => A & B;
+export function merge<S>(other: S): <T>(data: T) => Merge<T, S>;
 
 export function merge(): unknown {
   return purry(_merge, arguments);
 }
 
-function _merge<A, B>(a: A, b: B): A & B {
-  return { ...a, ...b };
+function _merge<T, S>(data: T, other: S): Merge<T, S> {
+  return { ...data, ...other };
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -2,12 +2,22 @@ import { purry } from "./purry";
 import type { Merge } from "./type-fest/merge";
 
 /**
- * Spreads the properties of the second object into the first object, overriding
- * any existing properties; equivalent to `{ ...data, ...source }`.
+ * Merges two objects into one by combining their properties, effectively
+ * creating a new object that incorporates elements from both. The merge
+ * operation prioritizes the second object's properties, allowing them to
+ * overwrite those from the first object with the same names.
  *
- * @param data - The destination object, shared props will be overridden.
- * @param source - The source object, this object would be fully contained
- * within the result object.
+ * Equivalent to `{ ...data, ...source }`.
+ *
+ * @param data - The destination object, serving as the basis for the merge.
+ * Properties from this object are included in the new object, but may be
+ * overwritten by properties from the source object with matching keys.
+ * @param source - The source object, whose properties will be included in the
+ * new object. If properties in this object share keys with properties in the
+ * destination object, the values from the source object will be used in the
+ * new object.
+ * @returns An object fully-containing `source`, and any properties from `data`
+ * that don't share a name with any property in `source`.
  * @signature
  *    R.merge(data, source)
  * @example
@@ -18,12 +28,22 @@ import type { Merge } from "./type-fest/merge";
 export function merge<T, Source>(data: T, source: Source): Merge<T, Source>;
 
 /**
- * Spreads the properties of the second object into the first object, overriding
- * any existing properties; equivalent to `{ ...data, ...source }`.
+ * Merges two objects into one by combining their properties, effectively
+ * creating a new object that incorporates elements from both. The merge
+ * operation prioritizes the second object's properties, allowing them to
+ * overwrite those from the first object with the same names.
  *
- * @param data - The destination object, shared props will be overridden.
- * @param source - The source object, this object would be fully contained
- * within the result object.
+ * Equivalent to `{ ...data, ...source }`.
+ *
+ * @param data - The destination object, serving as the basis for the merge.
+ * Properties from this object are included in the new object, but may be
+ * overwritten by properties from the source object with matching keys.
+ * @param source - The source object, whose properties will be included in the
+ * new object. If properties in this object share keys with properties in the
+ * destination object, the values from the source object will be used in the
+ * new object.
+ * @returns An object fully-containing `source`, and any properties from `data`
+ * that don't share a name with any property in `source`.
  * @signature
  *    R.merge(source)(data)
  * @example

--- a/src/type-fest/merge.ts
+++ b/src/type-fest/merge.ts
@@ -1,6 +1,6 @@
-import type { EnforceOptional } from "./enforce-optional";
 import type { OmitIndexSignature } from "./omit-index-signature";
 import type { PickIndexSignature } from "./pick-index-signature";
+import type { Simplify } from "./simplify";
 
 // Merges two objects without worrying about index signatures.
 type SimpleMerge<Destination, Source> = Source & {
@@ -9,7 +9,7 @@ type SimpleMerge<Destination, Source> = Source & {
     : Key]: Destination[Key];
 };
 
-export type Merge<Destination, Source> = EnforceOptional<
+export type Merge<Destination, Source> = Simplify<
   SimpleMerge<OmitIndexSignature<Destination>, OmitIndexSignature<Source>> &
     SimpleMerge<PickIndexSignature<Destination>, PickIndexSignature<Source>>
 >;


### PR DESCRIPTION
Our existing typing assumes that the 2 merged objects either share a type, or have types that don't overlap; and fail for cases where a merged property changes the type of the input.

We already have the type-fest merge type in our codebase (used in deepMerge) so we just need to change the typing for merge.

I added all the type tests from type-fest.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
