### PR TITLE
docs: remove exampleRaw tag

### DIFF
--- a/docs/src/lib/transform.ts
+++ b/docs/src/lib/transform.ts
@@ -81,7 +81,7 @@ function transformSignature({
     indexed: hasTag(comment, "indexed"),
     pipeable: hasTag(comment, "pipeable"),
     strict: hasTag(comment, "strict"),
-    example: getExample(comment),
+    example: tagContent(comment, "example"),
     args: parameters.map(getParameter),
     returns: {
       name: getReturnType(type),
@@ -118,16 +118,6 @@ function getReturnType(type: JSONOutput.SomeType | undefined) {
         : type.type === "predicate"
           ? "boolean"
           : "Object";
-}
-
-function getExample(comment: JSONOutput.Comment): string | undefined {
-  return (
-    tagContent(comment, "example") ??
-    tagContent(comment, "exampleRaw")
-      ?.split("\n")
-      .map((str) => str.replace(/^ {3}/, ""))
-      .join("\n")
-  );
 }
 
 function getParameter({ name, comment }: JSONOutput.ParameterReflection) {

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -26,7 +26,7 @@ type MaybeLazyFunction = {
  * @param fn the function to purry.
  * @param args the arguments
  * @signature R.purry(fn, arguments);
- * @exampleRaw
+ * @example
  *    function _findIndex(array, fn) {
  *      for (let i = 0; i < array.length; i++) {
  *        if (fn(array[i])) {


### PR DESCRIPTION
We don't need this special casing of the purry example, everything works fine without it, and exampleRaw isn't a standard JSDoc tag so it's just messy.