### PR TITLE
feat(v2): bumping typescript target and library to es2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
           # the lowest we can go here. This also means this is the lowest
           # version we support. When this value changes in the future it needs
           # to be communicated to the users.
-          - "~4.4.0"
-          - "~4.3.0"
-          - "~4.2.0"
+          - "~4.7.0"
+          - "~4.6.0"
+          - "~4.5.0"
 
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
           # the lowest we can go here. This also means this is the lowest
           # version we support. When this value changes in the future it needs
           # to be communicated to the users.
+          - "~4.8.0"
           - "~4.7.0"
           - "~4.6.0"
-          - "~4.5.0"
 
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
           - "~5.3.0"
           - "~5.2.0"
           - "~5.1.0"
-          # We use features that were added in v4.2 of typescript, so that is
-          # the lowest we can go here. This also means this is the lowest
-          # version we support. When this value changes in the future it needs
-          # to be communicated to the users.
+          # We use a target of ES2022 which was introduced in TypeScript v4.6,
+          # so that is the lowest we can go here. This also means this is the
+          # lowest version we support. When this value changes in the future it
+          # needs to be communicated to the users.
           - "~4.8.0"
           - "~4.7.0"
           - "~4.6.0"

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -164,6 +164,7 @@ export function debounce<F extends (...args: any) => any>(
     latestCallArgs = undefined;
 
     // Invoke the function and store the results locally.
+    // @ts-expect-error [ts2488] - I'm not sure why typescript is having problem re-spreading the args array we got.
     result = func(...args);
   };
 
@@ -210,6 +211,7 @@ export function debounce<F extends (...args: any) => any>(
         } else {
           // Otherwise for "leading" and "both" the first call is actually
           // called directly and not via a timeout.
+          // @ts-expect-error [ts2488] - I'm not sure why typescript is having problem re-spreading the args array we got.
           result = func(...args);
         }
       } else {

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -15,7 +15,6 @@ describe("at runtime", () => {
     });
 
     it("bigint", () => {
-      // @ts-expect-error [ts2737] - Our target is too low to use bigints but our runtimes support them so we want to test them too
       const array = [1n, 2n, 3n, 4n, 5n];
       const result = join(array, ",");
       expect(result).toEqual("1,2,3,4,5");
@@ -41,7 +40,6 @@ describe("at runtime", () => {
   });
 
   it("joins different-typed items", () => {
-    // @ts-expect-error [ts2737] - Our target is too low to use bigints but our runtimes support them so we want to test them too
     const array = [1, "2", 3n, true, null, undefined];
     const result = join(array, ",");
     expect(result).toEqual("1,2,3,true,,");
@@ -147,7 +145,6 @@ describe("typing", () => {
     });
 
     it("bigint", () => {
-      // @ts-expect-error [ts2737] - Our target is too low to use bigints but our runtimes support them so we want to test them too
       const array: [bigint, bigint] = [1n, 2n];
       const result = join(array, ",");
       expectTypeOf(result).toEqualTypeOf<`${bigint},${bigint}`>();

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -8,9 +8,6 @@
 
     "noEmit": true,
 
-    "target": "ES5",
-    "lib": ["ES6", "ES2017.Object", "DOM", "DOM.Iterable"],
-
     "skipDefaultLibCheck": false,
     "skipLibCheck": false
   }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -8,6 +8,9 @@
 
     "noEmit": true,
 
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+
     "skipDefaultLibCheck": false,
     "skipLibCheck": false
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
 
     // LANGUAGE and ENVIRONMENT
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM"],
 
     // COMPLETENESS
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,12 +33,8 @@
     "isolatedModules": true,
 
     // LANGUAGE and ENVIRONMENT
-    // TODO: The recommended target is ES2015 (ES6). Node10 supports es2018 and
-    // the vast majority of browsers are probably above that too already. It's
-    // most likely safe to up this value, and it would probably result in a
-    // smaller package size.
-    "target": "ES5",
-    "lib": ["ES6", "ES2017.Object", "DOM", "DOM.Iterable"],
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
 
     // COMPLETENESS
     "skipLibCheck": true


### PR DESCRIPTION
Just doing this change and following up on any errors and warnings