### PR TITLE
feat!: deprecate `indexed` variant

### DIFF
--- a/src/_reduceLazy.ts
+++ b/src/_reduceLazy.ts
@@ -3,14 +3,13 @@ import type { LazyEvaluator } from "./pipe";
 export function _reduceLazy<T, K>(
   array: ReadonlyArray<T>,
   lazy: LazyEvaluator<T, K>,
-  isIndexed = false,
 ): Array<K> {
   const out: Array<K> = [];
 
   // We intentionally use a for loop here instead of reduce for performance reasons. See https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/ for more info
   for (let index = 0; index < array.length; index++) {
     const item = array[index]!;
-    const result = isIndexed ? lazy(item, index, array) : lazy(item);
+    const result = lazy(item, index, array);
     if (result.hasMany === true) {
       out.push(...result.next);
     } else if (result.hasNext) {

--- a/src/_toLazyIndexed.ts
+++ b/src/_toLazyIndexed.ts
@@ -1,5 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Typescript requires using `any` to infer any kind of function type, `unknown` is not enough.
-export const _toLazyIndexed = <Func extends (...args: any) => unknown>(
-  fn: Func,
-): Func & { readonly indexed: true } =>
-  Object.assign(fn, { indexed: true as const });

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -23,17 +23,14 @@ describe("data_first", () => {
     expect(result).toEqual([1, 2, 3]);
   });
 
-  it("filter.indexed", () => {
-    const result = filter.indexed(
-      [1, 2, 3] as const,
-      (x, i) => x % 2 === 1 && i !== 1,
-    );
+  it("filter indexed", () => {
+    const result = filter([1, 2, 3] as const, (x, i) => x % 2 === 1 && i !== 1);
     assertType<Array<1 | 2 | 3>>(result); // Type test
     expect(result).toEqual([1, 3]);
   });
 
-  it("filter.indexed with typescript guard", () => {
-    const result = filter.indexed(
+  it("filter indexed with typescript guard", () => {
+    const result = filter(
       [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[]
       isNumber,
     );
@@ -78,22 +75,22 @@ describe("data_last", () => {
     assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(result).toEqual([1, 2, 3]);
   });
-  it("filter.indexed with typescript guard", () => {
+  it("filter indexed with typescript guard", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 3, false, "text"] as const, // Type (1 | 2 | 3 | false | "text")[]
-      filter.indexed(isNumber),
+      filter(isNumber),
       counter.fn(),
     );
     assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]
     expect(counter.count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([1, 2, 3]);
   });
-  it("filter.indexed", () => {
+  it("filter indexed", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 3] as const,
-      filter.indexed((x, i) => x % 2 === 1 && i !== 1),
+      filter((x, i) => x % 2 === 1 && i !== 1),
       counter.fn(),
     );
     assertType<Array<1 | 2 | 3>>(result); // Type test (1 | 2 | 3)[]

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,93 +1,63 @@
-import { _reduceLazy } from "./_reduceLazy";
-import { _toLazyIndexed } from "./_toLazyIndexed";
-import type { Pred, PredIndexed, PredIndexedOptional } from "./_types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
 /**
  * Filter the elements of an array that meet the condition specified in a callback function.
  * @param array The array to filter.
- * @param fn the callback function.
+ * @param predicate the callback function.
  * @signature
- *    R.filter(array, fn)
- *    R.filter.indexed(array, fn)
+ *    R.filter(array, predicate)
  * @example
  *    R.filter([1, 2, 3], x => x % 2 === 1) // => [1, 3]
- *    R.filter.indexed([1, 2, 3], (x, i, array) => x % 2 === 1) // => [1, 3]
+ *    R.filter([1, 2, 3], (x, i, array) => x % 2 === 1) // => [1, 3]
  * @dataFirst
- * @indexed
  * @pipeable
  * @category Array
  */
 export function filter<T, S extends T>(
   array: ReadonlyArray<T>,
-  fn: (value: T) => value is S,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => value is S,
 ): Array<S>;
 export function filter<T>(
   array: ReadonlyArray<T>,
-  fn: Pred<T, boolean>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
  * Filter the elements of an array that meet the condition specified in a callback function.
- * @param fn the callback function.
+ * @param predicate the callback function.
  * @signature
- *    R.filter(fn)(array)
- *    R.filter.indexed(fn)(array)
+ *    R.filter(predicate)(array)
  * @example
  *    R.pipe([1, 2, 3], R.filter(x => x % 2 === 1)) // => [1, 3]
- *    R.pipe([1, 2, 3], R.filter.indexed((x, i) => x % 2 === 1)) // => [1, 3]
+ *    R.pipe([1, 2, 3], R.filter((x, i) => x % 2 === 1)) // => [1, 3]
  * @dataLast
- * @indexed
  * @pipeable
  * @category Array
  */
 export function filter<T, S extends T>(
-  fn: (input: T) => input is S,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => value is S,
 ): (array: ReadonlyArray<T>) => Array<S>;
 export function filter<T>(
-  fn: Pred<T, boolean>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => Array<T>;
 
 export function filter(): unknown {
-  return purry(_filter(false), arguments, filter.lazy);
+  return purry(filterImplementation, arguments, lazyImplementation);
 }
 
-const _filter =
-  (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
-    _reduceLazy(array, indexed ? filter.lazyIndexed(fn) : filter.lazy(fn));
+const filterImplementation = <T>(
+  array: ReadonlyArray<T>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
+): Array<T> =>
+  // eslint-disable-next-line unicorn/no-array-callback-reference -- predicate is built base on the signature for Array.prototype.filter
+  array.filter(predicate);
 
-const _lazy =
-  (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, boolean>): LazyEvaluator<T> =>
+const lazyImplementation =
+  <T>(
+    predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
+  ): LazyEvaluator<T> =>
   (value, index, array) =>
-    (indexed ? fn(value, index, array) : fn(value))
+    predicate(value, index, array)
       ? { done: false, hasNext: true, next: value }
       : { done: false, hasNext: false };
-
-export namespace filter {
-  export function indexed<T, S extends T>(
-    array: ReadonlyArray<T>,
-    fn: (input: T, index: number, array: ReadonlyArray<T>) => input is S,
-  ): Array<S>;
-  export function indexed<T>(
-    array: ReadonlyArray<T>,
-    fn: PredIndexed<T, boolean>,
-  ): Array<T>;
-  /**
-   * @dataLast
-   */
-  export function indexed<T, S extends T>(
-    fn: (input: T, index: number, array: ReadonlyArray<T>) => input is S,
-  ): (array: ReadonlyArray<T>) => Array<S>;
-  export function indexed<T>(
-    fn: PredIndexed<T, boolean>,
-  ): (array: ReadonlyArray<T>) => Array<T>;
-  export function indexed(): unknown {
-    return purry(_filter(true), arguments, filter.lazyIndexed);
-  }
-
-  export const lazy = _lazy(false);
-  export const lazyIndexed = _toLazyIndexed(_lazy(true));
-}

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -56,11 +56,7 @@ export function filter(): unknown {
 const _filter =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
-    _reduceLazy(
-      array,
-      indexed ? filter.lazyIndexed(fn) : filter.lazy(fn),
-      indexed,
-    );
+    _reduceLazy(array, indexed ? filter.lazyIndexed(fn) : filter.lazy(fn));
 
 const _lazy =
   (indexed: boolean) =>

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -14,10 +14,8 @@ describe("data first", () => {
   test("find", () => {
     expect(find(array, (x) => x.b === 2)).toEqual(expected);
   });
-  test("find.indexed", () => {
-    expect(find.indexed(array, (x, idx) => x.b === 2 && idx === 1)).toEqual(
-      expected,
-    );
+  test("find indexed", () => {
+    expect(find(array, (x, idx) => x.b === 2 && idx === 1)).toEqual(expected);
   });
 });
 
@@ -33,12 +31,12 @@ describe("data last", () => {
     expect(actual).toEqual(expected);
   });
 
-  test("find.indexed", () => {
+  test("find indexed", () => {
     const counter = createLazyInvocationCounter();
     const actual = pipe(
       array,
       counter.fn(),
-      find.indexed((x, idx) => x.b === 2 && idx === 1),
+      find((x, idx) => x.b === 2 && idx === 1),
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(actual).toEqual(expected);

--- a/src/findIndex.test.ts
+++ b/src/findIndex.test.ts
@@ -7,10 +7,6 @@ describe("data first", () => {
     expect(findIndex([10, 20, 30] as const, (x) => x === 20)).toBe(1);
   });
 
-  test("findIndex.indexed", () => {
-    expect(findIndex([10, 20, 30] as const, (x) => x === 20)).toBe(1);
-  });
-
   test("findIndex -1", () => {
     expect(findIndex([2, 3, 4] as const, (x) => x === (20 as number))).toBe(-1);
   });
@@ -23,17 +19,6 @@ describe("data last", () => {
       [10, 20, 30] as const,
       counter.fn(),
       findIndex((x) => x === 20),
-    );
-    expect(counter.count).toHaveBeenCalledTimes(2);
-    expect(actual).toEqual(1);
-  });
-
-  test("findIndex.indexed", () => {
-    const counter = createLazyInvocationCounter();
-    const actual = pipe(
-      [10, 20, 30] as const,
-      counter.fn(),
-      findIndex.indexed((x) => x === 20),
     );
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(actual).toEqual(1);

--- a/src/forEach.test.ts
+++ b/src/forEach.test.ts
@@ -8,12 +8,6 @@ describe("data_first", () => {
   it("forEach", () => {
     const cb = vi.fn();
     const result = forEach(array, cb);
-    expect(cb.mock.calls).toEqual([[1], [2], [3]]);
-    expect(result).toEqual(array);
-  });
-  it("forEach.indexed", () => {
-    const cb = vi.fn();
-    const result = forEach.indexed(array, cb);
     expect(cb.mock.calls).toEqual([
       [1, 0, array],
       [2, 1, array],
@@ -24,15 +18,9 @@ describe("data_first", () => {
 });
 
 describe("data_last", () => {
-  it("forEach", () => {
+  it("forEach indexed", () => {
     const cb = vi.fn();
     const result = pipe(array, forEach(cb));
-    expect(cb.mock.calls).toEqual([[1], [2], [3]]);
-    expect(result).toEqual(array);
-  });
-  it("forEach.indexed", () => {
-    const cb = vi.fn();
-    const result = pipe(array, forEach.indexed(cb));
     expect(cb.mock.calls).toEqual([
       [1, 0, array],
       [2, 1, array],
@@ -60,7 +48,7 @@ describe("pipe", () => {
     const count = vi.fn();
     const result = pipe(
       [1, 2, 3],
-      forEach.indexed(() => {
+      forEach(() => {
         count();
       }),
       take(2),

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -64,11 +64,7 @@ export function forEach(): unknown {
 const _forEach =
   (indexed: boolean) =>
   <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) =>
-    _reduceLazy(
-      array,
-      indexed ? forEach.lazyIndexed(fn) : forEach.lazy(fn),
-      indexed,
-    );
+    _reduceLazy(array, indexed ? forEach.lazyIndexed(fn) : forEach.lazy(fn));
 
 const _lazy =
   (indexed: boolean) =>

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -9,11 +9,7 @@ describe("data_first", () => {
     const result = map([1, 2, 3] as const, (x) => x * 2);
     expect(result).toEqual([2, 4, 6]);
   });
-  it("map.indexed", () => {
-    const result = map.indexed([0, 0, 0] as const, (_, i) => i);
-    expect(result).toEqual([0, 1, 2]);
-  });
-  it("indexed map", () => {
+  it("map indexed", () => {
     const result = map([0, 0, 0] as const, (_, i) => i);
     expect(result).toEqual([0, 1, 2]);
   });
@@ -27,14 +23,7 @@ describe("data_last", () => {
     );
     expect(result).toEqual([2, 4, 6]);
   });
-  it("map.indexed", () => {
-    const result = pipe(
-      [0, 0, 0] as const,
-      map.indexed((_, i) => i),
-    );
-    expect(result).toEqual([0, 1, 2]);
-  });
-  it("indexed map", () => {
+  it("map indexed", () => {
     const result = pipe(
       [0, 0, 0] as const,
       map((_, i) => i),
@@ -58,20 +47,6 @@ describe("pipe", () => {
     expect(result).toEqual([10, 20]);
   });
 
-  it("indexed (deprecated)", () => {
-    const count = vi.fn();
-    const result = pipe(
-      [0, 0, 0] as const,
-      map.indexed((_, i) => {
-        count();
-        return i;
-      }),
-      take(2),
-    );
-    expect(count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([0, 1]);
-  });
-
   it("indexed", () => {
     const count = vi.fn();
     const result = pipe(
@@ -84,38 +59,6 @@ describe("pipe", () => {
     );
     expect(count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([0, 1]);
-  });
-
-  it("indexed: check index and items (deprecated)", () => {
-    const indexes1: Array<number> = [];
-    const indexes2: Array<number> = [];
-    const anyItems1: Array<Array<number>> = [];
-    const anyItems2: Array<Array<number>> = [];
-    const result = pipe(
-      [1, 2, 3, 4, 5] as const,
-      map.indexed((x, i, items) => {
-        anyItems1.push([...items]);
-        indexes1.push(i);
-        return x;
-      }),
-      filter((x) => x % 2 === 1),
-      map.indexed((x, i, items) => {
-        anyItems2.push([...items]);
-        indexes2.push(i);
-        return x;
-      }),
-    );
-    expect(result).toEqual([1, 3, 5]);
-    expect(indexes1).toEqual([0, 1, 2, 3, 4]);
-    expect(indexes2).toEqual([0, 1, 2]);
-    expect(anyItems1).toEqual([
-      [1],
-      [1, 2],
-      [1, 2, 3],
-      [1, 2, 3, 4],
-      [1, 2, 3, 4, 5],
-    ]);
-    expect(anyItems2).toEqual([[1], [1, 3], [1, 3, 5]]);
   });
 
   it("indexed: check index and items", () => {
@@ -248,110 +191,6 @@ describe("Strict", () => {
       boolean,
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
     const result = map.strict(input, identity);
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean | number | string>, boolean | number | string]
-    >();
-    expect(result).toEqual(input);
-  });
-});
-
-describe("Strict Indexed (deprecated)", () => {
-  it("number array", () => {
-    const input: Array<number> = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("readonly number array", () => {
-    const input: ReadonlyArray<number> = [1, 2, 3] as const;
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("number 3-tuple", () => {
-    const input: [number, number, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("readonly number 3-tuple", () => {
-    const input: readonly [number, number, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("named number 3-tuple", () => {
-    const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    // There's no way to test this, but notice that the names are copied to the
-    // output here...
-    expectTypeOf(result).toEqualTypeOf<
-      [item1: number, item2: number, item3: number]
-    >();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("mixed type tuple", () => {
-    const input: [number, string, boolean] = [1, "2", true];
-    const result = map.strict.indexed(input, (_, index) => index);
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([0, 1, 2]);
-  });
-
-  it("readonly mixed type tuple", () => {
-    const input: readonly [number, string, boolean] = [1, "2", true];
-    const result = map.strict.indexed(input, (_, index) => index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([0, 1, 2]);
-  });
-
-  it("nonempty (tail) number array", () => {
-    const input: [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("nonempty (tail) readonly number array", () => {
-    const input: readonly [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("nonempty (head) number array", () => {
-    const input: [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("nonempty readonly (head) number array", () => {
-    const input: readonly [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
-
-  it("complex variadic number array", () => {
-    const input: [
-      ...Array<"hello">,
-      "world",
-      ...Array<number>,
-      string,
-      ...Array<number>,
-      boolean,
-    ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
-    const result = map.strict.indexed(input, identity);
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean | number | string>, boolean | number | string]
     >();

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -13,6 +13,10 @@ describe("data_first", () => {
     const result = map.indexed([0, 0, 0] as const, (_, i) => i);
     expect(result).toEqual([0, 1, 2]);
   });
+  it("indexed map", () => {
+    const result = map([0, 0, 0] as const, (_, i) => i);
+    expect(result).toEqual([0, 1, 2]);
+  });
 });
 
 describe("data_last", () => {
@@ -27,6 +31,13 @@ describe("data_last", () => {
     const result = pipe(
       [0, 0, 0] as const,
       map.indexed((_, i) => i),
+    );
+    expect(result).toEqual([0, 1, 2]);
+  });
+  it("indexed map", () => {
+    const result = pipe(
+      [0, 0, 0] as const,
+      map((_, i) => i),
     );
     expect(result).toEqual([0, 1, 2]);
   });
@@ -47,7 +58,7 @@ describe("pipe", () => {
     expect(result).toEqual([10, 20]);
   });
 
-  it("indexed", () => {
+  it("indexed (deprecated)", () => {
     const count = vi.fn();
     const result = pipe(
       [0, 0, 0] as const,
@@ -61,7 +72,21 @@ describe("pipe", () => {
     expect(result).toEqual([0, 1]);
   });
 
-  it("indexed: check index and items", () => {
+  it("indexed", () => {
+    const count = vi.fn();
+    const result = pipe(
+      [0, 0, 0] as const,
+      map((_, i) => {
+        count();
+        return i;
+      }),
+      take(2),
+    );
+    expect(count).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([0, 1]);
+  });
+
+  it("indexed: check index and items (deprecated)", () => {
     const indexes1: Array<number> = [];
     const indexes2: Array<number> = [];
     const anyItems1: Array<Array<number>> = [];
@@ -75,6 +100,38 @@ describe("pipe", () => {
       }),
       filter((x) => x % 2 === 1),
       map.indexed((x, i, items) => {
+        anyItems2.push([...items]);
+        indexes2.push(i);
+        return x;
+      }),
+    );
+    expect(result).toEqual([1, 3, 5]);
+    expect(indexes1).toEqual([0, 1, 2, 3, 4]);
+    expect(indexes2).toEqual([0, 1, 2]);
+    expect(anyItems1).toEqual([
+      [1],
+      [1, 2],
+      [1, 2, 3],
+      [1, 2, 3, 4],
+      [1, 2, 3, 4, 5],
+    ]);
+    expect(anyItems2).toEqual([[1], [1, 3], [1, 3, 5]]);
+  });
+
+  it("indexed: check index and items", () => {
+    const indexes1: Array<number> = [];
+    const indexes2: Array<number> = [];
+    const anyItems1: Array<Array<number>> = [];
+    const anyItems2: Array<Array<number>> = [];
+    const result = pipe(
+      [1, 2, 3, 4, 5] as const,
+      map((x, i, items) => {
+        anyItems1.push([...items]);
+        indexes1.push(i);
+        return x;
+      }),
+      filter((x) => x % 2 === 1),
+      map((x, i, items) => {
         anyItems2.push([...items]);
         indexes2.push(i);
         return x;
@@ -198,7 +255,7 @@ describe("Strict", () => {
   });
 });
 
-describe("Strict Indexed", () => {
+describe("Strict Indexed (deprecated)", () => {
   it("number array", () => {
     const input: Array<number> = [1, 2, 3];
     const result = map.strict.indexed(input, (x, index) => x + index);
@@ -295,6 +352,110 @@ describe("Strict Indexed", () => {
       boolean,
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
     const result = map.strict.indexed(input, identity);
+    expectTypeOf(result).toEqualTypeOf<
+      [...Array<boolean | number | string>, boolean | number | string]
+    >();
+    expect(result).toEqual(input);
+  });
+});
+
+describe("Strict Indexed", () => {
+  it("number array", () => {
+    const input: Array<number> = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("readonly number array", () => {
+    const input: ReadonlyArray<number> = [1, 2, 3] as const;
+    const result = map.strict(input, (x, index) => x + index);
+    // readonlyness is stripped
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("number 3-tuple", () => {
+    const input: [number, number, number] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("readonly number 3-tuple", () => {
+    const input: readonly [number, number, number] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    // readonlyness is stripped
+    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("named number 3-tuple", () => {
+    const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    // There's no way to test this, but notice that the names are copied to the
+    // output here...
+    expectTypeOf(result).toEqualTypeOf<
+      [item1: number, item2: number, item3: number]
+    >();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("mixed type tuple", () => {
+    const input: [number, string, boolean] = [1, "2", true];
+    const result = map.strict(input, (_, index) => index);
+    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    expect(result).toEqual([0, 1, 2]);
+  });
+
+  it("readonly mixed type tuple", () => {
+    const input: readonly [number, string, boolean] = [1, "2", true];
+    const result = map.strict(input, (_, index) => index);
+    // readonlyness is stripped
+    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    expect(result).toEqual([0, 1, 2]);
+  });
+
+  it("nonempty (tail) number array", () => {
+    const input: [number, ...Array<number>] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("nonempty (tail) readonly number array", () => {
+    const input: readonly [number, ...Array<number>] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    // readonlyness is stripped
+    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("nonempty (head) number array", () => {
+    const input: [...Array<number>, number] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("nonempty readonly (head) number array", () => {
+    const input: readonly [...Array<number>, number] = [1, 2, 3];
+    const result = map.strict(input, (x, index) => x + index);
+    // readonlyness is stripped
+    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+    expect(result).toEqual([1, 3, 5]);
+  });
+
+  it("complex variadic number array", () => {
+    const input: [
+      ...Array<"hello">,
+      "world",
+      ...Array<number>,
+      string,
+      ...Array<number>,
+      boolean,
+    ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
+    const result = map.strict(input, identity);
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean | number | string>, boolean | number | string]
     >();

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,11 +1,5 @@
 import { _reduceLazy } from "./_reduceLazy";
-import { _toLazyIndexed } from "./_toLazyIndexed";
-import type {
-  IterableContainer,
-  Pred,
-  PredIndexed,
-  PredIndexedOptional,
-} from "./_types";
+import type { IterableContainer, PredIndexed } from "./_types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
@@ -13,60 +7,59 @@ import { purry } from "./purry";
  * Map each element of an array using a defined callback function. If the input
  * array is a tuple use the `strict` variant to maintain it's shape.
  * @param array The array to map.
- * @param fn The function mapper.
+ * @param mapper The function mapper.
  * @returns The new mapped array.
  * @signature
  *    R.map(array, fn)
- *    R.map.indexed(array, fn)
  *    R.map.strict(array, fn)
- *    R.map.strict.indexed(array, fn)
  * @example
  *    R.map([1, 2, 3], x => x * 2) // => [2, 4, 6], typed number[]
- *    R.map.indexed([0, 0, 0], (x, i) => i) // => [0, 1, 2], typed number[]
+ *    R.map([0, 0, 0], (x, i) => i) // => [0, 1, 2], typed number[]
  *    R.map.strict([0, 0] as const, x => x + 1) // => [1, 1], typed [number, number]
- *    R.map.strict.indexed([0, 0] as const, (x, i) => x + i) // => [0, 1], typed [number, number]
+ *    R.map.strict([0, 0] as const, (x, i) => x + i) // => [0, 1], typed [number, number]
  * @dataFirst
- * @indexed
  * @pipeable
  * @strict
  * @category Array
  */
-export function map<T, K>(array: ReadonlyArray<T>, fn: Pred<T, K>): Array<K>;
+export function map<T, K>(
+  array: ReadonlyArray<T>,
+  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+): Array<K>;
 
 /**
  * Map each value of an object using a defined callback function.
- * @param fn the function mapper
+ * @param mapper the function mapper
  * @signature
  *    R.map(fn)(array)
- *    R.map.indexed(fn)(array)
  * @example
  *    R.pipe([0, 1, 2], R.map(x => x * 2)) // => [0, 2, 4]
- *    R.pipe([0, 0, 0], R.map.indexed((x, i) => i)) // => [0, 1, 2]
+ *    R.pipe([0, 0, 0], R.map((x, i) => i)) // => [0, 1, 2]
  * @dataLast
- * @indexed
  * @pipeable
  * @category Array
  */
 export function map<T, K>(
-  fn: Pred<T, K>,
+  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
 ): (array: ReadonlyArray<T>) => Array<K>;
 
 export function map(): unknown {
-  return purry(_map(false), arguments, map.lazy);
+  return purry(mapImplementation, arguments, _lazy);
 }
 
-const _map =
-  (indexed: boolean) =>
-  <T, K>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, K>) =>
-    _reduceLazy(array, indexed ? map.lazyIndexed(fn) : map.lazy(fn), indexed);
+const mapImplementation = <T, K>(
+  array: ReadonlyArray<T>,
+  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+): Array<K> => _reduceLazy(array, _lazy(mapper));
 
 const _lazy =
-  (indexed: boolean) =>
-  <T, K>(fn: PredIndexedOptional<T, K>): LazyEvaluator<T, K> =>
+  <T, K>(
+    mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+  ): LazyEvaluator<T, K> =>
   (value, index, array) => ({
     done: false,
     hasNext: true,
-    next: indexed ? fn(value, index, array) : fn(value),
+    next: mapper(value, index, array),
   });
 
 // Redefining the map API with a stricter return type. This API is accessed via
@@ -74,19 +67,25 @@ const _lazy =
 type Strict = {
   <T extends IterableContainer, K>(
     items: T,
-    mapper: Pred<T[number], K>,
+    mapper: (value: T[number], index: number, array: T) => K,
   ): StrictOut<T, K>;
 
   <T extends IterableContainer, K>(
-    mapper: Pred<T[number], K>,
+    mapper: (value: T[number], index: number, array: T) => K,
   ): (items: T) => StrictOut<T, K>;
 
   readonly indexed: {
+    /**
+     * @deprecated use `map.strict` directly, `indexed` modifier no longer needed.
+     */
     <T extends IterableContainer, K>(
       items: T,
       mapper: PredIndexed<T[number], K>,
     ): StrictOut<T, K>;
 
+    /**
+     * @deprecated use `map.strict` directly, `indexed` modifier no longer needed.
+     */
     <T extends IterableContainer, K>(
       mapper: PredIndexed<T[number], K>,
     ): (items: T) => StrictOut<T, K>;
@@ -98,19 +97,24 @@ type StrictOut<T extends IterableContainer, K> = {
 };
 
 export namespace map {
+  /**
+   * @deprecated use `map` directly, `indexed` modifier no longer needed.
+   */
   export function indexed<T, K>(
     array: ReadonlyArray<T>,
     fn: PredIndexed<T, K>,
   ): Array<K>;
+
+  /**
+   * @deprecated use `map` directly, `indexed` modifier no longer needed.
+   */
   export function indexed<T, K>(
     fn: PredIndexed<T, K>,
   ): (array: ReadonlyArray<T>) => Array<K>;
-  export function indexed(): unknown {
-    return purry(_map(true), arguments, map.lazyIndexed);
-  }
 
-  export const lazy = _lazy(false);
-  export const lazyIndexed = _toLazyIndexed(_lazy(true));
+  export function indexed(): unknown {
+    return purry(mapImplementation, arguments, _lazy);
+  }
 
   export const strict: Strict = map;
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,5 +1,4 @@
-import { _reduceLazy } from "./_reduceLazy";
-import type { IterableContainer, PredIndexed } from "./_types";
+import type { IterableContainer } from "./_types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
@@ -7,11 +6,11 @@ import { purry } from "./purry";
  * Map each element of an array using a defined callback function. If the input
  * array is a tuple use the `strict` variant to maintain it's shape.
  * @param array The array to map.
- * @param mapper The function mapper.
+ * @param callbackfn The mapping function.
  * @returns The new mapped array.
  * @signature
- *    R.map(array, fn)
- *    R.map.strict(array, fn)
+ *    R.map(array, callbackfn)
+ *    R.map.strict(array, callbackfn)
  * @example
  *    R.map([1, 2, 3], x => x * 2) // => [2, 4, 6], typed number[]
  *    R.map([0, 0, 0], (x, i) => i) // => [0, 1, 2], typed number[]
@@ -24,14 +23,14 @@ import { purry } from "./purry";
  */
 export function map<T, K>(
   array: ReadonlyArray<T>,
-  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+  callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => K,
 ): Array<K>;
 
 /**
  * Map each value of an object using a defined callback function.
- * @param mapper the function mapper
+ * @param callbackfn The mapping function
  * @signature
- *    R.map(fn)(array)
+ *    R.map(callbackfn)(array)
  * @example
  *    R.pipe([0, 1, 2], R.map(x => x * 2)) // => [0, 2, 4]
  *    R.pipe([0, 0, 0], R.map((x, i) => i)) // => [0, 1, 2]
@@ -40,26 +39,28 @@ export function map<T, K>(
  * @category Array
  */
 export function map<T, K>(
-  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+  callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => K,
 ): (array: ReadonlyArray<T>) => Array<K>;
 
 export function map(): unknown {
-  return purry(mapImplementation, arguments, _lazy);
+  return purry(mapImplementation, arguments, lazyImplementation);
 }
 
 const mapImplementation = <T, K>(
   array: ReadonlyArray<T>,
-  mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
-): Array<K> => _reduceLazy(array, _lazy(mapper));
+  callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => K,
+): Array<K> =>
+  // eslint-disable-next-line unicorn/no-array-callback-reference -- callbackfn is built base on the signature for Array.prototype.map
+  array.map(callbackfn);
 
-const _lazy =
+const lazyImplementation =
   <T, K>(
-    mapper: (value: T, index: number, array: ReadonlyArray<T>) => K,
+    callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => K,
   ): LazyEvaluator<T, K> =>
   (value, index, array) => ({
     done: false,
     hasNext: true,
-    next: mapper(value, index, array),
+    next: callbackfn(value, index, array),
   });
 
 // Redefining the map API with a stricter return type. This API is accessed via
@@ -67,29 +68,12 @@ const _lazy =
 type Strict = {
   <T extends IterableContainer, K>(
     items: T,
-    mapper: (value: T[number], index: number, array: T) => K,
+    callbackfn: (value: T[number], index: number, array: T) => K,
   ): StrictOut<T, K>;
 
   <T extends IterableContainer, K>(
-    mapper: (value: T[number], index: number, array: T) => K,
+    callbackfn: (value: T[number], index: number, array: T) => K,
   ): (items: T) => StrictOut<T, K>;
-
-  readonly indexed: {
-    /**
-     * @deprecated use `map.strict` directly, `indexed` modifier no longer needed.
-     */
-    <T extends IterableContainer, K>(
-      items: T,
-      mapper: PredIndexed<T[number], K>,
-    ): StrictOut<T, K>;
-
-    /**
-     * @deprecated use `map.strict` directly, `indexed` modifier no longer needed.
-     */
-    <T extends IterableContainer, K>(
-      mapper: PredIndexed<T[number], K>,
-    ): (items: T) => StrictOut<T, K>;
-  };
 };
 
 type StrictOut<T extends IterableContainer, K> = {
@@ -97,24 +81,5 @@ type StrictOut<T extends IterableContainer, K> = {
 };
 
 export namespace map {
-  /**
-   * @deprecated use `map` directly, `indexed` modifier no longer needed.
-   */
-  export function indexed<T, K>(
-    array: ReadonlyArray<T>,
-    fn: PredIndexed<T, K>,
-  ): Array<K>;
-
-  /**
-   * @deprecated use `map` directly, `indexed` modifier no longer needed.
-   */
-  export function indexed<T, K>(
-    fn: PredIndexed<T, K>,
-  ): (array: ReadonlyArray<T>) => Array<K>;
-
-  export function indexed(): unknown {
-    return purry(mapImplementation, arguments, _lazy);
-  }
-
   export const strict: Strict = map;
 }

--- a/src/reject.test.ts
+++ b/src/reject.test.ts
@@ -7,11 +7,8 @@ describe("data_first", () => {
     const result = reject([1, 2, 3] as const, (x) => x % 2 === 0);
     expect(result).toEqual([1, 3]);
   });
-  it("reject.indexed", () => {
-    const result = reject.indexed(
-      [1, 2, 3] as const,
-      (x, i) => x % 2 === 0 && i === 1,
-    );
+  it("reject indexed", () => {
+    const result = reject([1, 2, 3] as const, (x, i) => x % 2 === 0 && i === 1);
     expect(result).toEqual([1, 3]);
   });
 });
@@ -27,11 +24,11 @@ describe("data_last", () => {
     expect(counter.count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });
-  it("filter.indexed", () => {
+  it("filter indexed", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 3] as const,
-      reject.indexed((x, i) => x % 2 === 0 && i === 1),
+      reject((x, i) => x % 2 === 0 && i === 1),
       counter.fn(),
     );
     expect(counter.count).toHaveBeenCalledTimes(2);

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -1,77 +1,58 @@
-import { _reduceLazy } from "./_reduceLazy";
-import { _toLazyIndexed } from "./_toLazyIndexed";
-import type { Pred, PredIndexed, PredIndexedOptional } from "./_types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
 /**
  * Reject the elements of an array that meet the condition specified in a callback function.
  * @param items The array to reject.
- * @param fn the callback function.
+ * @param predicate the callback function.
  * @signature
- *    R.reject(array, fn)
- *    R.reject.indexed(array, fn)
+ *    R.reject(array, predicate)
+ *    R.reject(array, predicate)
  * @example
  *    R.reject([1, 2, 3], x => x % 2 === 0) // => [1, 3]
- *    R.reject.indexed([1, 2, 3], (x, i, array) => x % 2 === 0) // => [1, 3]
+ *    R.reject([1, 2, 3], (x, i, array) => x % 2 === 0) // => [1, 3]
  * @dataFirst
- * @indexed
  * @pipeable
  * @category Array
  */
 export function reject<T>(
   items: ReadonlyArray<T>,
-  fn: Pred<T, boolean>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
  * Reject the elements of an array that meet the condition specified in a callback function.
  * @param items The array to reject.
- * @param fn the callback function.
+ * @param predicate the callback function.
  * @signature
- *    R.reject(array, fn)
- *    R.reject.indexed(array, fn)
+ *    R.reject(array, predicate)
+ *    R.reject(array, predicate)
  * @example
  *    R.reject([1, 2, 3], x => x % 2 === 0) // => [1, 3]
- *    R.reject.indexed([1, 2, 3], (x, i, array) => x % 2 === 0) // => [1, 3]
+ *    R.reject([1, 2, 3], (x, i, array) => x % 2 === 0) // => [1, 3]
  * @dataFirst
- * @indexed
  * @pipeable
  * @category Array
  */
 export function reject<T>(
-  fn: Pred<T, boolean>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): (items: ReadonlyArray<T>) => Array<T>;
 
 export function reject(): unknown {
-  return purry(_reject(false), arguments, reject.lazy);
+  return purry(rejectImplementation, arguments, lazyImplementation);
 }
 
-const _reject =
-  (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
-    _reduceLazy(array, indexed ? reject.lazyIndexed(fn) : reject.lazy(fn));
+const rejectImplementation = <T>(
+  array: ReadonlyArray<T>,
+  predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
+): Array<T> =>
+  array.filter((item, index, data) => !predicate(item, index, data));
 
-const _lazy =
-  (indexed: boolean) =>
-  <T>(fn: PredIndexedOptional<T, boolean>): LazyEvaluator<T> =>
+const lazyImplementation =
+  <T>(
+    predicate: (value: T, index: number, array: ReadonlyArray<T>) => boolean,
+  ): LazyEvaluator<T> =>
   (item, index, data) =>
-    (indexed ? fn(item, index, data) : fn(item))
+    predicate(item, index, data)
       ? { done: false, hasNext: false }
       : { done: false, hasNext: true, next: item };
-
-export namespace reject {
-  export function indexed<T, K>(
-    array: ReadonlyArray<T>,
-    fn: PredIndexed<T, boolean>,
-  ): Array<K>;
-  export function indexed<T, K>(
-    fn: PredIndexed<T, boolean>,
-  ): (array: ReadonlyArray<T>) => Array<K>;
-  export function indexed(): unknown {
-    return purry(_reject(true), arguments, reject.lazyIndexed);
-  }
-
-  export const lazy = _lazy(false);
-  export const lazyIndexed = _toLazyIndexed(_lazy(true));
-}

--- a/src/reject.ts
+++ b/src/reject.ts
@@ -50,11 +50,7 @@ export function reject(): unknown {
 const _reject =
   (indexed: boolean) =>
   <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, boolean>) =>
-    _reduceLazy(
-      array,
-      indexed ? reject.lazyIndexed(fn) : reject.lazy(fn),
-      indexed,
-    );
+    _reduceLazy(array, indexed ? reject.lazyIndexed(fn) : reject.lazy(fn));
 
 const _lazy =
   (indexed: boolean) =>

--- a/src/uniqWith.ts
+++ b/src/uniqWith.ts
@@ -1,5 +1,4 @@
 import { _reduceLazy } from "./_reduceLazy";
-import { _toLazyIndexed } from "./_toLazyIndexed";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
@@ -47,15 +46,14 @@ export function uniqWith<T>(
 ): (array: ReadonlyArray<T>) => Array<T>;
 
 export function uniqWith(): unknown {
-  return purry(_uniqWith, arguments, uniqWith.lazy);
+  return purry(_uniqWith, arguments, _lazy);
 }
 
 function _uniqWith<T>(
   array: ReadonlyArray<T>,
   isEquals: IsEquals<T>,
 ): Array<T> {
-  const lazy = uniqWith.lazy(isEquals);
-  return _reduceLazy(array, lazy);
+  return _reduceLazy(array, _lazy(isEquals));
 }
 
 const _lazy =
@@ -64,7 +62,3 @@ const _lazy =
     array.findIndex((otherValue) => isEquals(value, otherValue)) === index
       ? { done: false, hasNext: true, next: value }
       : { done: false, hasNext: false };
-
-export namespace uniqWith {
-  export const lazy = _toLazyIndexed(_lazy);
-}

--- a/src/uniqWith.ts
+++ b/src/uniqWith.ts
@@ -55,13 +55,12 @@ function _uniqWith<T>(
   isEquals: IsEquals<T>,
 ): Array<T> {
   const lazy = uniqWith.lazy(isEquals);
-  return _reduceLazy(array, lazy, true);
+  return _reduceLazy(array, lazy);
 }
 
 const _lazy =
   <T>(isEquals: IsEquals<T>): LazyEvaluator<T> =>
   (value, index, array) =>
-    array !== undefined &&
     array.findIndex((otherValue) => isEquals(value, otherValue)) === index
       ? { done: false, hasNext: true, next: value }
       : { done: false, hasNext: false };


### PR DESCRIPTION
The `indexed` variant isn't required by the runtime as Typescript considers functions with partial signatures (those that take less params then the expected type) as extending there full counterpart. This can be seen througout the typescript library since ES5 where:
`Array.prototype.map((item) => ...)` is just as valid as `Array.prototype.map(item, index, array) => ...)` without the function needing any overloads to do so.

The current implementation of pipe (and reduce lazy) had explicit checks for `indexed` just for the sake of calling the function with less params, but that was just preventing this optimization.

In this PR I only changed the implementation of `map` from the user's perspective, although all functions are now different.

We can't remove `indexed` altogether because that would be a major breaking change and would need to be done as part of Remeda v2.

I want to release this change as a canary to see if anyone reports any breakages. After a few days we can followup and deprecate all indexed variants.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
