### PR TITLE
feat: Promote `strict` variants as core

### DIFF
--- a/docs/src/components/function-tag.tsx
+++ b/docs/src/components/function-tag.tsx
@@ -4,7 +4,6 @@ import { cn } from "@/lib/utils";
 const tagToClass: Record<string, string> = {
   pipeable: "bg-green-600 text-green-50 dark:bg-green-500 dark:text-green-950",
   indexed: "bg-sky-600 text-sky-50 dark:bg-sky-500 dark:text-sky-950",
-  strict: "bg-rose-600 text-rose-50 dark:bg-rose-500 dark:text-rose-950",
 };
 
 interface Props {

--- a/docs/src/lib/get-tags.ts
+++ b/docs/src/lib/get-tags.ts
@@ -3,7 +3,7 @@ import type { DocumentedFunction } from "./transform";
 export function getTags({
   methods: [method],
 }: DocumentedFunction): ReadonlyArray<string> {
-  const { pipeable = false, indexed = false, strict = false } = method ?? {};
+  const { pipeable = false, indexed = false } = method ?? {};
 
   const out = [];
 
@@ -13,10 +13,6 @@ export function getTags({
 
   if (indexed) {
     out.push("indexed");
-  }
-
-  if (strict) {
-    out.push("strict");
   }
 
   return out;

--- a/docs/src/lib/transform.ts
+++ b/docs/src/lib/transform.ts
@@ -80,7 +80,6 @@ function transformSignature({
     signature: tagContent(comment, "signature"),
     indexed: hasTag(comment, "indexed"),
     pipeable: hasTag(comment, "pipeable"),
-    strict: hasTag(comment, "strict"),
     example: tagContent(comment, "example"),
     args: parameters.map(getParameter),
     returns: {

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -183,27 +183,6 @@ R.filter.indexed(arr, (x, i) => i % 2 === 0); // => [10, 13]
       `
         />
       </section>
-
-      <section>
-        <Typography.H2>Strict version</Typography.H2>
-
-        <Typography.P>
-          Some functions have an extra property <code>strict</code> which is the
-          same function with stricter types.
-        </Typography.P>
-
-        <CodeBlock
-          code=`
-const input = { a: 'x', b: 'y', c: 'z' } as const;
-
-const result = R.keys(input);
-//    ^?: Array<string>
-
-const resultStrict = R.keys.strict(input);
-//    ^?: Array<'a' | 'b' | 'c'>
-      `
-        />
-      </section>
     </div>
   </main>
 </Layout>

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -102,3 +102,7 @@ export type ExactRecord<Key extends PropertyKey, Value> =
           // because we can't statically know what values the mapper would return on
           // a specific input
           Partial<Record<Key, Value>>;
+
+export type ReorderedArray<T extends IterableContainer> = {
+  -readonly [P in keyof T]: T[number];
+};

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -83,3 +83,22 @@ export type CompareFunction<T> = (a: T, b: T) => number;
  * @see https://github.com/sindresorhus/type-fest/blob/main/source/is-any.d.ts
  */
 export type IfIsAny<T, Then, Else> = 0 extends T & 1 ? Then : Else;
+
+// Records keyed with generic `string` and `number` have different semantics
+// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
+// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
+// the latter are implicitly `Required`.
+// TODO: Support template string literals (e.g. `prefix_${number}`)
+export type ExactRecord<Key extends PropertyKey, Value> =
+  // If either string, number or symbol extend Key it means that Key is at least
+  // as wide as them, so we don't need to wrap the returned record with Partial.
+  string extends Key
+    ? Record<Key, Value>
+    : number extends Key
+      ? Record<Key, Value>
+      : symbol extends Key
+        ? Record<Key, Value>
+        : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
+          // because we can't statically know what values the mapper would return on
+          // a specific input
+          Partial<Record<Key, Value>>;

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -34,7 +34,7 @@ describe("data last", () => {
   });
 });
 
-describe("strict typing", () => {
+describe("typing", () => {
   test("empty tuple", () => {
     const input: [] = [];
     const result = chunk(input, 2);

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -12,6 +12,20 @@ describe("runtime", () => {
 
 describe("typing", () => {
   test("with known properties", () => {
+    const actual = entries({ a: 1, b: 2, c: 3 });
+    expectTypeOf(actual).toEqualTypeOf<
+      Array<["a", number] | ["b", number] | ["c", number]>
+    >();
+  });
+
+  test("with different value types", () => {
+    const actual = entries({ a: 1, b: "2", c: true });
+    expectTypeOf(actual).toEqualTypeOf<
+      Array<["a", number] | ["b", string] | ["c", boolean]>
+    >();
+  });
+
+  test("with const object", () => {
     const actual = entries({ a: 1, b: 2, c: 3 } as const);
     expectTypeOf(actual).toEqualTypeOf<Array<["a", 1] | ["b", 2] | ["c", 3]>>();
   });

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -1,42 +1,8 @@
 import { entries } from "./entries";
 
-describe("runtime", () => {
-  test("dataFirst", () => {
-    expect(entries({ a: 1, b: 2, c: 3 })).toEqual([
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ]);
-  });
-
-  describe("typing", () => {
-    test("with known properties", () => {
-      const actual = entries({ a: 1, b: 2, c: 3 });
-      expectTypeOf(actual).toEqualTypeOf<Array<[string, number]>>();
-    });
-
-    test("with optional properties", () => {
-      const actual = entries({} as { a?: string });
-      expectTypeOf(actual).toEqualTypeOf<Array<[string, string]>>();
-    });
-
-    test("with undefined properties", () => {
-      const actual = entries({ a: undefined } as {
-        a: string | undefined;
-      });
-      expectTypeOf(actual).toEqualTypeOf<Array<[string, string | undefined]>>();
-    });
-
-    test("with unknown properties", () => {
-      const actual = entries({} as Record<string, unknown>);
-      expectTypeOf(actual).toEqualTypeOf<Array<[string, unknown]>>();
-    });
-  });
-});
-
-describe("entries.strict", () => {
+describe("entries", () => {
   test("should return pairs", () => {
-    const actual = entries.strict({ a: 1, b: 2, c: 3 });
+    const actual = entries({ a: 1, b: 2, c: 3 });
     expect(actual).toEqual([
       ["a", 1],
       ["b", 2],
@@ -46,26 +12,26 @@ describe("entries.strict", () => {
 
   describe("typing", () => {
     test("with known properties", () => {
-      const actual = entries.strict({ a: 1, b: 2, c: 3 } as const);
+      const actual = entries({ a: 1, b: 2, c: 3 } as const);
       expectTypeOf(actual).toEqualTypeOf<
         Array<["a", 1] | ["b", 2] | ["c", 3]>
       >();
     });
 
     test("with optional properties", () => {
-      const actual = entries.strict({} as { a?: string });
+      const actual = entries({} as { a?: string });
       expectTypeOf(actual).toEqualTypeOf<Array<["a", string]>>();
     });
 
     test("with undefined properties", () => {
-      const actual = entries.strict({ a: undefined } as {
+      const actual = entries({ a: undefined } as {
         a: string | undefined;
       });
       expectTypeOf(actual).toEqualTypeOf<Array<["a", string | undefined]>>();
     });
 
     test("with unknown properties", () => {
-      const actual = entries.strict({} as Record<string, unknown>);
+      const actual = entries({} as Record<string, unknown>);
       expectTypeOf(actual).toEqualTypeOf<Array<[string, unknown]>>();
     });
   });

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -1,38 +1,35 @@
 import { entries } from "./entries";
 
-describe("entries", () => {
+describe("runtime", () => {
   test("should return pairs", () => {
-    const actual = entries({ a: 1, b: 2, c: 3 });
-    expect(actual).toEqual([
+    expect(entries({ a: 1, b: 2, c: 3 })).toEqual([
       ["a", 1],
       ["b", 2],
       ["c", 3],
     ]);
   });
+});
 
-  describe("typing", () => {
-    test("with known properties", () => {
-      const actual = entries({ a: 1, b: 2, c: 3 } as const);
-      expectTypeOf(actual).toEqualTypeOf<
-        Array<["a", 1] | ["b", 2] | ["c", 3]>
-      >();
-    });
+describe("typing", () => {
+  test("with known properties", () => {
+    const actual = entries({ a: 1, b: 2, c: 3 } as const);
+    expectTypeOf(actual).toEqualTypeOf<Array<["a", 1] | ["b", 2] | ["c", 3]>>();
+  });
 
-    test("with optional properties", () => {
-      const actual = entries({} as { a?: string });
-      expectTypeOf(actual).toEqualTypeOf<Array<["a", string]>>();
-    });
+  test("with optional properties", () => {
+    const actual = entries({} as { a?: string });
+    expectTypeOf(actual).toEqualTypeOf<Array<["a", string]>>();
+  });
 
-    test("with undefined properties", () => {
-      const actual = entries({ a: undefined } as {
-        a: string | undefined;
-      });
-      expectTypeOf(actual).toEqualTypeOf<Array<["a", string | undefined]>>();
+  test("with undefined properties", () => {
+    const actual = entries({ a: undefined } as {
+      a: string | undefined;
     });
+    expectTypeOf(actual).toEqualTypeOf<Array<["a", string | undefined]>>();
+  });
 
-    test("with unknown properties", () => {
-      const actual = entries({} as Record<string, unknown>);
-      expectTypeOf(actual).toEqualTypeOf<Array<[string, unknown]>>();
-    });
+  test("with unknown properties", () => {
+    const actual = entries({} as Record<string, unknown>);
+    expectTypeOf(actual).toEqualTypeOf<Array<[string, unknown]>>();
   });
 });

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,14 +1,19 @@
+/* eslint-disable @typescript-eslint/ban-types --
+ * We want to match the typing of the built-in Object.entries as much as
+ * possible!
+ */
+
 import { purry } from "./purry";
 import type { Simplify } from "./type-fest/simplify";
 
-type Entries<T> = Array<
-  { [K in keyof T]-?: [key: K, value: Required<T>[K]] }[keyof T]
->;
+export type EntryForKey<T, K extends keyof T> = [key: K, value: Required<T>[K]];
+
+type EntryOf<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
  *
- * @param object - Object to return keys and values of.
+ * @param data - Object to return keys and values of.
  * @signature
  *    R.entries(object)
  * @example
@@ -16,9 +21,7 @@ type Entries<T> = Array<
  * @dataFirst
  * @category Object
  */
-export function entries<T extends NonNullable<unknown>>(
-  object: T,
-): Simplify<Entries<T>>;
+export function entries<T extends {}>(data: T): Array<EntryOf<T>>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
@@ -33,9 +36,7 @@ export function entries<T extends NonNullable<unknown>>(
  * @dataLast
  * @category Object
  */
-export function entries(): <T extends NonNullable<unknown>>(
-  object: T,
-) => Simplify<Entries<T>>;
+export function entries(): <T extends {}>(data: T) => Array<EntryOf<T>>;
 
 export function entries(): unknown {
   return purry(Object.entries, arguments);

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -17,7 +17,7 @@ type EntryOf<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
  * @signature
  *    R.entries(object)
  * @example
- *    R.entries({ a: 1 } as const) // => [['a', 1]] typed Array<['a', 1]>
+ *    R.entries({ a: 1, b: 2, c: 3 }); // => [['a', 1], ['b', 2], ['c', 3]]
  * @dataFirst
  * @category Object
  */
@@ -29,10 +29,7 @@ export function entries<T extends {}>(data: T): Array<EntryOf<T>>;
  * @signature
  *    R.entries()(object)
  * @example
- *    R.pipe(
- *      { a: 1 } as const,
- *      entries(),
- *    ); // => [['a', 1]] typed Array<['a', 1]>
+ *    R.pipe({ a: 1, b: 2, c: 3 }, R.entries()); // => [['a', 1], ['b', 2], ['c', 3]]
  * @dataLast
  * @category Object
  */

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -6,9 +6,12 @@
 import { purry } from "./purry";
 import type { Simplify } from "./type-fest/simplify";
 
-export type EntryForKey<T, K extends keyof T> = [key: K, value: Required<T>[K]];
+export type EntryForKey<T, Key extends keyof T> = [
+  key: Key,
+  value: Required<T>[Key],
+];
 
-type Entry<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
+type Entry<T> = Simplify<{ [P in keyof T]-?: EntryForKey<T, P> }[keyof T]>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,59 +1,39 @@
 import { purry } from "./purry";
 
+type Entries<T> = Array<
+  { [K in keyof T]-?: [key: K, value: Required<T>[K]] }[keyof T]
+>;
+
 /**
  * Returns an array of key/values of the enumerable properties of an object.
  *
  * @param object - Object to return keys and values of.
  * @signature
  *    R.entries(object)
- *    R.entries.strict(object)
  * @example
- *    R.entries({ a: 1, b: 2, c: 3 }) // => [['a', 1], ['b', 2], ['c', 3]]
- *    R.entries.strict({ a: 1 } as const) // => [['a', 1]] typed Array<['a', 1]>
+ *    R.entries({ a: 1 } as const) // => [['a', 1]] typed Array<['a', 1]>
  * @dataFirst
- * @strict
  * @category Object
  */
-export function entries<T>(
-  object: Readonly<Record<string, T>>,
-): Array<[string, T]>;
+export function entries<T extends NonNullable<unknown>>(object: T): Entries<T>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
  *
  * @signature
  *    R.entries()(object)
- *    R.entries.strict()(object)
  * @example
  *    R.pipe(
- *      { a: 1, b: 2, c: 3 },
- *      entries(),
- *    ); // => [['a', 1], ['b', 2], ['c', 3]]
- *    R.pipe(
  *      { a: 1 } as const,
- *      entries.strict(),
+ *      entries(),
  *    ); // => [['a', 1]] typed Array<['a', 1]>
  * @dataLast
- * @strict
  * @category Object
  */
-export function entries(): <T>(
-  object: Readonly<Record<string, T>>,
-) => Array<[string, T]>;
+export function entries(): <T extends NonNullable<unknown>>(
+  object: T,
+) => Entries<T>;
 
 export function entries(): unknown {
   return purry(Object.entries, arguments);
-}
-
-type Entries<T> = Array<
-  { [K in keyof T]-?: [key: K, value: Required<T>[K]] }[keyof T]
->;
-
-type Strict = {
-  <T extends NonNullable<unknown>>(object: T): Entries<T>;
-  (): <T extends NonNullable<unknown>>(object: T) => Entries<T>;
-};
-
-export namespace entries {
-  export const strict = entries as Strict;
 }

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,4 +1,5 @@
 import { purry } from "./purry";
+import type { Simplify } from "./type-fest/simplify";
 
 type Entries<T> = Array<
   { [K in keyof T]-?: [key: K, value: Required<T>[K]] }[keyof T]
@@ -15,7 +16,9 @@ type Entries<T> = Array<
  * @dataFirst
  * @category Object
  */
-export function entries<T extends NonNullable<unknown>>(object: T): Entries<T>;
+export function entries<T extends NonNullable<unknown>>(
+  object: T,
+): Simplify<Entries<T>>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
@@ -32,7 +35,7 @@ export function entries<T extends NonNullable<unknown>>(object: T): Entries<T>;
  */
 export function entries(): <T extends NonNullable<unknown>>(
   object: T,
-) => Entries<T>;
+) => Simplify<Entries<T>>;
 
 export function entries(): unknown {
   return purry(Object.entries, arguments);

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -8,7 +8,7 @@ import type { Simplify } from "./type-fest/simplify";
 
 export type EntryForKey<T, K extends keyof T> = [key: K, value: Required<T>[K]];
 
-type EntryOf<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
+type Entry<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
@@ -21,7 +21,7 @@ type EntryOf<T> = Simplify<{ [K in keyof T]-?: EntryForKey<T, K> }[keyof T]>;
  * @dataFirst
  * @category Object
  */
-export function entries<T extends {}>(data: T): Array<EntryOf<T>>;
+export function entries<T extends {}>(data: T): Array<Entry<T>>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.
@@ -33,7 +33,7 @@ export function entries<T extends {}>(data: T): Array<EntryOf<T>>;
  * @dataLast
  * @category Object
  */
-export function entries(): <T extends {}>(data: T) => Array<EntryOf<T>>;
+export function entries(): <T extends {}>(data: T) => Array<Entry<T>>;
 
 export function entries(): unknown {
   return purry(Object.entries, arguments);

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -6,10 +6,7 @@
 import { purry } from "./purry";
 import type { Simplify } from "./type-fest/simplify";
 
-export type EntryForKey<T, Key extends keyof T> = [
-  key: Key,
-  value: Required<T>[Key],
-];
+type EntryForKey<T, Key extends keyof T> = [key: Key, value: Required<T>[Key]];
 
 type Entry<T> = Simplify<{ [P in keyof T]-?: EntryForKey<T, P> }[keyof T]>;
 

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -24,11 +24,7 @@ describe("data first", () => {
           time: { elapsed: add(1), remaining: add(-1) },
         },
       ),
-    ).toEqual({
-      id: 2,
-      quartile: 10,
-      time: { elapsed: 101, remaining: 1399 },
-    });
+    ).toEqual({ id: 2, quartile: 10, time: { elapsed: 101, remaining: 1399 } });
   });
 
   it("does not invoke function if `data` does not contain the key", () => {

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -11,30 +11,28 @@ const sum = reduce((a, b: number) => add(a, b), 0);
 
 describe("data first", () => {
   it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
-    const expected = {
+    expect(
+      evolve(
+        {
+          id: 1,
+          quartile: [1, 2, 3, 4],
+          time: { elapsed: 100, remaining: 1400 },
+        },
+        {
+          id: add(1),
+          quartile: sum,
+          time: { elapsed: add(1), remaining: add(-1) },
+        },
+      ),
+    ).toEqual({
       id: 2,
       quartile: 10,
       time: { elapsed: 101, remaining: 1399 },
-    };
-    const result = evolve(
-      {
-        id: 1,
-        quartile: [1, 2, 3, 4],
-        time: { elapsed: 100, remaining: 1400 },
-      },
-      {
-        id: add(1),
-        quartile: sum,
-        time: { elapsed: add(1), remaining: add(-1) },
-      },
-    );
-    expect(result).toEqual(expected);
-    expectTypeOf(result).toEqualTypeOf<typeof expected>();
+    });
   });
 
   it("does not invoke function if `data` does not contain the key", () => {
-    const result = evolve({} as { id?: number }, { id: add(1) });
-    expect(result).toEqual({});
+    expect(evolve({} as { id?: number }, { id: add(1) })).toEqual({});
   });
 
   it("is not destructive and is immutable", () => {
@@ -44,17 +42,15 @@ describe("data first", () => {
     expect(data).toEqual({ n: 100 });
     expect(result).toEqual(expected);
     expect(result).not.toBe(expected);
-    expectTypeOf(result).toEqualTypeOf<typeof expected>();
   });
 
   it("is recursive", () => {
-    const expected = { first: 1, nested: { second: 1, third: 4 } };
-    const result = evolve(
-      { first: 1, nested: { second: 2, third: 3 } },
-      { nested: { second: add(-1), third: add(1) } },
-    );
-    expect(result).toEqual(expected);
-    expectTypeOf(result).toEqualTypeOf<typeof expected>();
+    expect(
+      evolve(
+        { first: 1, nested: { second: 2, third: 3 } },
+        { nested: { second: add(-1), third: add(1) } },
+      ),
+    ).toEqual({ first: 1, nested: { second: 1, third: 4 } });
   });
 
   it("ignores undefined transformations", () => {
@@ -62,28 +58,40 @@ describe("data first", () => {
   });
 
   it("can handle data that is complex nested objects", () => {
-    const result = evolve(
-      {
-        array: ["1", "2", "3"],
-        nestedObj: { a: { b: "c" } },
-        objAry: [
-          { a: 0, b: 0 },
-          { a: 1, b: 1 },
-        ],
-      },
-      {
-        array: length(),
-        nestedObj: { a: (x) => set(x, "b", "Set") },
-        objAry: (x) => map(x, omit(["b"])),
-      },
-    );
-    const expected = {
+    expect(
+      evolve(
+        {
+          array: ["1", "2", "3"],
+          nestedObj: { a: { b: "c" } },
+          objAry: [
+            { a: 0, b: 0 },
+            { a: 1, b: 1 },
+          ],
+        },
+        {
+          array: length(),
+          nestedObj: { a: (x) => set(x, "b", "Set") },
+          objAry: (x) => map(x, omit(["b"])),
+        },
+      ),
+    ).toEqual({
       array: 3,
       nestedObj: { a: { b: "Set" } },
       objAry: [{ a: 0 }, { a: 1 }],
-    };
-    expect(result).toEqual(expected);
-    expectTypeOf(result).toEqualTypeOf<typeof expected>();
+    });
+  });
+
+  it("accept function whose second and subsequent arguments are optional", () => {
+    expect(
+      evolve(
+        { arg2Optional: 1, arg2arg3Optional: 1 },
+        {
+          arg2Optional: (_: number, arg2?: number) => arg2 === undefined,
+          arg2arg3Optional: (_: number, arg2?: number, arg3?: number) =>
+            arg2 === undefined && arg3 === undefined,
+        },
+      ),
+    ).toEqual({ arg2Optional: true, arg2arg3Optional: true });
   });
 });
 
@@ -170,51 +178,116 @@ describe("data last", () => {
 
 describe("typing", () => {
   describe("data first", () => {
-    describe("type reflection", (): void => {
-      it("can reflect type of data to function of evolver object", () => {
-        const data = {
+    it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
+      const result = evolve(
+        {
           id: 1,
           quartile: [1, 2, 3, 4],
           time: { elapsed: 100, remaining: 1400 },
-        } as {
+        },
+        {
+          id: add(1),
+          quartile: sum,
+          time: { elapsed: add(1), remaining: add(-1) },
+        },
+      );
+      expectTypeOf(result).toEqualTypeOf<{
+        id: number;
+        quartile: number;
+        time: { elapsed: number; remaining: number };
+      }>();
+    });
+
+    it("is not destructive and is immutable", () => {
+      const result = evolve({ n: 100 }, { n: add(1) });
+      expectTypeOf(result).toEqualTypeOf<{ n: number }>();
+    });
+
+    it("is recursive", () => {
+      const result = evolve(
+        { first: 1, nested: { second: 2, third: 3 } },
+        { nested: { second: add(-1), third: add(1) } },
+      );
+      expectTypeOf(result).toEqualTypeOf<{
+        first: number;
+        nested: { second: number; third: number };
+      }>();
+    });
+
+    it("can handle data that is complex nested objects", () => {
+      const result = evolve(
+        {
+          array: ["1", "2", "3"],
+          nestedObj: { a: { b: "c" } },
+          objAry: [
+            { a: 0, b: 0 },
+            { a: 1, b: 1 },
+          ],
+        },
+        {
+          array: length(),
+          nestedObj: { a: (x) => set(x, "b", "Set") },
+          objAry: (x) => map(x, omit(["b"])),
+        },
+      );
+      expectTypeOf(result).toEqualTypeOf<{
+        array: number;
+        nestedObj: { a: { b: string } };
+        objAry: Array<{ a: number }>;
+      }>();
+    });
+
+    describe("type reflection", (): void => {
+      it("can reflect type of data to function of evolver object", () => {
+        const result = evolve(
+          {
+            id: 1,
+            quartile: [1, 2, 3, 4],
+            time: { elapsed: 100, remaining: 1400 },
+          } as {
+            id: number;
+            quartile: Array<number>;
+            time?: { elapsed: number; remaining?: number };
+          },
+          {
+            // type of parameter is required because `count` property is not
+            // defined in data
+            count: (x: number) => x,
+            quartile: (x) => x,
+            time: (x) => x,
+          },
+        );
+        expectTypeOf(result).toEqualTypeOf<{
           id: number;
           quartile: Array<number>;
           time?: { elapsed: number; remaining?: number };
-        };
-        const expected = data;
-
-        const result = evolve(data, {
-          // type of parameter is required because `count` property is not
-          // defined in data
-          count: (x: number) => x,
-          quartile: (x) => x,
-          time: (x) => x,
-        });
-        expect(result).toEqual(expected);
-        expectTypeOf(result).toEqualTypeOf<typeof expected>();
+        }>();
       });
 
       it("can reflect type of data to function of nested evolver object", () => {
-        const data = {
-          id: 1,
-          quartile: [1, 2, 3, 4],
-          time: { elapsed: 100, remaining: 1400 },
-        } as {
+        const result = evolve(
+          {
+            id: 1,
+            quartile: [1, 2, 3, 4],
+            time: { elapsed: 100, remaining: 1400 },
+          } as {
+            id: number;
+            quartile: Array<number>;
+            time?: { elapsed: number; remaining?: number };
+          },
+          {
+            // type of parameter is required because `count` property is not
+            // defined in data
+            count: (x: number) => x,
+            quartile: (x) => x,
+            time: { elapsed: (x) => x, remaining: (x) => x },
+          },
+        );
+        expectTypeOf(result).toEqualTypeOf<{
           id: number;
           quartile: Array<number>;
           time?: { elapsed: number; remaining?: number };
-        };
-        const expected = data;
-
-        const result = evolve(data, {
-          // type of parameter is required because `count` property is not
-          // defined in data
-          count: (x: number) => x,
-          quartile: (x) => x,
-          time: { elapsed: (x) => x, remaining: (x) => x },
-        });
-        expect(result).toEqual(expected);
-        expectTypeOf(result).toEqualTypeOf<typeof expected>();
+        }>();
       });
     });
 
@@ -264,7 +337,6 @@ describe("typing", () => {
             arg2 === undefined && arg3 === undefined,
         },
       );
-      expect(result).toEqual({ arg2Optional: true, arg2arg3Optional: true });
       expectTypeOf(result).toEqualTypeOf<{
         arg2Optional: boolean;
         arg2arg3Optional: boolean;

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -63,11 +63,6 @@ describe("data first", () => {
   });
 
   it("can handle data that is complex nested objects", () => {
-    const evolver = {
-      array: (array: ReadonlyArray<string>) => array.length,
-      nestedObj: { a: set<{ b: string }, "b">("b", "Set") },
-      objAry: map(omit<{ a: number; b: number }, "b">(["b"])),
-    };
     const result = evolve(
       {
         array: ["1", "2", "3"],
@@ -77,7 +72,11 @@ describe("data first", () => {
           { a: 1, b: 1 },
         ],
       },
-      evolver,
+      {
+        array: (x) => x.length,
+        nestedObj: { a: (x) => set(x, "b", "Set") },
+        objAry: (x) => map(x, omit(["b"])),
+      },
     );
     const expected = {
       array: 3,
@@ -158,9 +157,9 @@ describe("data last", () => {
         ],
       },
       evolve({
-        array: (array: ReadonlyArray<string>) => array.length,
-        nestedObj: { a: set<{ b: string }, "b">("b", "Set") },
-        objAry: map(omit<{ a: number; b: number }, "b">(["b"])),
+        array: (x) => x.length,
+        nestedObj: { a: (x) => set(x, "b", "Set") },
+        objAry: (x) => map(x, omit(["b"])),
       }),
     );
     const expected = {

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -24,19 +24,23 @@ describe("data first", () => {
           time: { elapsed: add(1), remaining: add(-1) },
         },
       ),
-    ).toEqual({ id: 2, quartile: 10, time: { elapsed: 101, remaining: 1399 } });
+    ).toStrictEqual({
+      id: 2,
+      quartile: 10,
+      time: { elapsed: 101, remaining: 1399 },
+    });
   });
 
   it("does not invoke function if `data` does not contain the key", () => {
-    expect(evolve({} as { id?: number }, { id: add(1) })).toEqual({});
+    expect(evolve({} as { id?: number }, { id: add(1) })).toStrictEqual({});
   });
 
   it("is not destructive and is immutable", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = evolve(data, { n: add(1) });
-    expect(data).toEqual({ n: 100 });
-    expect(result).toEqual(expected);
+    expect(data).toStrictEqual({ n: 100 });
+    expect(result).toStrictEqual(expected);
     expect(result).not.toBe(expected);
   });
 
@@ -46,11 +50,11 @@ describe("data first", () => {
         { first: 1, nested: { second: 2, third: 3 } },
         { nested: { second: add(-1), third: add(1) } },
       ),
-    ).toEqual({ first: 1, nested: { second: 1, third: 4 } });
+    ).toStrictEqual({ first: 1, nested: { second: 1, third: 4 } });
   });
 
   it("ignores undefined transformations", () => {
-    expect(evolve({ n: 0 }, {})).toEqual({ n: 0 });
+    expect(evolve({ n: 0 }, {})).toStrictEqual({ n: 0 });
   });
 
   it("can handle data that is complex nested objects", () => {
@@ -70,7 +74,7 @@ describe("data first", () => {
           objAry: (x) => map(x, omit(["b"])),
         },
       ),
-    ).toEqual({
+    ).toStrictEqual({
       array: 3,
       nestedObj: { a: { b: "Set" } },
       objAry: [{ a: 0 }, { a: 1 }],
@@ -87,7 +91,7 @@ describe("data first", () => {
             arg2 === undefined && arg3 === undefined,
         },
       ),
-    ).toEqual({ arg2Optional: true, arg2arg3Optional: true });
+    ).toStrictEqual({ arg2Optional: true, arg2arg3Optional: true });
   });
 });
 
@@ -106,19 +110,25 @@ describe("data last", () => {
           time: { elapsed: add(1), remaining: add(-1) },
         }),
       ),
-    ).toEqual({ id: 2, quartile: 10, time: { elapsed: 101, remaining: 1399 } });
+    ).toStrictEqual({
+      id: 2,
+      quartile: 10,
+      time: { elapsed: 101, remaining: 1399 },
+    });
   });
 
   it("does not invoke function if `data` does not contain the key", () => {
-    expect(pipe({} as { id?: number }, evolve({ id: add(1) }))).toEqual({});
+    expect(pipe({} as { id?: number }, evolve({ id: add(1) }))).toStrictEqual(
+      {},
+    );
   });
 
   it("is not destructive and is immutable", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = pipe(data, evolve({ n: add(1) }));
-    expect(data).toEqual({ n: 100 });
-    expect(result).toEqual(expected);
+    expect(data).toStrictEqual({ n: 100 });
+    expect(result).toStrictEqual(expected);
     expect(result).not.toBe(expected);
   });
 
@@ -128,11 +138,11 @@ describe("data last", () => {
         { first: 1, nested: { second: 2, third: 3 } },
         evolve({ nested: { second: add(-1), third: add(1) } }),
       ),
-    ).toEqual({ first: 1, nested: { second: 1, third: 4 } });
+    ).toStrictEqual({ first: 1, nested: { second: 1, third: 4 } });
   });
 
   it("ignores undefined transformations", () => {
-    expect(pipe({ n: 0 }, evolve({}))).toEqual({ n: 0 });
+    expect(pipe({ n: 0 }, evolve({}))).toStrictEqual({ n: 0 });
   });
 
   it("can handle data that is complex nested objects", () => {
@@ -152,7 +162,7 @@ describe("data last", () => {
           objAry: (x) => map(x, omit(["b"])),
         }),
       ),
-    ).toEqual({
+    ).toStrictEqual({
       array: 3,
       nestedObj: { a: { b: "Set" } },
       objAry: [{ a: 0 }, { a: 1 }],
@@ -169,7 +179,7 @@ describe("data last", () => {
             arg2 === undefined && arg3 === undefined,
         }),
       ),
-    ).toEqual({ arg2Optional: true, arg2arg3Optional: true });
+    ).toStrictEqual({ arg2Optional: true, arg2arg3Optional: true });
   });
 });
 

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -142,7 +142,7 @@ function _evolve(data: unknown, evolver: GenericEvolver): unknown {
 
   const out: Record<string, unknown> = { ...data };
 
-  for (const [key, value] of entries.strict(evolver)) {
+  for (const [key, value] of entries(evolver)) {
     if (key in out) {
       out[key] =
         typeof value === "function"

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -2,10 +2,6 @@ import { createLazyInvocationCounter } from "../test/lazy_invocation_counter";
 import { filter } from "./filter";
 import { pipe } from "./pipe";
 
-function assertType<T>(data: T): T {
-  return data;
-}
-
 function isNumber<T>(data: T): data is Extract<T, number> {
   return typeof data === "number";
 } // TODO Refactor to remeda function

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -90,7 +90,7 @@ describe("pipe", () => {
   });
 });
 
-describe("strict typing", () => {
+describe("typing", () => {
   test("simple empty array", () => {
     const arr: Array<number> = [];
     const result = first(arr);

--- a/src/fromEntries.test.ts
+++ b/src/fromEntries.test.ts
@@ -1,264 +1,299 @@
 import { fromEntries } from "./fromEntries";
-
-const tuples: Array<[string, number]> = [
-  ["a", 1],
-  ["b", 2],
-  ["c", 3],
-];
+import { pipe } from "./pipe";
 
 describe("runtime", () => {
   test("dataFirst", () => {
-    expect(fromEntries(tuples)).toEqual({
-      a: 1,
-      b: 2,
-      c: 3,
+    expect(
+      fromEntries([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]),
+    ).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  test("dataLast", () => {
+    expect(
+      pipe(
+        [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+        ] as const,
+        fromEntries(),
+      ),
+    ).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  test("trivial empty case", () => {
+    expect(fromEntries([])).toStrictEqual({});
+  });
+
+  test("trivial single entry const case", () => {
+    expect(fromEntries([["a", 1]])).toStrictEqual({ a: 1 });
+  });
+
+  test("trivial multi entry const case", () => {
+    expect(
+      fromEntries([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ] as const),
+    ).toStrictEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  test("single value generic type", () => {
+    expect(fromEntries([["hello", true]])).toStrictEqual({ hello: true });
+  });
+
+  test("multi-value generic type", () => {
+    expect(
+      fromEntries([
+        ["hello", true],
+        ["world", false],
+      ]),
+    ).toStrictEqual({ hello: true, world: false });
+  });
+
+  test("array with literal keys", () => {
+    expect(fromEntries([["a", "d"]])).toStrictEqual({ a: "d" });
+  });
+
+  test("backwards compatibility (number)", () => {
+    expect(fromEntries([[1, 123]])).toStrictEqual({ 1: 123 });
+  });
+
+  test("backwards compatibility (string)", () => {
+    expect(fromEntries([["a", 123]])).toStrictEqual({ a: 123 });
+  });
+
+  test("single value generic type", () => {
+    expect(fromEntries([["hello", true]])).toStrictEqual({ hello: true });
+  });
+
+  test("multi-value generic type", () => {
+    expect(
+      fromEntries([
+        ["hello", true],
+        ["world", false],
+      ]),
+    ).toStrictEqual({ hello: true, world: false });
+  });
+});
+
+describe("typing", () => {
+  describe("readonly inputs", () => {
+    test("trivial empty case", () => {
+      const result = fromEntries([] as const);
+      expectTypeOf(result).toEqualTypeOf({} as const);
+    });
+
+    test("trivial single entry const case", () => {
+      const result = fromEntries([["a", 1]] as const);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1 }>();
+    });
+
+    test("trivial multi entry const case", () => {
+      const result = fromEntries([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ] as const);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1; b: 2; c: 3 }>();
+    });
+
+    test("empty well defined array", () => {
+      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
+
+    test("single value well defined array", () => {
+      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
+
+    test("multi-value well defined array", () => {
+      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
+
+    test("mixed tuple with rest (first)", () => {
+      const arr: readonly [["a", 1], ...ReadonlyArray<["b", 2] | ["c", 3]>] = [
+        ["a", 1],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+    });
+
+    test("mixed tuple with rest (last)", () => {
+      const arr: readonly [...ReadonlyArray<["b", 2] | ["c", 3]>, ["a", 1]] = [
+        ["a", 1],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+    });
+
+    test("empty generic type", () => {
+      const arr: ReadonlyArray<readonly [string, boolean]> = [];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
+
+    test("single value generic type", () => {
+      const arr: ReadonlyArray<readonly [string, boolean]> = [["hello", true]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
+
+    test("multi-value generic type", () => {
+      const arr: ReadonlyArray<readonly [string, boolean]> = [
+        ["hello", true],
+        ["world", false],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
+
+    test("mixed literals and generics", () => {
+      const arr: ReadonlyArray<
+        readonly ["a", 1] | readonly [`testing_${string}`, boolean]
+      > = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<
+        Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
+      >();
+    });
+
+    test("array with literal keys", () => {
+      const arr: ReadonlyArray<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<
+        Partial<Record<"a" | "b" | "c", "d">>
+      >();
+    });
+
+    test("backwards compatibility (number)", () => {
+      const arr: ReadonlyArray<readonly [number, 123]> = [[1, 123]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
+    });
+
+    test("backwards compatibility (string)", () => {
+      const arr: ReadonlyArray<readonly [string, 123]> = [["a", 123]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
     });
   });
-});
 
-describe("typings", () => {
-  test("arrays", () => {
-    const actual = fromEntries(tuples);
-    assertType<Record<string, number>>(actual);
-  });
-});
+  describe("non-readonly inputs", () => {
+    test("trivial empty case", () => {
+      const result = fromEntries([]);
+      expectTypeOf(result).toEqualTypeOf({} as const);
+    });
 
-describe("Strict (with readonly inputs)", () => {
-  test("trivial empty case", () => {
-    const result = fromEntries([] as const);
-    expectTypeOf(result).toEqualTypeOf({} as const);
-    expect(result).toStrictEqual({});
-  });
+    test("trivial single entry const case", () => {
+      const result = fromEntries([["a", 1]]);
+      expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
+    });
 
-  test("trivial single entry const case", () => {
-    const result = fromEntries([["a", 1]] as const);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
+    test("trivial multi entry const case", () => {
+      const result = fromEntries([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
+      expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
+    });
 
-  test("trivial multi entry const case", () => {
-    const result = fromEntries([
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ] as const);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1; b: 2; c: 3 }>();
-    expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
-  });
+    test("empty well defined array", () => {
+      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
 
-  test("runtime empty well defined array", () => {
-    const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({});
-  });
+    test("single value well defined array", () => {
+      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
 
-  test("runtime single value well defined array", () => {
-    const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
+    test("multi-value well defined array", () => {
+      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
+    });
 
-  test("runtime multi-value well defined array", () => {
-    const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
-  });
+    test("mixed tuple with rest (first)", () => {
+      const arr: [["a", 1], ...Array<["b", 2] | ["c", 3]>] = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+    });
 
-  test("runtime mixed tuple with rest (first)", () => {
-    const arr: readonly [["a", 1], ...ReadonlyArray<["b", 2] | ["c", 3]>] = [
-      ["a", 1],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
+    test("mixed tuple with rest (last)", () => {
+      const arr: [...Array<["b", 2] | ["c", 3]>, ["a", 1]] = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+    });
 
-  test("runtime mixed tuple with rest (last)", () => {
-    const arr: readonly [...ReadonlyArray<["b", 2] | ["c", 3]>, ["a", 1]] = [
-      ["a", 1],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
+    test("empty generic type", () => {
+      const arr: Array<[string, boolean]> = [];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
 
-  test("runtime empty generic type", () => {
-    const arr: ReadonlyArray<readonly [string, boolean]> = [];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({});
-  });
+    test("single value generic type", () => {
+      const arr: Array<[string, boolean]> = [["hello", true]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
 
-  test("runtime single value generic type", () => {
-    const arr: ReadonlyArray<readonly [string, boolean]> = [["hello", true]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({ hello: true });
-  });
+    test("multi-value generic type", () => {
+      const arr: Array<[string, boolean]> = [
+        ["hello", true],
+        ["world", false],
+      ];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
+    });
 
-  test("runtime multi-value generic type", () => {
-    const arr: ReadonlyArray<readonly [string, boolean]> = [
-      ["hello", true],
-      ["world", false],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({ hello: true, world: false });
-  });
+    test("mixed literals and generics", () => {
+      const arr: Array<["a", 1] | [`testing_${string}`, boolean]> = [["a", 1]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toMatchTypeOf<
+        Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
+      >();
+    });
 
-  test("mixed literals and generics", () => {
-    const arr: ReadonlyArray<
-      readonly ["a", 1] | readonly [`testing_${string}`, boolean]
-    > = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<
-      Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
-    >();
-    expect(result).toStrictEqual({ a: 1 });
-  });
+    test("array with literal keys", () => {
+      const arr: Array<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<
+        Partial<Record<"a" | "b" | "c", "d">>
+      >();
+    });
 
-  test("array with literal keys", () => {
-    const arr: ReadonlyArray<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Partial<Record<"a" | "b" | "c", "d">>>();
-    expect(result).toStrictEqual({ a: "d" });
-  });
+    test("backwards compatibility (number)", () => {
+      const arr: Array<[number, 123]> = [[1, 123]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
+    });
 
-  test("backwards compatibility (number)", () => {
-    const arr: ReadonlyArray<readonly [number, 123]> = [[1, 123]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
-    expect(result).toStrictEqual({ 1: 123 });
-  });
-
-  test("backwards compatibility (string)", () => {
-    const arr: ReadonlyArray<readonly [string, 123]> = [["a", 123]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
-    expect(result).toStrictEqual({ a: 123 });
-  });
-});
-
-describe("Strict (with non-readonly inputs)", () => {
-  test("trivial empty case", () => {
-    const result = fromEntries([]);
-    expectTypeOf(result).toEqualTypeOf({} as const);
-    expect(result).toStrictEqual({});
-  });
-
-  test("trivial single entry const case", () => {
-    const result = fromEntries([["a", 1]]);
-    expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
-
-  test("trivial multi entry const case", () => {
-    const result = fromEntries([
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ]);
-    expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
-    expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
-  });
-
-  test("runtime empty well defined array", () => {
-    const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({});
-  });
-
-  test("runtime single value well defined array", () => {
-    const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
-
-  test("runtime multi-value well defined array", () => {
-    const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [
-      ["a", 1],
-      ["b", 2],
-      ["c", 3],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
-  });
-
-  test("runtime mixed tuple with rest (first)", () => {
-    const arr: [["a", 1], ...Array<["b", 2] | ["c", 3]>] = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
-
-  test("runtime mixed tuple with rest (last)", () => {
-    const arr: [...Array<["b", 2] | ["c", 3]>, ["a", 1]] = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
-    expect(result).toStrictEqual({ a: 1 });
-  });
-
-  test("runtime empty generic type", () => {
-    const arr: Array<[string, boolean]> = [];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({});
-  });
-
-  test("runtime single value generic type", () => {
-    const arr: Array<[string, boolean]> = [["hello", true]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({ hello: true });
-  });
-
-  test("runtime multi-value generic type", () => {
-    const arr: Array<[string, boolean]> = [
-      ["hello", true],
-      ["world", false],
-    ];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    expect(result).toStrictEqual({ hello: true, world: false });
-  });
-
-  test("mixed literals and generics", () => {
-    const arr: Array<["a", 1] | [`testing_${string}`, boolean]> = [["a", 1]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toMatchTypeOf<
-      Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
-    >();
-    expect(result).toStrictEqual({ a: 1 });
-  });
-
-  test("array with literal keys", () => {
-    const arr: Array<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Partial<Record<"a" | "b" | "c", "d">>>();
-    expect(result).toStrictEqual({ a: "d" });
-  });
-
-  test("backwards compatibility (number)", () => {
-    const arr: Array<[number, 123]> = [[1, 123]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
-    expect(result).toStrictEqual({ 1: 123 });
-  });
-
-  test("backwards compatibility (string)", () => {
-    const arr: Array<[string, 123]> = [["a", 123]];
-    const result = fromEntries(arr);
-    expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
-    expect(result).toStrictEqual({ a: 123 });
+    test("backwards compatibility (string)", () => {
+      const arr: Array<[string, 123]> = [["a", 123]];
+      const result = fromEntries(arr);
+      expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
+    });
   });
 });

--- a/src/fromEntries.test.ts
+++ b/src/fromEntries.test.ts
@@ -21,30 +21,23 @@ describe("typings", () => {
     const actual = fromEntries(tuples);
     assertType<Record<string, number>>(actual);
   });
-  test("arrays with mixed type value", () => {
-    const actual = fromEntries<number | string>([
-      ["a", 2],
-      ["b", "c"],
-    ]);
-    assertType<Record<string, number | string>>(actual);
-  });
 });
 
 describe("Strict (with readonly inputs)", () => {
   test("trivial empty case", () => {
-    const result = fromEntries.strict([] as const);
+    const result = fromEntries([] as const);
     expectTypeOf(result).toEqualTypeOf({} as const);
     expect(result).toStrictEqual({});
   });
 
   test("trivial single entry const case", () => {
-    const result = fromEntries.strict([["a", 1]] as const);
+    const result = fromEntries([["a", 1]] as const);
     expectTypeOf(result).toMatchTypeOf<{ a: 1 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
 
   test("trivial multi entry const case", () => {
-    const result = fromEntries.strict([
+    const result = fromEntries([
       ["a", 1],
       ["b", 2],
       ["c", 3],
@@ -55,14 +48,14 @@ describe("Strict (with readonly inputs)", () => {
 
   test("runtime empty well defined array", () => {
     const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({});
   });
 
   test("runtime single value well defined array", () => {
     const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
@@ -73,7 +66,7 @@ describe("Strict (with readonly inputs)", () => {
       ["b", 2],
       ["c", 3],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
   });
@@ -82,7 +75,7 @@ describe("Strict (with readonly inputs)", () => {
     const arr: readonly [["a", 1], ...ReadonlyArray<["b", 2] | ["c", 3]>] = [
       ["a", 1],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
@@ -91,21 +84,21 @@ describe("Strict (with readonly inputs)", () => {
     const arr: readonly [...ReadonlyArray<["b", 2] | ["c", 3]>, ["a", 1]] = [
       ["a", 1],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
 
   test("runtime empty generic type", () => {
     const arr: ReadonlyArray<readonly [string, boolean]> = [];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({});
   });
 
   test("runtime single value generic type", () => {
     const arr: ReadonlyArray<readonly [string, boolean]> = [["hello", true]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({ hello: true });
   });
@@ -115,7 +108,7 @@ describe("Strict (with readonly inputs)", () => {
       ["hello", true],
       ["world", false],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({ hello: true, world: false });
   });
@@ -124,7 +117,7 @@ describe("Strict (with readonly inputs)", () => {
     const arr: ReadonlyArray<
       readonly ["a", 1] | readonly [`testing_${string}`, boolean]
     > = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<
       Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
     >();
@@ -133,21 +126,21 @@ describe("Strict (with readonly inputs)", () => {
 
   test("array with literal keys", () => {
     const arr: ReadonlyArray<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Partial<Record<"a" | "b" | "c", "d">>>();
     expect(result).toStrictEqual({ a: "d" });
   });
 
   test("backwards compatibility (number)", () => {
     const arr: ReadonlyArray<readonly [number, 123]> = [[1, 123]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
     expect(result).toStrictEqual({ 1: 123 });
   });
 
   test("backwards compatibility (string)", () => {
     const arr: ReadonlyArray<readonly [string, 123]> = [["a", 123]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
     expect(result).toStrictEqual({ a: 123 });
   });
@@ -155,19 +148,19 @@ describe("Strict (with readonly inputs)", () => {
 
 describe("Strict (with non-readonly inputs)", () => {
   test("trivial empty case", () => {
-    const result = fromEntries.strict([]);
+    const result = fromEntries([]);
     expectTypeOf(result).toEqualTypeOf({} as const);
     expect(result).toStrictEqual({});
   });
 
   test("trivial single entry const case", () => {
-    const result = fromEntries.strict([["a", 1]]);
+    const result = fromEntries([["a", 1]]);
     expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
     expect(result).toStrictEqual({ a: 1 });
   });
 
   test("trivial multi entry const case", () => {
-    const result = fromEntries.strict([
+    const result = fromEntries([
       ["a", 1],
       ["b", 2],
       ["c", 3],
@@ -178,14 +171,14 @@ describe("Strict (with non-readonly inputs)", () => {
 
   test("runtime empty well defined array", () => {
     const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({});
   });
 
   test("runtime single value well defined array", () => {
     const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
@@ -196,35 +189,35 @@ describe("Strict (with non-readonly inputs)", () => {
       ["b", 2],
       ["c", 3],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1, b: 2, c: 3 });
   });
 
   test("runtime mixed tuple with rest (first)", () => {
     const arr: [["a", 1], ...Array<["b", 2] | ["c", 3]>] = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
 
   test("runtime mixed tuple with rest (last)", () => {
     const arr: [...Array<["b", 2] | ["c", 3]>, ["a", 1]] = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     expect(result).toStrictEqual({ a: 1 });
   });
 
   test("runtime empty generic type", () => {
     const arr: Array<[string, boolean]> = [];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({});
   });
 
   test("runtime single value generic type", () => {
     const arr: Array<[string, boolean]> = [["hello", true]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({ hello: true });
   });
@@ -234,14 +227,14 @@ describe("Strict (with non-readonly inputs)", () => {
       ["hello", true],
       ["world", false],
     ];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     expect(result).toStrictEqual({ hello: true, world: false });
   });
 
   test("mixed literals and generics", () => {
     const arr: Array<["a", 1] | [`testing_${string}`, boolean]> = [["a", 1]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toMatchTypeOf<
       Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
     >();
@@ -250,21 +243,21 @@ describe("Strict (with non-readonly inputs)", () => {
 
   test("array with literal keys", () => {
     const arr: Array<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Partial<Record<"a" | "b" | "c", "d">>>();
     expect(result).toStrictEqual({ a: "d" });
   });
 
   test("backwards compatibility (number)", () => {
     const arr: Array<[number, 123]> = [[1, 123]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
     expect(result).toStrictEqual({ 1: 123 });
   });
 
   test("backwards compatibility (string)", () => {
     const arr: Array<[string, 123]> = [["a", 123]];
-    const result = fromEntries.strict(arr);
+    const result = fromEntries(arr);
     expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
     expect(result).toStrictEqual({ a: 123 });
   });

--- a/src/fromEntries.test.ts
+++ b/src/fromEntries.test.ts
@@ -9,7 +9,7 @@ describe("runtime", () => {
         ["b", 2],
         ["c", 3],
       ]),
-    ).toEqual({ a: 1, b: 2, c: 3 });
+    ).toStrictEqual({ a: 1, b: 2, c: 3 });
   });
 
   test("dataLast", () => {
@@ -22,7 +22,7 @@ describe("runtime", () => {
         ] as const,
         fromEntries(),
       ),
-    ).toEqual({ a: 1, b: 2, c: 3 });
+    ).toStrictEqual({ a: 1, b: 2, c: 3 });
   });
 
   test("empty array", () => {
@@ -60,7 +60,7 @@ describe("typing", () => {
 
     test("trivial single entry const case", () => {
       const result = fromEntries([["a", 1]] as const);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1 }>();
     });
 
     test("trivial multi entry const case", () => {
@@ -69,7 +69,7 @@ describe("typing", () => {
         ["b", 2],
         ["c", 3],
       ] as const);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1; b: 2; c: 3 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1; b: 2; c: 3 }>();
     });
 
     test("empty well defined array", () => {
@@ -84,7 +84,7 @@ describe("typing", () => {
         ["a", 1],
         ...ReadonlyArray<["b", 2] | ["c", 3]>,
       ]);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (last)", () => {
@@ -92,7 +92,7 @@ describe("typing", () => {
         ...ReadonlyArray<["b", 2] | ["c", 3]>,
         ["a", 1],
       ]);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("empty generic type", () => {
@@ -106,9 +106,11 @@ describe("typing", () => {
       const result = fromEntries([["a", 1]] as ReadonlyArray<
         readonly ["a", 1] | readonly [`testing_${string}`, boolean]
       >);
-      expectTypeOf(result).toMatchTypeOf<
-        Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
-      >();
+
+      expectTypeOf(result).toEqualTypeOf<{
+        [x: `testing_${string}`]: boolean | undefined;
+        a?: 1;
+      }>();
     });
 
     test("array with literal keys", () => {
@@ -143,7 +145,7 @@ describe("typing", () => {
 
     test("trivial single entry const case", () => {
       const result = fromEntries([["a", 1]]);
-      expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
+      expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
     });
 
     test("trivial multi entry const case", () => {
@@ -152,7 +154,7 @@ describe("typing", () => {
         ["b", 2],
         ["c", 3],
       ]);
-      expectTypeOf(result).toMatchTypeOf<Record<string, number>>();
+      expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
     });
 
     test("empty well defined array", () => {
@@ -165,7 +167,7 @@ describe("typing", () => {
         ["a", 1],
         ...Array<["b", 2] | ["c", 3]>,
       ]);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (last)", () => {
@@ -173,7 +175,7 @@ describe("typing", () => {
         ...Array<["b", 2] | ["c", 3]>,
         ["a", 1],
       ]);
-      expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
+      expectTypeOf(result).toEqualTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("empty generic type", () => {
@@ -185,9 +187,10 @@ describe("typing", () => {
       const result = fromEntries([["a", 1]] as Array<
         ["a", 1] | [`testing_${string}`, boolean]
       >);
-      expectTypeOf(result).toMatchTypeOf<
-        Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
-      >();
+      expectTypeOf(result).toEqualTypeOf<{
+        [x: `testing_${string}`]: boolean | undefined;
+        a?: 1;
+      }>();
     });
 
     test("array with literal keys", () => {

--- a/src/fromEntries.test.ts
+++ b/src/fromEntries.test.ts
@@ -25,29 +25,15 @@ describe("runtime", () => {
     ).toEqual({ a: 1, b: 2, c: 3 });
   });
 
-  test("trivial empty case", () => {
+  test("empty array", () => {
     expect(fromEntries([])).toStrictEqual({});
   });
 
-  test("trivial single entry const case", () => {
+  test("Single entry", () => {
     expect(fromEntries([["a", 1]])).toStrictEqual({ a: 1 });
   });
 
-  test("trivial multi entry const case", () => {
-    expect(
-      fromEntries([
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-      ] as const),
-    ).toStrictEqual({ a: 1, b: 2, c: 3 });
-  });
-
-  test("single value generic type", () => {
-    expect(fromEntries([["hello", true]])).toStrictEqual({ hello: true });
-  });
-
-  test("multi-value generic type", () => {
+  test("boolean values", () => {
     expect(
       fromEntries([
         ["hello", true],
@@ -56,29 +42,12 @@ describe("runtime", () => {
     ).toStrictEqual({ hello: true, world: false });
   });
 
-  test("array with literal keys", () => {
+  test("string values", () => {
     expect(fromEntries([["a", "d"]])).toStrictEqual({ a: "d" });
   });
 
-  test("backwards compatibility (number)", () => {
+  test("number keys and values", () => {
     expect(fromEntries([[1, 123]])).toStrictEqual({ 1: 123 });
-  });
-
-  test("backwards compatibility (string)", () => {
-    expect(fromEntries([["a", 123]])).toStrictEqual({ a: 123 });
-  });
-
-  test("single value generic type", () => {
-    expect(fromEntries([["hello", true]])).toStrictEqual({ hello: true });
-  });
-
-  test("multi-value generic type", () => {
-    expect(
-      fromEntries([
-        ["hello", true],
-        ["world", false],
-      ]),
-    ).toStrictEqual({ hello: true, world: false });
   });
 });
 
@@ -104,91 +73,64 @@ describe("typing", () => {
     });
 
     test("empty well defined array", () => {
-      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    });
-
-    test("single value well defined array", () => {
-      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    });
-
-    test("multi-value well defined array", () => {
-      const arr: ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]> = [
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-      ];
-      const result = fromEntries(arr);
+      const result = fromEntries(
+        [] as ReadonlyArray<["a", 1] | ["b", 2] | ["c", 3]>,
+      );
       expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (first)", () => {
-      const arr: readonly [["a", 1], ...ReadonlyArray<["b", 2] | ["c", 3]>] = [
+      const result = fromEntries([["a", 1]] as readonly [
         ["a", 1],
-      ];
-      const result = fromEntries(arr);
+        ...ReadonlyArray<["b", 2] | ["c", 3]>,
+      ]);
       expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (last)", () => {
-      const arr: readonly [...ReadonlyArray<["b", 2] | ["c", 3]>, ["a", 1]] = [
+      const result = fromEntries([["a", 1]] as readonly [
+        ...ReadonlyArray<["b", 2] | ["c", 3]>,
         ["a", 1],
-      ];
-      const result = fromEntries(arr);
+      ]);
       expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("empty generic type", () => {
-      const arr: ReadonlyArray<readonly [string, boolean]> = [];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    });
-
-    test("single value generic type", () => {
-      const arr: ReadonlyArray<readonly [string, boolean]> = [["hello", true]];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    });
-
-    test("multi-value generic type", () => {
-      const arr: ReadonlyArray<readonly [string, boolean]> = [
-        ["hello", true],
-        ["world", false],
-      ];
-      const result = fromEntries(arr);
+      const result = fromEntries(
+        [] as ReadonlyArray<readonly [string, boolean]>,
+      );
       expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     });
 
     test("mixed literals and generics", () => {
-      const arr: ReadonlyArray<
+      const result = fromEntries([["a", 1]] as ReadonlyArray<
         readonly ["a", 1] | readonly [`testing_${string}`, boolean]
-      > = [["a", 1]];
-      const result = fromEntries(arr);
+      >);
       expectTypeOf(result).toMatchTypeOf<
         Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
       >();
     });
 
     test("array with literal keys", () => {
-      const arr: ReadonlyArray<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", "d"]] as ReadonlyArray<
+        readonly ["a" | "b" | "c", "d"]
+      >);
       expectTypeOf(result).toEqualTypeOf<
         Partial<Record<"a" | "b" | "c", "d">>
       >();
     });
 
     test("backwards compatibility (number)", () => {
-      const arr: ReadonlyArray<readonly [number, 123]> = [[1, 123]];
-      const result = fromEntries(arr);
+      const result = fromEntries([[1, 123]] as ReadonlyArray<
+        readonly [number, 123]
+      >);
       expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
     });
 
     test("backwards compatibility (string)", () => {
-      const arr: ReadonlyArray<readonly [string, 123]> = [["a", 123]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", 123]] as ReadonlyArray<
+        readonly [string, 123]
+      >);
       expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
     });
   });
@@ -214,85 +156,56 @@ describe("typing", () => {
     });
 
     test("empty well defined array", () => {
-      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    });
-
-    test("single value well defined array", () => {
-      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [["a", 1]];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
-    });
-
-    test("multi-value well defined array", () => {
-      const arr: Array<["a", 1] | ["b", 2] | ["c", 3]> = [
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-      ];
-      const result = fromEntries(arr);
+      const result = fromEntries([] as Array<["a", 1] | ["b", 2] | ["c", 3]>);
       expectTypeOf(result).toEqualTypeOf<{ a?: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (first)", () => {
-      const arr: [["a", 1], ...Array<["b", 2] | ["c", 3]>] = [["a", 1]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", 1]] as [
+        ["a", 1],
+        ...Array<["b", 2] | ["c", 3]>,
+      ]);
       expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("mixed tuple with rest (last)", () => {
-      const arr: [...Array<["b", 2] | ["c", 3]>, ["a", 1]] = [["a", 1]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", 1]] as [
+        ...Array<["b", 2] | ["c", 3]>,
+        ["a", 1],
+      ]);
       expectTypeOf(result).toMatchTypeOf<{ a: 1; b?: 2; c?: 3 }>();
     });
 
     test("empty generic type", () => {
-      const arr: Array<[string, boolean]> = [];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    });
-
-    test("single value generic type", () => {
-      const arr: Array<[string, boolean]> = [["hello", true]];
-      const result = fromEntries(arr);
-      expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
-    });
-
-    test("multi-value generic type", () => {
-      const arr: Array<[string, boolean]> = [
-        ["hello", true],
-        ["world", false],
-      ];
-      const result = fromEntries(arr);
+      const result = fromEntries([] as Array<[string, boolean]>);
       expectTypeOf(result).toEqualTypeOf<Record<string, boolean>>();
     });
 
     test("mixed literals and generics", () => {
-      const arr: Array<["a", 1] | [`testing_${string}`, boolean]> = [["a", 1]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", 1]] as Array<
+        ["a", 1] | [`testing_${string}`, boolean]
+      >);
       expectTypeOf(result).toMatchTypeOf<
         Partial<Record<`testing_${string}`, boolean>> & { a?: 1 }
       >();
     });
 
     test("array with literal keys", () => {
-      const arr: Array<readonly ["a" | "b" | "c", "d"]> = [["a", "d"]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", "d"]] as Array<
+        readonly ["a" | "b" | "c", "d"]
+      >);
       expectTypeOf(result).toEqualTypeOf<
         Partial<Record<"a" | "b" | "c", "d">>
       >();
     });
 
     test("backwards compatibility (number)", () => {
-      const arr: Array<[number, 123]> = [[1, 123]];
-      const result = fromEntries(arr);
+      const result = fromEntries([[1, 123]] as Array<[number, 123]>);
       expectTypeOf(result).toEqualTypeOf<Record<number, 123>>();
     });
 
     test("backwards compatibility (string)", () => {
-      const arr: Array<[string, 123]> = [["a", 123]];
-      const result = fromEntries(arr);
+      const result = fromEntries([["a", 123]] as Array<[string, 123]>);
       expectTypeOf(result).toEqualTypeOf<Record<string, 123>>();
     });
   });

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -120,12 +120,15 @@ export function fromEntries(): unknown {
   return purry(fromEntriesImplementation, arguments);
 }
 
-function fromEntriesImplementation(
-  entries: ReadonlyArray<Entry>,
-): Record<string, unknown> {
-  const out: Record<PropertyKey, unknown> = {};
+function fromEntriesImplementation<Entries extends IterableContainer<Entry>>(
+  entries: Entries,
+): FromEntries<Entries> {
+  const out: Partial<FromEntries<Entries>> = {};
+
   for (const [key, value] of entries) {
+    // @ts-expect-error [ts7053] - Our input is generic so typescript is having a hard time inferring this.
     out[key] = value;
   }
-  return out;
+
+  return out as FromEntries<Entries>;
 }

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -1,5 +1,6 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
+import type { Simplify } from "./type-fest/simplify";
 
 type Entry<Key extends PropertyKey = PropertyKey, Value = unknown> = readonly [
   key: Key,
@@ -93,7 +94,7 @@ type ValueForKey<
  */
 export function fromEntries<Entries extends IterableContainer<Entry>>(
   entries: Entries,
-): FromEntries<Entries>;
+): Simplify<FromEntries<Entries>>;
 
 /**
  * Creates a new object from an array of tuples by pairing up first and second
@@ -112,7 +113,7 @@ export function fromEntries<Entries extends IterableContainer<Entry>>(
  */
 export function fromEntries(): <Entries extends IterableContainer<Entry>>(
   entries: Entries,
-) => FromEntries<Entries>;
+) => Simplify<FromEntries<Entries>>;
 
 export function fromEntries(): unknown {
   // TODO: When we bump the typescript target beyond ES2019 we can use Object.fromEntries directly here instead of our user-space implementation.

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -88,7 +88,7 @@ type ValueForKey<
  * @signature
  *   R.fromEntries(tuples)
  * @example
- *   R.fromEntries(['a', 1] as const) // => {a: 1} (type: {a: 1})
+ *   R.fromEntries([['a', 'b'], ['c', 'd']]); // => {a: 'b', c: 'd'}
  * @dataFirst
  * @category Object
  */
@@ -105,9 +105,9 @@ export function fromEntries<Entries extends IterableContainer<Entry>>(
  *   R.fromEntries()(tuples)
  * @example
  *   R.pipe(
- *     ['a', 1] as const,
+ *     [['a', 'b'], ['c', 'd']] as const,
  *     R.fromEntries(),
- *   ); // => {a: 1} (type: {a: 1})
+ *   ); // => {a: 'b', c: 'd'}
  * @dataLast
  * @category Object
  */

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -58,7 +58,7 @@ type FromEntriesArray<Entries extends IterableContainer<Entry>> =
 // @see https://github.com/sindresorhus/ts-extras/blob/44f57392c5f027268330771996c4fdf9260b22d6/source/object-from-entries.ts)
 type FromEntriesArrayWithLiteralKeys<Entries extends IterableContainer<Entry>> =
   {
-    [K in AllKeys<Entries>]?: ValueForKey<Entries, K>;
+    [P in AllKeys<Entries>]?: ValueForKey<Entries, P>;
   };
 
 type AllKeys<Entries extends IterableContainer<Entry>> = Extract<

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -6,59 +6,113 @@ type Entry<Key extends PropertyKey = PropertyKey, Value = unknown> = readonly [
   value: Value,
 ];
 
-/**
- * Creates a new object from an array of tuples by pairing up first and second elements as {[key]: value}.
- * If a tuple is not supplied for any element in the array, the element will be ignored
- * If duplicate keys exist, the tuple with the greatest index in the input array will be preferred.
- *
- * The strict option supports more sophisticated use-cases like those that would
- * result when calling the strict `toPairs` function.
- *
- * @param entries - The list of input tuples.
- * @signature
- *   R.fromEntries(tuples)
- *   R.fromEntries.strict(tuples)
- * @example
- *   R.fromEntries([['a', 'b'], ['c', 'd']]) // => {a: 'b', c: 'd'} (type: Record<string, string>)
- *   R.fromEntries.strict(['a', 1] as const) // => {a: 1} (type: {a: 1})
- * @dataFirst
- * @strict
- * @category Object
- */
-export function fromEntries<V>(
-  entries: ReadonlyArray<Entry<number, V>>,
-): Record<number, V>;
-export function fromEntries<V>(
-  entries: ReadonlyArray<Entry<string, V>>,
-): Record<string, V>;
+// The 2 kinds of arrays we accept result in different kinds of outputs:
+// 1. If the input is a *tuple*, we know exactly what entries it would hold,
+// and thus can type the result so that the keys are required. We will then run
+// recursively on the rest of the tuple.
+// 2. If the input is an *array* then any keys defined in the array might not
+// actually show up in runtime, and thus need to be optional. (e.g. if the input
+// is an empty array).
+type FromEntries<Entries> = Entries extends readonly [
+  infer First,
+  ...infer Tail,
+]
+  ? FromEntriesTuple<First, Tail>
+  : Entries extends readonly [...infer Head, infer Last]
+    ? FromEntriesTuple<Last, Head>
+    : Entries extends IterableContainer<Entry>
+      ? FromEntriesArray<Entries>
+      : "ERROR: Entries array-like could not be inferred";
+
+// For strict tuples we build the result by intersecting each entry as a record
+// between it's key and value, recursively. The recursion goes through our main
+// type so that we support tuples which also contain rest parts.
+type FromEntriesTuple<E, Rest> = E extends Entry
+  ? Record<E[0], E[1]> & FromEntries<Rest>
+  : "ERROR: Array-like contains a non-entry element";
+
+// For the array case we also need to handle what kind of keys it defines:
+// 1. If it defines a *broad* key (one that has an infinite set of values, like
+// number or string) then the result is a simple record.
+// 2. If the keys are *literals* then we need to make the record partial
+// (because those props are explicit), and we need to match each key it's
+// specific possible value, as defined by the entries.
+//
+// Note that this destination between keys is the result of how typescript
+// considers Record<string, unknown> to be **implicitly** partial, whereas
+// Record<"a", unknown> is not.
+type FromEntriesArray<Entries extends IterableContainer<Entry>> =
+  string extends AllKeys<Entries>
+    ? Record<string, Entries[number][1]>
+    : number extends AllKeys<Entries>
+      ? Record<number, Entries[number][1]>
+      : symbol extends AllKeys<Entries>
+        ? Record<symbol, Entries[number][1]>
+        : FromEntriesArrayWithLiteralKeys<Entries>;
+
+// This type is largely copied from `objectFromEntries` in the repo:
+// *sindresorhus/ts-extras* but makes all properties of the output optional,
+// which is more correct because we can't assure that an entry will exist for
+// every possible prop/key of the input.
+// @see https://github.com/sindresorhus/ts-extras/blob/44f57392c5f027268330771996c4fdf9260b22d6/source/object-from-entries.ts)
+type FromEntriesArrayWithLiteralKeys<Entries extends IterableContainer<Entry>> =
+  {
+    [K in AllKeys<Entries>]?: ValueForKey<Entries, K>;
+  };
+
+type AllKeys<Entries extends IterableContainer<Entry>> = Extract<
+  Entries[number],
+  Entry
+>[0];
+
+// I tried and failed to simplify the type here! What the ternary does here is
+// to support the cases where the entries are defined by a single type that
+// defines all entries, but it defines the keys as a union of literals
+// (`['a' | 'b', number]`); which is different from the output of toPairs
+// which would define a separate tuple literal for each key (`['a', number] |
+// ['b', number]`). We need to support both cases!
+type ValueForKey<
+  Entries extends IterableContainer<Entry>,
+  K extends PropertyKey,
+> = (Extract<Entries[number], Entry<K>> extends never
+  ? Entries[number]
+  : Extract<Entries[number], Entry<K>>)[1];
 
 /**
- * Creates a new object from an array of tuples by pairing up first and second elements as {[key]: value}.
- * If a tuple is not supplied for any element in the array, the element will be ignored
- * If duplicate keys exist, the tuple with the greatest index in the input array will be preferred.
+ * Creates a new object from an array of tuples by pairing up first and second
+ * elements as `{ [key]: value }`. If duplicate keys exist, the tuple with the
+ * greatest index in the input array will be preferred.
  *
- * The strict option supports more sophisticated use-cases like those that would
- * result when calling the strict `toPairs` function.
+ * @param entries - An array of key-value pairs.
+ * @signature
+ *   R.fromEntries(tuples)
+ * @example
+ *   R.fromEntries(['a', 1] as const) // => {a: 1} (type: {a: 1})
+ * @dataFirst
+ * @category Object
+ */
+export function fromEntries<Entries extends IterableContainer<Entry>>(
+  entries: Entries,
+): FromEntries<Entries>;
+
+/**
+ * Creates a new object from an array of tuples by pairing up first and second
+ * elements as `{ [key]: value }`. If duplicate keys exist, the tuple with the
+ * greatest index in the input array will be preferred.
  *
  * @signature
  *   R.fromEntries()(tuples)
- *   R.fromEntries.strict()(tuples)
  * @example
  *   R.pipe(
- *     [['a', 'b'], ['c', 'd']],
- *     R.fromEntries(),
- *   ); // => {a: 'b', c: 'd'} (type: Record<string, string>)
- *   R.pipe(
  *     ['a', 1] as const,
- *     R.fromEntries.strict(),
+ *     R.fromEntries(),
  *   ); // => {a: 1} (type: {a: 1})
  * @dataLast
- * @strict
  * @category Object
  */
-export function fromEntries(): <K extends PropertyKey, V>(
-  entries: ReadonlyArray<Entry<K, V>>,
-) => Record<K extends string ? string : K extends number ? number : never, V>;
+export function fromEntries(): <Entries extends IterableContainer<Entry>>(
+  entries: Entries,
+) => FromEntries<Entries>;
 
 export function fromEntries(): unknown {
   // TODO: When we bump the typescript target beyond ES2019 we can use Object.fromEntries directly here instead of our user-space implementation.
@@ -73,91 +127,4 @@ function fromEntriesImplementation(
     out[key] = value;
   }
   return out;
-}
-
-// Redefining the fromEntries function to allow stricter entries arrays and
-// fine-grained handling of partiality of the output.
-type Strict = {
-  <Entries extends IterableContainer<Entry>>(
-    entries: Entries,
-  ): StrictOut<Entries>;
-
-  (): <Entries extends IterableContainer<Entry>>(
-    entries: Entries,
-  ) => StrictOut<Entries>;
-};
-
-// The 2 kinds of arrays we accept result in different kinds of outputs:
-// 1. If the input is a *tuple*, we know exactly what entries it would hold,
-// and thus can type the result so that the keys are required. We will then run
-// recursively on the rest of the tuple.
-// 2. If the input is an *array* then any keys defined in the array might not
-// actually show up in runtime, and thus need to be optional. (e.g. if the input
-// is an empty array).
-type StrictOut<Entries> = Entries extends readonly [infer First, ...infer Tail]
-  ? fromEntriesTuple<First, Tail>
-  : Entries extends readonly [...infer Head, infer Last]
-    ? fromEntriesTuple<Last, Head>
-    : Entries extends IterableContainer<Entry>
-      ? fromEntriesArray<Entries>
-      : "ERROR: Entries array-like could not be inferred";
-
-// For strict tuples we build the result by intersecting each entry as a record
-// between it's key and value, recursively. The recursion goes through our main
-// type so that we support tuples which also contain rest parts.
-type fromEntriesTuple<E, Rest> = E extends Entry
-  ? Record<E[0], E[1]> & StrictOut<Rest>
-  : "ERROR: Array-like contains a non-entry element";
-
-// For the array case we also need to handle what kind of keys it defines:
-// 1. If it defines a *broad* key (one that has an infinite set of values, like
-// number or string) then the result is a simple record.
-// 2. If the keys are *literals* then we need to make the record partial
-// (because those props are explicit), and we need to match each key it's
-// specific possible value, as defined by the entries.
-//
-// Note that this destination between keys is the result of how typescript
-// considers Record<string, unknown> to be **implicitly** partial, whereas
-// Record<"a", unknown> is not.
-type fromEntriesArray<Entries extends IterableContainer<Entry>> =
-  string extends AllKeys<Entries>
-    ? Record<string, Entries[number][1]>
-    : number extends AllKeys<Entries>
-      ? Record<number, Entries[number][1]>
-      : symbol extends AllKeys<Entries>
-        ? Record<symbol, Entries[number][1]>
-        : fromEntriesArrayWithLiteralKeys<Entries>;
-
-// This type is largely copied from `objectFromEntries` in the repo:
-// *sindresorhus/ts-extras* but makes all properties of the output optional,
-// which is more correct because we can't assure that an entry will exist for
-// every possible prop/key of the input.
-// @see https://github.com/sindresorhus/ts-extras/blob/44f57392c5f027268330771996c4fdf9260b22d6/source/object-from-entries.ts)
-type fromEntriesArrayWithLiteralKeys<Entries extends IterableContainer<Entry>> =
-  {
-    [K in AllKeys<Entries>]?: ValueForKey<Entries, K>;
-  };
-
-type AllKeys<Entries extends IterableContainer<Entry>> = Extract<
-  Entries[number],
-  Entry
->[0];
-
-type ValueForKey<
-  Entries extends IterableContainer<Entry>,
-  K extends PropertyKey,
-> =
-  // I tried and failed to simplify the type here! What the ternary does here is
-  // to support the cases where the entries are defined by a single type that
-  // defines all entries, but it defines the keys as a union of literals
-  // (`['a' | 'b', number]`); which is different from the output of toPairs
-  // which would define a separate tuple literal for each key (`['a', number] |
-  // ['b', number]`). We need to support both cases!
-  (Extract<Entries[number], Entry<K>> extends never
-    ? Entries[number]
-    : Extract<Entries[number], Entry<K>>)[1];
-
-export namespace fromEntries {
-  // Strict is simply a retyping of fromEntries, it runs the same runtime logic.
-  export const strict = fromEntries as Strict;
 }

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -28,7 +28,7 @@ type FromEntries<Entries> = Entries extends readonly [
 // between it's key and value, recursively. The recursion goes through our main
 // type so that we support tuples which also contain rest parts.
 type FromEntriesTuple<E, Rest> = E extends Entry
-  ? Record<E[0], E[1]> & FromEntries<Rest>
+  ? FromEntries<Rest> & Record<E[0], E[1]>
   : "ERROR: Array-like contains a non-entry element";
 
 // For the array case we also need to handle what kind of keys it defines:

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -1,104 +1,224 @@
 import type { NonEmptyArray } from "./_types";
 import { groupBy } from "./groupBy";
 import { pipe } from "./pipe";
+import { prop } from "./prop";
 
-const array = [
-  { a: 1, b: 1 },
-  { a: 1, b: 2 },
-  { a: 2, b: 1 },
-  { a: 1, b: 3 },
-] as const;
-const expected = {
-  1: [
-    { a: 1, b: 1 },
-    { a: 1, b: 2 },
-    { a: 1, b: 3 },
-  ],
-  2: [{ a: 2, b: 1 }],
-};
+describe("runtime", () => {
+  describe("data first", () => {
+    test("groupBy", () => {
+      expect(
+        groupBy(
+          [
+            { a: 1, b: 1 },
+            { a: 1, b: 2 },
+            { a: 2, b: 1 },
+            { a: 1, b: 3 },
+          ],
+          prop("a"),
+        ),
+      ).toEqual({
+        1: [
+          { a: 1, b: 1 },
+          { a: 1, b: 2 },
+          { a: 1, b: 3 },
+        ],
+        2: [{ a: 2, b: 1 }],
+      });
+    });
 
-const array2 = [
-  { a: "cat", b: 123 },
-  { a: "dog", b: 456 },
-] as const;
-type Array2Item = (typeof array2)[number];
-
-describe("data first", () => {
-  test("groupBy", () => {
-    expect(groupBy(array, (x) => x.a)).toEqual(expected);
+    test("groupBy.indexed", () => {
+      expect(
+        groupBy.indexed(
+          [
+            { a: 1, b: 1 },
+            { a: 1, b: 2 },
+            { a: 2, b: 1 },
+            { a: 1, b: 3 },
+          ],
+          prop("a"),
+        ),
+      ).toEqual({
+        1: [
+          { a: 1, b: 1 },
+          { a: 1, b: 2 },
+          { a: 1, b: 3 },
+        ],
+        2: [{ a: 2, b: 1 }],
+      });
+    });
   });
-  test("groupBy.indexed", () => {
-    expect(groupBy.indexed(array, (x) => x.a)).toEqual(expected);
+
+  describe("data last", () => {
+    test("groupBy", () => {
+      expect(
+        pipe(
+          [
+            { a: 1, b: 1 },
+            { a: 1, b: 2 },
+            { a: 2, b: 1 },
+            { a: 1, b: 3 },
+          ],
+          groupBy(prop("a")),
+        ),
+      ).toEqual({
+        1: [
+          { a: 1, b: 1 },
+          { a: 1, b: 2 },
+          { a: 1, b: 3 },
+        ],
+        2: [{ a: 2, b: 1 }],
+      });
+    });
+
+    test("groupBy.indexed", () => {
+      expect(
+        pipe(
+          [
+            { a: 1, b: 1 },
+            { a: 1, b: 2 },
+            { a: 2, b: 1 },
+            { a: 1, b: 3 },
+          ],
+          groupBy.indexed(prop("a")),
+        ),
+      ).toEqual({
+        1: [
+          { a: 1, b: 1 },
+          { a: 1, b: 2 },
+          { a: 1, b: 3 },
+        ],
+        2: [{ a: 2, b: 1 }],
+      });
+    });
+  });
+
+  describe("Filtering on undefined grouper result", () => {
+    // These tests use a contrived example that is basically a simple filter. The
+    // goal of these tests is to make sure that all flavours of the function
+    // accept an undefined return value for the grouper function, and that it
+    // works in all the cases, including the typing.
+
+    test("regular", () => {
+      const result = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
+        x % 2 === 0 ? "even" : undefined,
+      );
+      expect(Object.values(result)).toHaveLength(1);
+      expect(result.even).toEqual([0, 2, 4, 6, 8]);
+    });
+
+    test("regular indexed", () => {
+      const result = groupBy.indexed(
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+        (_, index) => (index % 2 === 0 ? "even" : undefined),
+      );
+      expect(Object.values(result)).toHaveLength(1);
+      expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
+    });
   });
 });
 
-describe("data last", () => {
-  test("groupBy", () => {
-    expect(
-      pipe(
-        array,
-        groupBy((x) => x.a),
-      ),
-    ).toEqual(expected);
-  });
-  test("groupBy.indexed", () => {
-    expect(
-      pipe(
-        array,
-        groupBy.indexed((x) => x.a),
-      ),
-    ).toEqual(expected);
-  });
-});
-
-describe("Result key types", () => {
+describe("typing", () => {
   test("Union of string literals", () => {
-    const data = groupBy(array2, (x) => x.a);
+    const data = groupBy(
+      [
+        { a: "cat", b: 123 },
+        { a: "dog", b: 456 },
+      ] as const,
+      prop("a"),
+    );
 
-    assertType<Partial<Record<"cat" | "dog", NonEmptyArray<Array2Item>>>>(data);
+    expectTypeOf(data).toEqualTypeOf<
+      Partial<
+        Record<
+          "cat" | "dog",
+          NonEmptyArray<
+            | { readonly a: "cat"; readonly b: 123 }
+            | { readonly a: "dog"; readonly b: 456 }
+          >
+        >
+      >
+    >();
   });
+
   test("Union of number literals", () => {
-    const data = groupBy(array2, (x) => x.b);
-    assertType<Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>>(data);
+    const data = groupBy(
+      [
+        { a: "cat", b: 123 },
+        { a: "dog", b: 456 },
+      ] as const,
+      prop("b"),
+    );
+    expectTypeOf(data).toEqualTypeOf<
+      Partial<
+        Record<
+          123 | 456,
+          NonEmptyArray<
+            | { readonly a: "cat"; readonly b: 123 }
+            | { readonly a: "dog"; readonly b: 456 }
+          >
+        >
+      >
+    >();
   });
+
   test("string", () => {
-    const data = groupBy(array2, (x): string => x.a);
-    assertType<Record<string, NonEmptyArray<Array2Item>>>(data);
+    const data = groupBy(
+      [
+        { a: "cat", b: 123 },
+        { a: "dog", b: 456 },
+      ] as const,
+      (x): string => x.a,
+    );
+    expectTypeOf(data).toEqualTypeOf<
+      Record<
+        string,
+        NonEmptyArray<
+          | { readonly a: "cat"; readonly b: 123 }
+          | { readonly a: "dog"; readonly b: 456 }
+        >
+      >
+    >();
   });
+
   test("number", () => {
-    const data = groupBy(array2, (x): number => x.b);
-    assertType<Record<number, NonEmptyArray<Array2Item>>>(data);
+    const data = groupBy(
+      [
+        { a: "cat", b: 123 },
+        { a: "dog", b: 456 },
+      ] as const,
+      (x): number => x.b,
+    );
+    expectTypeOf(data).toEqualTypeOf<
+      Record<
+        number,
+        NonEmptyArray<
+          | { readonly a: "cat"; readonly b: 123 }
+          | { readonly a: "dog"; readonly b: 456 }
+        >
+      >
+    >();
   });
+
   test("string | number", () => {
-    const data = groupBy(array2, (x): number | string => x.b);
-    assertType<Record<number | string, NonEmptyArray<Array2Item>>>(data);
-  });
-});
-
-describe("Filtering on undefined grouper result", () => {
-  // These tests use a contrived example that is basically a simple filter. The
-  // goal of these tests is to make sure that all flavours of the function
-  // accept an undefined return value for the grouper function, and that it
-  // works in all the cases, including the typing.
-
-  test("regular", () => {
-    const result = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
-      x % 2 === 0 ? "even" : undefined,
+    const data = groupBy(
+      [
+        { a: "cat", b: 123 },
+        { a: "dog", b: 456 },
+      ] as const,
+      (x): number | string => x.b,
     );
-    expect(Object.values(result)).toHaveLength(1);
-    expect(result.even).toEqual([0, 2, 4, 6, 8]);
+    expectTypeOf(data).toEqualTypeOf<
+      Record<
+        number | string,
+        NonEmptyArray<
+          | { readonly a: "cat"; readonly b: 123 }
+          | { readonly a: "dog"; readonly b: 456 }
+        >
+      >
+    >();
   });
 
-  test("regular indexed", () => {
-    const result = groupBy.indexed(
-      ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
-      (_, index) => (index % 2 === 0 ? "even" : undefined),
-    );
-    expect(Object.values(result)).toHaveLength(1);
-    expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
-  });
-
-  describe("typing", () => {
+  describe("Filtering on undefined grouper result", () => {
     test("regular", () => {
       const { even, ...rest } = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
         x % 2 === 0 ? "even" : undefined,

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -53,24 +53,24 @@ describe("data last", () => {
 
 describe("Result key types", () => {
   test("Union of string literals", () => {
-    const data = groupBy.strict(array2, (x) => x.a);
+    const data = groupBy(array2, (x) => x.a);
 
     assertType<Partial<Record<"cat" | "dog", NonEmptyArray<Array2Item>>>>(data);
   });
   test("Union of number literals", () => {
-    const data = groupBy.strict(array2, (x) => x.b);
+    const data = groupBy(array2, (x) => x.b);
     assertType<Partial<Record<123 | 456, NonEmptyArray<Array2Item>>>>(data);
   });
   test("string", () => {
-    const data = groupBy.strict(array2, (x): string => x.a);
+    const data = groupBy(array2, (x): string => x.a);
     assertType<Record<string, NonEmptyArray<Array2Item>>>(data);
   });
   test("number", () => {
-    const data = groupBy.strict(array2, (x): number => x.b);
+    const data = groupBy(array2, (x): number => x.b);
     assertType<Record<number, NonEmptyArray<Array2Item>>>(data);
   });
   test("string | number", () => {
-    const data = groupBy.strict(array2, (x): number | string => x.b);
+    const data = groupBy(array2, (x): number | string => x.b);
     assertType<Record<number | string, NonEmptyArray<Array2Item>>>(data);
   });
 });
@@ -87,8 +87,7 @@ describe("Filtering on undefined grouper result", () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty("even");
-    // eslint-disable-next-line dot-notation
-    expect(result["even"]).toEqual([0, 2, 4, 6, 8]);
+    expect(result.even).toEqual([0, 2, 4, 6, 8]);
   });
 
   test("regular indexed", () => {
@@ -98,21 +97,19 @@ describe("Filtering on undefined grouper result", () => {
     );
     expect(Object.values(result)).toHaveLength(1);
     expect(result).toHaveProperty("even");
-    // eslint-disable-next-line dot-notation
-    expect(result["even"]).toEqual(["a", "c", "e", "g", "i"]);
+    expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
   });
 
   test("strict", () => {
-    const { even, ...rest } = groupBy.strict(
-      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      (x) => (x % 2 === 0 ? "even" : undefined),
+    const { even, ...rest } = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
+      x % 2 === 0 ? "even" : undefined,
     );
     expectTypeOf(rest).toEqualTypeOf({} as const);
     expect(even).toEqual([0, 2, 4, 6, 8]);
   });
 
   test("strict indexed", () => {
-    const { even, ...rest } = groupBy.strict.indexed(
+    const { even, ...rest } = groupBy.indexed(
       ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
       (_, index) => (index % 2 === 0 ? "even" : undefined),
     );

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -86,7 +86,6 @@ describe("Filtering on undefined grouper result", () => {
       x % 2 === 0 ? "even" : undefined,
     );
     expect(Object.values(result)).toHaveLength(1);
-    expect(result).toHaveProperty("even");
     expect(result.even).toEqual([0, 2, 4, 6, 8]);
   });
 
@@ -96,24 +95,23 @@ describe("Filtering on undefined grouper result", () => {
       (_, index) => (index % 2 === 0 ? "even" : undefined),
     );
     expect(Object.values(result)).toHaveLength(1);
-    expect(result).toHaveProperty("even");
     expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
   });
 
-  test("strict", () => {
-    const { even, ...rest } = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
-      x % 2 === 0 ? "even" : undefined,
-    );
-    expectTypeOf(rest).toEqualTypeOf({} as const);
-    expect(even).toEqual([0, 2, 4, 6, 8]);
-  });
+  describe("typing", () => {
+    test("regular", () => {
+      const { even, ...rest } = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
+        x % 2 === 0 ? "even" : undefined,
+      );
+      expectTypeOf(rest).toEqualTypeOf({} as const);
+    });
 
-  test("strict indexed", () => {
-    const { even, ...rest } = groupBy.indexed(
-      ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
-      (_, index) => (index % 2 === 0 ? "even" : undefined),
-    );
-    expectTypeOf(rest).toEqualTypeOf({} as const);
-    expect(even).toEqual(["a", "c", "e", "g", "i"]);
+    test("indexed", () => {
+      const { even, ...rest } = groupBy.indexed(
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+        (_, index) => (index % 2 === 0 ? "even" : undefined),
+      );
+      expectTypeOf(rest).toEqualTypeOf({} as const);
+    });
   });
 });

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,44 +1,72 @@
 import { purry } from "./purry";
 import type { NonEmptyArray, PredIndexedOptional, PredIndexed } from "./_types";
 
+// Records keyed with generic `string` and `number` have different semantics
+// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
+// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
+// the latter are implicitly `Required`. Because groupBy returns a partial
+// record by definition, we need to make sure the result is properly partial
+// when using it with a refined key.
+type Grouped<Value, Key extends PropertyKey = PropertyKey> =
+  // If either string, number or symbol extend Key it means that Key is at least
+  // as wide as them, so we don't need to wrap the returned record with Partial.
+  string extends Key
+    ? Record<Key, NonEmptyArray<Value>>
+    : number extends Key
+      ? Record<Key, NonEmptyArray<Value>>
+      : symbol extends Key
+        ? Record<Key, NonEmptyArray<Value>>
+        : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
+          // because we can't statically know what values the mapper would return on
+          // a specific input
+          Partial<Record<Key, NonEmptyArray<Value>>>;
+
 /**
- * Splits a collection into sets, grouped by the result of running each value through `fn`.
+ * Splits a collection into sets, grouped by the result of running each value
+ * through `fn`.
  *
  * @param items - The items to group.
- * @param fn - The grouping function. When `undefined` is returned the item would
- * be skipped and not grouped under any key.
+ * @param fn - The grouping function. When `undefined` is returned the item
+ * would be skipped and not grouped under any key.
  * @signature
  *    R.groupBy(array, fn)
- *    R.groupBy.strict(array, fn)
  * @example
- *    R.groupBy(['one', 'two', 'three'], x => x.length) // => {3: ['one', 'two'], 5: ['three']}
- *    R.groupBy.strict([{a: 'cat'}, {a: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *    R.groupBy([{a: 'cat'}, {a: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
  *    R.groupBy([0, 1], x => x % 2 === 0 ? 'even' : undefined) // => {even: [0]}
  * @dataFirst
  * @indexed
- * @strict
  * @category Array
  */
-export function groupBy<T>(
-  items: ReadonlyArray<T>,
-  fn: (item: T) => PropertyKey | undefined,
-): Record<PropertyKey, NonEmptyArray<T>>;
-
-export function groupBy<T>(
-  fn: (item: T) => PropertyKey | undefined,
-): (array: ReadonlyArray<T>) => Record<PropertyKey, NonEmptyArray<T>>;
+export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
+  items: ReadonlyArray<Value>,
+  fn: (item: Value) => Key | undefined,
+): Grouped<Value, Key>;
 
 /**
- * Splits a collection into sets, grouped by the result of running each value through `fn`.
+ * Splits a collection into sets, grouped by the result of running each value
+ * through `fn`.
  *
+ * @param fn - The grouping function. When `undefined` is returned the item
+ * would be skipped and not grouped under any key.
  * @signature
- *    R.groupBy(fn)(array)
+ *    R.groupBy(fn)(array);
  * @example
- *    R.pipe(['one', 'two', 'three'], R.groupBy(x => x.length)) // => {3: ['one', 'two'], 5: ['three']}
+ *    R.pipe(
+ *      [{a: 'cat'}, {a: 'dog'}] as const,
+ *      R.groupBy(prop('a'),
+ *    ); // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *    R.pipe(
+ *      [0, 1],
+ *      R.groupBy(x => x % 2 === 0 ? 'even' : undefined),
+ *    ); // => {even: [0]}
  * @dataLast
  * @indexed
  * @category Array
  */
+export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
+  fn: (item: Value) => Key | undefined,
+): (items: ReadonlyArray<Value>) => Grouped<Value, Key>;
+
 export function groupBy(): unknown {
   return purry(_groupBy(false), arguments);
 }
@@ -70,65 +98,17 @@ const _groupBy =
     return ret;
   };
 
-// Redefining the groupBy API with a stricter return type. This API is accessed
-// via `groupBy.strict`
-type Strict = {
-  // Data-First
-  <Value, Key extends PropertyKey = PropertyKey>(
-    items: ReadonlyArray<Value>,
-    fn: (item: Value) => Key | undefined,
-  ): StrictOut<Value, Key>;
-
-  // Data-Last
-  <Value, Key extends PropertyKey = PropertyKey>(
-    fn: (item: Value) => Key | undefined,
-  ): (items: ReadonlyArray<Value>) => StrictOut<Value, Key>;
-
-  readonly indexed: {
-    // Data-First
-    <Value, Key extends PropertyKey = PropertyKey>(
-      items: ReadonlyArray<Value>,
-      fn: PredIndexed<Value, Key | undefined>,
-    ): StrictOut<Value, Key>;
-
-    // Data-Last
-    <Value, Key extends PropertyKey = PropertyKey>(
-      fn: PredIndexed<Value, Key | undefined>,
-    ): (items: ReadonlyArray<Value>) => StrictOut<Value, Key>;
-  };
-};
-
-// Records keyed with generic `string` and `number` have different semantics
-// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
-// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
-// the latter are implicitly `Required`. Because groupBy returns a partial
-// record by definition, we need to make sure the result is properly partial
-// when using it with a refined key.
-type StrictOut<Value, Key extends PropertyKey = PropertyKey> =
-  // If either string, number or symbol extend Key it means that Key is at least
-  // as wide as them, so we don't need to wrap the returned record with Partial.
-  string extends Key
-    ? Record<Key, NonEmptyArray<Value>>
-    : number extends Key
-      ? Record<Key, NonEmptyArray<Value>>
-      : symbol extends Key
-        ? Record<Key, NonEmptyArray<Value>>
-        : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
-          // because we can't statically know what values the mapper would return on
-          // a specific input
-          Partial<Record<Key, NonEmptyArray<Value>>>;
-
 export namespace groupBy {
-  export function indexed<T>(
-    array: ReadonlyArray<T>,
-    fn: PredIndexed<T, PropertyKey | undefined>,
-  ): Record<string, NonEmptyArray<T>>;
-  export function indexed<T>(
-    fn: PredIndexed<T, PropertyKey | undefined>,
-  ): (array: ReadonlyArray<T>) => Record<string, NonEmptyArray<T>>;
+  export function indexed<Value, Key extends PropertyKey = PropertyKey>(
+    items: ReadonlyArray<Value>,
+    fn: PredIndexed<Value, Key | undefined>,
+  ): Grouped<Value, Key>;
+
+  export function indexed<Value, Key extends PropertyKey = PropertyKey>(
+    fn: PredIndexed<Value, Key | undefined>,
+  ): (items: ReadonlyArray<Value>) => Grouped<Value, Key>;
+
   export function indexed(): unknown {
     return purry(_groupBy(true), arguments);
   }
-
-  export const strict: Strict = groupBy;
 }

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -37,10 +37,10 @@ type Grouped<Value, Key extends PropertyKey = PropertyKey> =
  * @indexed
  * @category Array
  */
-export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
-  items: ReadonlyArray<Value>,
-  fn: (item: Value) => Key | undefined,
-): Grouped<Value, Key>;
+export function groupBy<T, Key extends PropertyKey = PropertyKey>(
+  items: ReadonlyArray<T>,
+  fn: (item: T) => Key | undefined,
+): Grouped<T, Key>;
 
 /**
  * Splits a collection into sets, grouped by the result of running each value
@@ -63,9 +63,9 @@ export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
  * @indexed
  * @category Array
  */
-export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
-  fn: (item: Value) => Key | undefined,
-): (items: ReadonlyArray<Value>) => Grouped<Value, Key>;
+export function groupBy<T, Key extends PropertyKey = PropertyKey>(
+  fn: (item: T) => Key | undefined,
+): (items: ReadonlyArray<T>) => Grouped<T, Key>;
 
 export function groupBy(): unknown {
   return purry(_groupBy(false), arguments);

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -1,25 +1,10 @@
+import type {
+  ExactRecord,
+  NonEmptyArray,
+  PredIndexed,
+  PredIndexedOptional,
+} from "./_types";
 import { purry } from "./purry";
-import type { NonEmptyArray, PredIndexedOptional, PredIndexed } from "./_types";
-
-// Records keyed with generic `string` and `number` have different semantics
-// to those with a a union of literal values (e.g. 'cat' | 'dog') when using
-// 'noUncheckedIndexedAccess', the former being implicitly `Partial` whereas
-// the latter are implicitly `Required`. Because groupBy returns a partial
-// record by definition, we need to make sure the result is properly partial
-// when using it with a refined key.
-type Grouped<Value, Key extends PropertyKey = PropertyKey> =
-  // If either string, number or symbol extend Key it means that Key is at least
-  // as wide as them, so we don't need to wrap the returned record with Partial.
-  string extends Key
-    ? Record<Key, NonEmptyArray<Value>>
-    : number extends Key
-      ? Record<Key, NonEmptyArray<Value>>
-      : symbol extends Key
-        ? Record<Key, NonEmptyArray<Value>>
-        : // If the key is specific, e.g. 'cat' | 'dog', the result is partial
-          // because we can't statically know what values the mapper would return on
-          // a specific input
-          Partial<Record<Key, NonEmptyArray<Value>>>;
 
 /**
  * Splits a collection into sets, grouped by the result of running each value
@@ -40,7 +25,7 @@ type Grouped<Value, Key extends PropertyKey = PropertyKey> =
 export function groupBy<T, Key extends PropertyKey = PropertyKey>(
   items: ReadonlyArray<T>,
   fn: (item: T) => Key | undefined,
-): Grouped<T, Key>;
+): ExactRecord<Key, NonEmptyArray<T>>;
 
 /**
  * Splits a collection into sets, grouped by the result of running each value
@@ -65,7 +50,7 @@ export function groupBy<T, Key extends PropertyKey = PropertyKey>(
  */
 export function groupBy<T, Key extends PropertyKey = PropertyKey>(
   fn: (item: T) => Key | undefined,
-): (items: ReadonlyArray<T>) => Grouped<T, Key>;
+): (items: ReadonlyArray<T>) => ExactRecord<Key, NonEmptyArray<T>>;
 
 export function groupBy(): unknown {
   return purry(_groupBy(false), arguments);
@@ -99,14 +84,14 @@ const _groupBy =
   };
 
 export namespace groupBy {
-  export function indexed<Value, Key extends PropertyKey = PropertyKey>(
-    items: ReadonlyArray<Value>,
-    fn: PredIndexed<Value, Key | undefined>,
-  ): Grouped<Value, Key>;
+  export function indexed<T, Key extends PropertyKey = PropertyKey>(
+    items: ReadonlyArray<T>,
+    fn: PredIndexed<T, Key | undefined>,
+  ): ExactRecord<Key, NonEmptyArray<T>>;
 
   export function indexed<Value, Key extends PropertyKey = PropertyKey>(
     fn: PredIndexed<Value, Key | undefined>,
-  ): (items: ReadonlyArray<Value>) => Grouped<Value, Key>;
+  ): (items: ReadonlyArray<Value>) => ExactRecord<Key, NonEmptyArray<Value>>;
 
   export function indexed(): unknown {
     return purry(_groupBy(true), arguments);

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -31,7 +31,7 @@ type Grouped<Value, Key extends PropertyKey = PropertyKey> =
  * @signature
  *    R.groupBy(array, fn)
  * @example
- *    R.groupBy([{a: 'cat'}, {a: 'dog'}] as const, prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *    R.groupBy([{a: 'cat'}, {a: 'dog'}] as const, R.prop('a')) // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]}
  *    R.groupBy([0, 1], x => x % 2 === 0 ? 'even' : undefined) // => {even: [0]}
  * @dataFirst
  * @indexed
@@ -53,8 +53,8 @@ export function groupBy<Value, Key extends PropertyKey = PropertyKey>(
  * @example
  *    R.pipe(
  *      [{a: 'cat'}, {a: 'dog'}] as const,
- *      R.groupBy(prop('a'),
- *    ); // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]} typed Partial<Record<'cat' | 'dog', NonEmptyArray<{a: 'cat' | 'dog'}>>>
+ *      R.groupBy(R.prop('a'),
+ *    ); // => {cat: [{a: 'cat'}], dog: [{a: 'dog'}]}
  *    R.pipe(
  *      [0, 1],
  *      R.groupBy(x => x % 2 === 0 ? 'even' : undefined),

--- a/src/indexBy.test.ts
+++ b/src/indexBy.test.ts
@@ -22,12 +22,8 @@ describe("data first", () => {
     expect(indexBy(array, (x) => x.code)).toEqual(expected);
   });
 
-  test("indexBy.indexed", () => {
-    expect(indexBy.indexed(array, (x) => x.code)).toEqual(expected);
-  });
-
-  test("indexBy.strict", () => {
-    const result = indexBy.strict(array, (x) => x.code);
+  test("indexBy", () => {
+    const result = indexBy(array, (x) => x.code);
     expectTypeOf<ExpectedTypeStrict>(result);
     expect(result).toStrictEqual(expectedStrict);
   });
@@ -43,19 +39,10 @@ describe("data last", () => {
     ).toEqual(expected);
   });
 
-  test("indexBy.indexed", () => {
-    expect(
-      pipe(
-        array,
-        indexBy.indexed((x) => x.code),
-      ),
-    ).toEqual(expected);
-  });
-
-  test("indexBy.strict", () => {
+  test("indexBy", () => {
     const result = pipe(
       array,
-      indexBy.strict((x) => x.code),
+      indexBy((x) => x.code),
     );
     expectTypeOf<ExpectedTypeStrict>(result);
     expect(result).toEqual(expectedStrict);

--- a/src/indexBy.test.ts
+++ b/src/indexBy.test.ts
@@ -1,50 +1,63 @@
 import { indexBy } from "./indexBy";
 import { pipe } from "./pipe";
+import { prop } from "./prop";
 
-const array = [
-  { dir: "left", code: 97 },
-  { dir: "right", code: 100 },
-] as const;
-const expected = {
-  "97": { dir: "left", code: 97 },
-  "100": { dir: "right", code: 100 },
-};
-const expectedStrict = {
-  97: { dir: "left", code: 97 },
-  100: { dir: "right", code: 100 },
-};
-type ExpectedTypeStrict = Partial<
-  Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>
->;
-
-describe("data first", () => {
-  test("indexBy", () => {
-    expect(indexBy(array, (x) => x.code)).toEqual(expected);
+describe("runtime", () => {
+  test("dataFirst", () => {
+    expect(
+      indexBy(
+        [
+          { dir: "left", code: 97 },
+          { dir: "right", code: 100 },
+        ] as const,
+        prop("code"),
+      ),
+    ).toStrictEqual({
+      97: { dir: "left", code: 97 },
+      100: { dir: "right", code: 100 },
+    });
   });
 
-  test("indexBy", () => {
-    const result = indexBy(array, (x) => x.code);
-    expectTypeOf<ExpectedTypeStrict>(result);
-    expect(result).toStrictEqual(expectedStrict);
+  test("dataLast", () => {
+    expect(
+      pipe(
+        [
+          { dir: "left", code: 97 },
+          { dir: "right", code: 100 },
+        ] as const,
+        indexBy(prop("code")),
+      ),
+    ).toStrictEqual({
+      97: { dir: "left", code: 97 },
+      100: { dir: "right", code: 100 },
+    });
   });
 });
 
-describe("data last", () => {
-  test("indexBy", () => {
-    expect(
-      pipe(
-        array,
-        indexBy((x) => x.code),
-      ),
-    ).toEqual(expected);
+describe("typing", () => {
+  test("dataFirst", () => {
+    const result = indexBy(
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ] as const,
+      (x) => x.code,
+    );
+    expectTypeOf<
+      Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>
+    >(result);
   });
 
-  test("indexBy", () => {
+  test("dataLast", () => {
     const result = pipe(
-      array,
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ] as const,
       indexBy((x) => x.code),
     );
-    expectTypeOf<ExpectedTypeStrict>(result);
-    expect(result).toEqual(expectedStrict);
+    expectTypeOf<
+      Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>
+    >(result);
   });
 });

--- a/src/indexBy.test.ts
+++ b/src/indexBy.test.ts
@@ -9,7 +9,7 @@ describe("runtime", () => {
         [
           { dir: "left", code: 97 },
           { dir: "right", code: 100 },
-        ] as const,
+        ],
         prop("code"),
       ),
     ).toStrictEqual({
@@ -24,7 +24,7 @@ describe("runtime", () => {
         [
           { dir: "left", code: 97 },
           { dir: "right", code: 100 },
-        ] as const,
+        ],
         indexBy(prop("code")),
       ),
     ).toStrictEqual({
@@ -40,8 +40,8 @@ describe("typing", () => {
       [
         { dir: "left", code: 97 },
         { dir: "right", code: 100 },
-      ] as const,
-      (x) => x.code,
+      ],
+      prop("code"),
     );
     expectTypeOf<
       Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>
@@ -53,8 +53,8 @@ describe("typing", () => {
       [
         { dir: "left", code: 97 },
         { dir: "right", code: 100 },
-      ] as const,
-      indexBy((x) => x.code),
+      ],
+      indexBy(prop("code")),
     );
     expectTypeOf<
       Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -1,11 +1,12 @@
+import type { ExactRecord } from "./_types";
 import { purry } from "./purry";
 
 /**
  * Converts a list of objects into an object indexing the objects by the given
  * key.
  *
- * @param array - The array.
- * @param fn - The indexing function.
+ * @param data - The array.
+ * @param mapper - The indexing function.
  * @signature
  *    R.indexBy(array, fn)
  * @example
@@ -13,16 +14,16 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Array
  */
-export function indexBy<K extends PropertyKey, T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => K,
-): Partial<Record<K, T>>;
+export function indexBy<T, K extends PropertyKey>(
+  data: ReadonlyArray<T>,
+  mapper: (item: T) => K,
+): ExactRecord<K, T>;
 
 /**
  * Converts a list of objects into an object indexing the objects by the given
  * key.
  *
- * @param fn - The indexing function.
+ * @param mapper - The indexing function.
  * @signature
  *    R.indexBy(fn)(array)
  * @example
@@ -33,24 +34,24 @@ export function indexBy<K extends PropertyKey, T>(
  * @dataLast
  * @category Array
  */
-export function indexBy<K extends PropertyKey, T>(
-  fn: (item: T) => K,
-): (array: ReadonlyArray<T>) => Partial<Record<K, T>>;
+export function indexBy<T, K extends PropertyKey>(
+  mapper: (item: T) => K,
+): (data: ReadonlyArray<T>) => ExactRecord<K, T>;
 
 export function indexBy(): unknown {
   return purry(indexByImplementation, arguments);
 }
 
-function indexByImplementation<K extends PropertyKey, T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => K,
-): Partial<Record<K, T>> {
+function indexByImplementation<T, K extends PropertyKey>(
+  data: ReadonlyArray<T>,
+  mapper: (item: T) => K,
+): ExactRecord<K, T> {
   const out: Partial<Record<K, T>> = {};
 
-  for (const item of array) {
-    const key = fn(item);
+  for (const item of data) {
+    const key = mapper(item);
     out[key] = item;
   }
 
-  return out;
+  return out as ExactRecord<K, T>;
 }

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -1,87 +1,47 @@
 import { purry } from "./purry";
-import type { PredIndexedOptional, PredIndexed } from "./_types";
 
 /**
- * Converts a list of objects into an object indexing the objects by the given key (casted to a string).
- * Use the strict version to maintain the given key's type, so long as it is a valid `PropertyKey`.
+ * Converts a list of objects into an object indexing the objects by the given
+ * key.
  *
  * @param array - The array.
  * @param fn - The indexing function.
  * @signature
  *    R.indexBy(array, fn)
- *    R.indexBy.strict(array, fn)
  * @example
- *    R.indexBy(['one', 'two', 'three'], x => x.length) // => {"3": 'two', "5": 'three'}
- *    R.indexBy.strict(['one', 'two', 'three'], x => x.length) // => {3: 'two', 5: 'three'}
+ *    R.indexBy(['one', 'two', 'three'], x => x.length) // => {3: 'two', 5: 'three'}
  * @dataFirst
- * @indexed
- * @strict
  * @category Array
  */
-export function indexBy<T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => unknown,
-): Record<string, T>;
-
-/**
- * Converts a list of objects into an object indexing the objects by the given key.
- * (casted to a string). Use the strict version to maintain the given key's type, so
- * long as it is a valid `PropertyKey`.
- *
- * @param fn - The indexing function.
- * @signature
- *    R.indexBy(fn)(array)
- *    R.indexBy.strict(fn)(array)
- * @example
- *    R.pipe(
- *      ['one', 'two', 'three'],
- *      R.indexBy(x => x.length)
- *    ) // => {"3": 'two', "5": 'three'}
- *    R.pipe(
- *      ['one', 'two', 'three'],
- *      R.indexBy.strict(x => x.length)
- *    ) // => {3: 'two', 5: 'three'}
- * @dataLast
- * @indexed
- * @strict
- * @category Array
- */
-export function indexBy<T>(
-  fn: (item: T) => unknown,
-): (array: ReadonlyArray<T>) => Record<string, T>;
-
-export function indexBy(): unknown {
-  return purry(_indexBy(false), arguments);
-}
-
-const _indexBy =
-  (indexed: boolean) =>
-  <T>(array: ReadonlyArray<T>, fn: PredIndexedOptional<T, unknown>) => {
-    const out: Record<string, T> = {};
-    for (let index = 0; index < array.length; index++) {
-      // TODO: Once we bump our Typescript target version we can use Array.prototype.entries to iterate over the elements and index at the same time.
-      const item = array[index]!;
-      const value = indexed ? fn(item, index, array) : fn(item);
-      const key = String(value);
-      out[key] = item;
-    }
-    return out;
-  };
-
-function indexByStrict<K extends PropertyKey, T>(
+export function indexBy<K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
   fn: (item: T) => K,
 ): Partial<Record<K, T>>;
 
-function indexByStrict<K extends PropertyKey, T>(
+/**
+ * Converts a list of objects into an object indexing the objects by the given
+ * key.
+ *
+ * @param fn - The indexing function.
+ * @signature
+ *    R.indexBy(fn)(array)
+ * @example
+ *    R.pipe(
+ *      ['one', 'two', 'three'],
+ *      R.indexBy(x => x.length)
+ *    ) // => {3: 'two', 5: 'three'}
+ * @dataLast
+ * @category Array
+ */
+export function indexBy<K extends PropertyKey, T>(
   fn: (item: T) => K,
 ): (array: ReadonlyArray<T>) => Partial<Record<K, T>>;
 
-function indexByStrict(): unknown {
-  return purry(_indexByStrict, arguments);
+export function indexBy(): unknown {
+  return purry(indexByImplementation, arguments);
 }
 
-function _indexByStrict<K extends PropertyKey, T>(
+function indexByImplementation<K extends PropertyKey, T>(
   array: ReadonlyArray<T>,
   fn: (item: T) => K,
 ): Partial<Record<K, T>> {
@@ -93,18 +53,4 @@ function _indexByStrict<K extends PropertyKey, T>(
   }
 
   return out;
-}
-
-export namespace indexBy {
-  export function indexed<T>(
-    array: ReadonlyArray<T>,
-    fn: PredIndexed<T, unknown>,
-  ): Record<string, T>;
-  export function indexed<T>(
-    fn: PredIndexed<T, unknown>,
-  ): (array: ReadonlyArray<T>) => Record<string, T>;
-  export function indexed(): unknown {
-    return purry(_indexBy(true), arguments);
-  }
-  export const strict = indexByStrict;
 }

--- a/src/isDefined.ts
+++ b/src/isDefined.ts
@@ -6,7 +6,6 @@
  * @returns True if the passed input is defined, false otherwise.
  * @signature
  *    R.isDefined(data)
- *    R.isDefined.strict(data)
  * @example
  *    R.isDefined('string') //=> true
  *    R.isDefined(null) //=> true

--- a/src/isDefined.ts
+++ b/src/isDefined.ts
@@ -11,7 +11,6 @@
  *    R.isDefined('string') //=> true
  *    R.isDefined(null) //=> true
  *    R.isDefined(undefined) //=> false
- * @strict
  * @category Guard
  */
 export function isDefined<T>(data: T | undefined): data is T {

--- a/src/isNonNullish.ts
+++ b/src/isNonNullish.ts
@@ -11,7 +11,6 @@
  *    R.isNonNullish('string') //=> true
  *    R.isNonNullish(null) //=> false
  *    R.isNonNullish(undefined) //=> false
- * @strict
  * @category Guard
  */
 export function isNonNullish<T>(data: T): data is NonNullable<T> {

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -19,80 +19,68 @@ describe("runtime", () => {
 describe("typing", () => {
   describe("arrays", () => {
     test("empty tuple", () => {
-      const array: [] = [];
-      const result = keys(array);
-      expectTypeOf(result).toEqualTypeOf<typeof array>();
+      const result = keys([] as []);
+      expectTypeOf(result).toEqualTypeOf<[]>();
     });
 
     test("empty readonly tuple", () => {
-      const array: readonly [] = [];
-      const result = keys(array);
+      const result = keys([] as const);
       expectTypeOf(result).toEqualTypeOf<[]>();
     });
 
     test("array", () => {
-      const array: Array<number> = [];
-      const result = keys(array);
+      const result = keys([] as Array<number>);
       expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
     });
 
     test("readonly array", () => {
-      const array: ReadonlyArray<number> = [];
-      const result = keys(array);
+      const result = keys([] as ReadonlyArray<number>);
       expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
     });
 
     test("tuple", () => {
-      const array: ["a", 1, true] = ["a", 1, true];
-      const result = keys(array);
+      const result = keys(["a", 1, true] as ["a", 1, true]);
       expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
     });
 
     test("readonly tuple", () => {
-      const array: readonly ["a", 1, true] = ["a", 1, true];
-      const result = keys(array);
+      const result = keys(["a", 1, true] as const);
       expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
     });
 
     test("tuple with rest tail", () => {
-      const array: ["a", ...Array<"b">] = ["a"];
-      const result = keys(array);
+      const result = keys(["a"] as ["a", ...Array<"b">]);
       expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
     });
 
     test("readonly tuple with rest tail", () => {
-      const array: readonly ["a", ...Array<"b">] = ["a"];
-      const result = keys(array);
+      const result = keys(["a"] as readonly ["a", ...Array<"b">]);
       expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
     });
 
     test("tuple with rest head", () => {
-      const array: [...Array<"a">, "b"] = ["b"];
-      const result = keys(array);
+      const result = keys(["b"] as [...Array<"a">, "b"]);
       expectTypeOf(result).toEqualTypeOf<
         [...Array<`${number}`>, `${number}`]
       >();
     });
 
     test("readonly tuple with rest head", () => {
-      const array: readonly [...Array<"a">, "b"] = ["b"];
-      const result = keys(array);
+      const result = keys(["b"] as readonly [...Array<"a">, "b"]);
       expectTypeOf(result).toEqualTypeOf<
         [...Array<`${number}`>, `${number}`]
       >();
     });
 
     test("tuple with rest middle", () => {
-      const array: ["a", ...Array<"b">, "c"] = ["a", "c"];
-      const result = keys(array);
+      const result = keys(["a", "c"] as ["a", ...Array<"b">, "c"]);
       expectTypeOf(result).toEqualTypeOf<
         ["0", ...Array<`${number}`>, `${number}`]
       >();
     });
 
     test("readonly tuple with rest middle", () => {
-      const array: readonly ["a", ...Array<"b">, "c"] = ["a", "c"];
-      const result = keys(array);
+      const result = keys(["a", "c"] as readonly ["a", ...Array<"b">, "c"]);
       expectTypeOf(result).toEqualTypeOf<
         ["0", ...Array<`${number}`>, `${number}`]
       >();
@@ -101,64 +89,56 @@ describe("typing", () => {
 
   describe("object types", () => {
     test("empty record (string)", () => {
-      const obj: Record<string, never> = {};
-      const result = keys(obj);
+      const result = keys({} as Record<string, never>);
       expectTypeOf(result).toEqualTypeOf<[]>();
     });
 
     test("empty record (number)", () => {
-      const obj: Record<number, never> = {};
-      const result = keys(obj);
+      const result = keys({} as Record<number, never>);
       expectTypeOf(result).toEqualTypeOf<[]>();
     });
 
     test("empty record (const)", () => {
-      const obj = {} as const;
-      const result = keys(obj);
+      const result = keys({} as const);
       expectTypeOf(result).toEqualTypeOf<[]>();
     });
 
     test("simple (required) object", () => {
-      const obj: { a: string; b: number; c: boolean } = {
-        a: "a",
-        b: 1,
-        c: true,
-      };
-      const result = keys(obj);
+      const result = keys({ a: "a", b: 1, c: true } as {
+        a: string;
+        b: number;
+        c: boolean;
+      });
       expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
     });
 
     test("simple partial object", () => {
-      const obj: { a?: string; b?: number; c?: boolean } = {
-        a: "a",
-        b: 1,
-        c: true,
-      };
-      const result = keys(obj);
+      const result = keys({ a: "a", b: 1, c: true } as {
+        a?: string;
+        b?: number;
+        c?: boolean;
+      });
       expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
     });
 
     test("object with index signature", () => {
-      const obj: { [keys: string]: string; a: string } = {
-        hello: "world",
-        a: "goodbye",
-      };
-      const result = keys(obj);
+      const result = keys({ hello: "world", a: "goodbye" } as {
+        [keys: string]: string;
+        a: string;
+      });
       expectTypeOf(result).toEqualTypeOf<Array<string>>();
     });
 
     test("Record with literal union", () => {
-      const obj: Record<"a" | "b", number> = { a: 1, b: 2 };
-      const result = keys(obj);
+      const result = keys({ a: 1, b: 2 } as Record<"a" | "b", number>);
       expectTypeOf(result).toEqualTypeOf<Array<"a" | "b">>();
     });
 
     test("Record with template string literal", () => {
-      const obj: Record<`param_${number}`, string> = {
-        param_123: "hello",
-        param_456: "world",
-      };
-      const result = keys(obj);
+      const result = keys({ param_123: "hello", param_456: "world" } as Record<
+        `param_${number}`,
+        string
+      >);
       expectTypeOf(result).toEqualTypeOf<Array<`param_${number}`>>();
     });
   });

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -11,149 +11,155 @@ describe("runtime", () => {
     });
 
     it("should return strict types", () => {
-      expect(keys({ 5: "x", b: "y", c: "z" } as const)).toEqual([
-        "5",
-        "b",
-        "c",
-      ]);
+      expect(keys({ 5: "x", b: "y", c: "z" })).toEqual(["5", "b", "c"]);
     });
   });
 });
 
-describe("strict tuple types", () => {
-  test("empty tuple", () => {
-    const array: [] = [];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<typeof array>();
+describe("typing", () => {
+  describe("arrays", () => {
+    test("empty tuple", () => {
+      const array: [] = [];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<typeof array>();
+    });
+
+    test("empty readonly tuple", () => {
+      const array: readonly [] = [];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
+
+    test("array", () => {
+      const array: Array<number> = [];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
+    });
+
+    test("readonly array", () => {
+      const array: ReadonlyArray<number> = [];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
+    });
+
+    test("tuple", () => {
+      const array: ["a", 1, true] = ["a", 1, true];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
+    });
+
+    test("readonly tuple", () => {
+      const array: readonly ["a", 1, true] = ["a", 1, true];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
+    });
+
+    test("tuple with rest tail", () => {
+      const array: ["a", ...Array<"b">] = ["a"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
+    });
+
+    test("readonly tuple with rest tail", () => {
+      const array: readonly ["a", ...Array<"b">] = ["a"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
+    });
+
+    test("tuple with rest head", () => {
+      const array: [...Array<"a">, "b"] = ["b"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<`${number}`>, `${number}`]
+      >();
+    });
+
+    test("readonly tuple with rest head", () => {
+      const array: readonly [...Array<"a">, "b"] = ["b"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<`${number}`>, `${number}`]
+      >();
+    });
+
+    test("tuple with rest middle", () => {
+      const array: ["a", ...Array<"b">, "c"] = ["a", "c"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<
+        ["0", ...Array<`${number}`>, `${number}`]
+      >();
+    });
+
+    test("readonly tuple with rest middle", () => {
+      const array: readonly ["a", ...Array<"b">, "c"] = ["a", "c"];
+      const result = keys(array);
+      expectTypeOf(result).toEqualTypeOf<
+        ["0", ...Array<`${number}`>, `${number}`]
+      >();
+    });
   });
 
-  test("empty readonly tuple", () => {
-    const array: readonly [] = [];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
+  describe("object types", () => {
+    test("empty record (string)", () => {
+      const obj: Record<string, never> = {};
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("array", () => {
-    const array: Array<number> = [];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
-  });
+    test("empty record (number)", () => {
+      const obj: Record<number, never> = {};
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("readonly array", () => {
-    const array: ReadonlyArray<number> = [];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
-  });
+    test("empty record (const)", () => {
+      const obj = {} as const;
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("tuple", () => {
-    const array: ["a", 1, true] = ["a", 1, true];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
-  });
+    test("simple (required) object", () => {
+      const obj: { a: string; b: number; c: boolean } = {
+        a: "a",
+        b: 1,
+        c: true,
+      };
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
+    });
 
-  test("readonly tuple", () => {
-    const array: readonly ["a", 1, true] = ["a", 1, true];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
-  });
+    test("simple partial object", () => {
+      const obj: { a?: string; b?: number; c?: boolean } = {
+        a: "a",
+        b: 1,
+        c: true,
+      };
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
+    });
 
-  test("tuple with rest tail", () => {
-    const array: ["a", ...Array<"b">] = ["a"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
-  });
+    test("object with index signature", () => {
+      const obj: { [keys: string]: string; a: string } = {
+        hello: "world",
+        a: "goodbye",
+      };
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<Array<string>>();
+    });
 
-  test("readonly tuple with rest tail", () => {
-    const array: readonly ["a", ...Array<"b">] = ["a"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
-  });
+    test("Record with literal union", () => {
+      const obj: Record<"a" | "b", number> = { a: 1, b: 2 };
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<Array<"a" | "b">>();
+    });
 
-  test("tuple with rest head", () => {
-    const array: [...Array<"a">, "b"] = ["b"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<[...Array<`${number}`>, `${number}`]>();
-  });
-
-  test("readonly tuple with rest head", () => {
-    const array: readonly [...Array<"a">, "b"] = ["b"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<[...Array<`${number}`>, `${number}`]>();
-  });
-
-  test("tuple with rest middle", () => {
-    const array: ["a", ...Array<"b">, "c"] = ["a", "c"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<
-      ["0", ...Array<`${number}`>, `${number}`]
-    >();
-  });
-
-  test("readonly tuple with rest middle", () => {
-    const array: readonly ["a", ...Array<"b">, "c"] = ["a", "c"];
-    const result = keys(array);
-    expectTypeOf(result).toEqualTypeOf<
-      ["0", ...Array<`${number}`>, `${number}`]
-    >();
-  });
-});
-
-describe("strict object types", () => {
-  test("empty record (string)", () => {
-    const obj: Record<string, never> = {};
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
-
-  test("empty record (number)", () => {
-    const obj: Record<number, never> = {};
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
-
-  test("empty record (const)", () => {
-    const obj = {} as const;
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
-
-  test("simple (required) object", () => {
-    const obj: { a: string; b: number; c: boolean } = { a: "a", b: 1, c: true };
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
-  });
-
-  test("simple partial object", () => {
-    const obj: { a?: string; b?: number; c?: boolean } = {
-      a: "a",
-      b: 1,
-      c: true,
-    };
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
-  });
-
-  test("object with index signature", () => {
-    const obj: { [keys: string]: string; a: string } = {
-      hello: "world",
-      a: "goodbye",
-    };
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<Array<string>>();
-  });
-
-  test("Record with literal union", () => {
-    const obj: Record<"a" | "b", number> = { a: 1, b: 2 };
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<Array<"a" | "b">>();
-  });
-
-  test("Record with template string literal", () => {
-    const obj: Record<`param_${number}`, string> = {
-      param_123: "hello",
-      param_456: "world",
-    };
-    const result = keys(obj);
-    expectTypeOf(result).toEqualTypeOf<Array<`param_${number}`>>();
+    test("Record with template string literal", () => {
+      const obj: Record<`param_${number}`, string> = {
+        param_123: "hello",
+        param_456: "world",
+      };
+      const result = keys(obj);
+      expectTypeOf(result).toEqualTypeOf<Array<`param_${number}`>>();
+    });
   });
 });

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -11,7 +11,7 @@ describe("runtime", () => {
     });
 
     it("should return strict types", () => {
-      expect(keys.strict({ 5: "x", b: "y", c: "z" } as const)).toEqual([
+      expect(keys({ 5: "x", b: "y", c: "z" } as const)).toEqual([
         "5",
         "b",
         "c",
@@ -23,67 +23,67 @@ describe("runtime", () => {
 describe("strict tuple types", () => {
   test("empty tuple", () => {
     const array: [] = [];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
   test("empty readonly tuple", () => {
     const array: readonly [] = [];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("array", () => {
     const array: Array<number> = [];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
   });
 
   test("readonly array", () => {
     const array: ReadonlyArray<number> = [];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<Array<`${number}`>>();
   });
 
   test("tuple", () => {
     const array: ["a", 1, true] = ["a", 1, true];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
   });
 
   test("readonly tuple", () => {
     const array: readonly ["a", 1, true] = ["a", 1, true];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<["0", "1", "2"]>();
   });
 
   test("tuple with rest tail", () => {
     const array: ["a", ...Array<"b">] = ["a"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
   });
 
   test("readonly tuple with rest tail", () => {
     const array: readonly ["a", ...Array<"b">] = ["a"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<["0", ...Array<`${number}`>]>();
   });
 
   test("tuple with rest head", () => {
     const array: [...Array<"a">, "b"] = ["b"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<[...Array<`${number}`>, `${number}`]>();
   });
 
   test("readonly tuple with rest head", () => {
     const array: readonly [...Array<"a">, "b"] = ["b"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<[...Array<`${number}`>, `${number}`]>();
   });
 
   test("tuple with rest middle", () => {
     const array: ["a", ...Array<"b">, "c"] = ["a", "c"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<
       ["0", ...Array<`${number}`>, `${number}`]
     >();
@@ -91,7 +91,7 @@ describe("strict tuple types", () => {
 
   test("readonly tuple with rest middle", () => {
     const array: readonly ["a", ...Array<"b">, "c"] = ["a", "c"];
-    const result = keys.strict(array);
+    const result = keys(array);
     expectTypeOf(result).toEqualTypeOf<
       ["0", ...Array<`${number}`>, `${number}`]
     >();
@@ -101,25 +101,25 @@ describe("strict tuple types", () => {
 describe("strict object types", () => {
   test("empty record (string)", () => {
     const obj: Record<string, never> = {};
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("empty record (number)", () => {
     const obj: Record<number, never> = {};
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("empty record (const)", () => {
     const obj = {} as const;
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("simple (required) object", () => {
     const obj: { a: string; b: number; c: boolean } = { a: "a", b: 1, c: true };
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
   });
 
@@ -129,7 +129,7 @@ describe("strict object types", () => {
       b: 1,
       c: true,
     };
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<Array<"a" | "b" | "c">>();
   });
 
@@ -138,13 +138,13 @@ describe("strict object types", () => {
       hello: "world",
       a: "goodbye",
     };
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<Array<string>>();
   });
 
   test("Record with literal union", () => {
     const obj: Record<"a" | "b", number> = { a: 1, b: 2 };
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<Array<"a" | "b">>();
   });
 
@@ -153,7 +153,7 @@ describe("strict object types", () => {
       param_123: "hello",
       param_456: "world",
     };
-    const result = keys.strict(obj);
+    const result = keys(obj);
     expectTypeOf(result).toEqualTypeOf<Array<`param_${number}`>>();
   });
 });

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,66 +1,6 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
-/**
- * Returns a new array containing the keys of the array or object.
- *
- * @param source - Either an array or an object.
- * @signature
- *    R.keys(source)
- *    R.keys.strict(source)
- * @example
- *    R.keys(['x', 'y', 'z']) // => ['0', '1', '2']
- *    R.keys({ a: 'x', b: 'y', c: 'z' }) // => ['a', 'b', 'c']
- *    R.keys.strict({ a: 'x', b: 'y', 5: 'z' } as const ) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
- *    R.pipe(['x', 'y', 'z'], R.keys) // => ['0', '1', '2']
- *    R.pipe({ a: 'x', b: 'y', c: 'z' }, R.keys) // => ['a', 'b', 'c']
- *    R.pipe(
- *      { a: 'x', b: 'y', c: 'z' },
- *      R.keys,
- *      R.first(),
- *    ) // => 'a'
- *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys.strict) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
- * @dataFirst
- * @pipeable
- * @strict
- * @category Object
- */
-export function keys(
-  source: ArrayLike<unknown> | Readonly<Record<PropertyKey, unknown>>,
-): Array<string>;
-
-/**
- * Returns a new array containing the keys of the array or object.
- *
- * @signature
- *    R.keys()(source)
- *    R.keys.strict()(source)
- * @example
- *    R.pipe(['x', 'y', 'z'], R.keys()) // => ['0', '1', '2']
- *    R.pipe({ a: 'x', b: 'y', c: 'z' }, R.keys()) // => ['a', 'b', 'c']
- *    R.pipe(
- *      { a: 'x', b: 'y', c: 'z' },
- *      R.keys(),
- *      R.first(),
- *    ) // => 'a'
- *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys.strict()) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
- * @dataLast
- * @pipeable
- * @strict
- * @category Object
- */
-// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-// export function keys(): (
-//   source: Record<PropertyKey, unknown> | ArrayLike<unknown>,
-// ) => Array<string>;
-
-export function keys(): unknown {
-  return purry(Object.keys, arguments);
-}
-
-type Strict = // (): <T extends object>(data: T) => Keys<T>;
-  // TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-  <T extends object>(data: T) => Keys<T>;
 type Keys<T> = T extends IterableContainer ? ArrayKeys<T> : ObjectKeys<T>;
 
 // The keys output can mirror the input when it is an array/tuple. We do this by
@@ -110,6 +50,34 @@ type ObjectKeys<T> =
   T extends Record<PropertyKey, never>
     ? []
     : Array<`${Exclude<keyof T, symbol>}`>;
-export namespace keys {
-  export const strict = keys as Strict;
+
+/**
+ * Returns a new array containing the keys of the array or object.
+ *
+ * @param source - Either an array or an object.
+ * @signature
+ *    R.keys(source)
+ * @example
+ *    R.keys({ a: 'x', b: 'y', 5: 'z' } as const) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
+ * @dataFirst
+ * @pipeable
+ * @category Object
+ */
+export function keys<T extends object>(data: T): Keys<T>;
+
+/**
+ * Returns a new array containing the keys of the array or object.
+ *
+ * @signature
+ *    R.keys()(source)
+ * @example
+ *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys()) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
+ * @dataLast
+ * @pipeable
+ * @category Object
+ */
+export function keys(): <T extends object>(data: T) => Keys<T>;
+
+export function keys(): unknown {
+  return purry(Object.keys, arguments);
 }

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -58,7 +58,8 @@ type ObjectKeys<T> =
  * @signature
  *    R.keys(source)
  * @example
- *    R.keys({ a: 'x', b: 'y', 5: 'z' } as const) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
+ *    R.keys(['x', 'y', 'z']); // => ['0', '1', '2']
+ *    R.keys({ a: 'x', b: 'y', 5: 'z' }); // => ['a', 'b', '5']
  * @dataFirst
  * @pipeable
  * @category Object
@@ -71,7 +72,8 @@ export function keys<T extends object>(data: T): Keys<T>;
  * @signature
  *    R.keys()(source)
  * @example
- *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys()) // => ['a', 'b', '5'], typed Array<'a' | 'b' | '5'>
+ *    R.Pipe(['x', 'y', 'z'], keys()); // => ['0', '1', '2']
+ *    R.pipe({ a: 'x', b: 'y', 5: 'z' } as const, R.keys()) // => ['a', 'b', '5']
  * @dataLast
  * @pipeable
  * @category Object

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -54,7 +54,7 @@ type ObjectKeys<T> =
 /**
  * Returns a new array containing the keys of the array or object.
  *
- * @param source - Either an array or an object.
+ * @param data - Either an array or an object.
  * @signature
  *    R.keys(source)
  * @example

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -1,105 +1,157 @@
+import { constant } from "./constant";
 import { filter } from "./filter";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { take } from "./take";
 
-describe("data_first", () => {
-  it("map", () => {
-    const result = map([1, 2, 3] as const, (x) => x * 2);
-    expect(result).toEqual([2, 4, 6]);
+describe("runtime", () => {
+  describe("data_first", () => {
+    it("map", () => {
+      const result = map([1, 2, 3] as const, (x) => x * 2);
+      expect(result).toEqual([2, 4, 6]);
+    });
+    it("map.indexed", () => {
+      const result = map.indexed([0, 0, 0] as const, (_, i) => i);
+      expect(result).toEqual([0, 1, 2]);
+    });
   });
-  it("map.indexed", () => {
-    const result = map.indexed([0, 0, 0] as const, (_, i) => i);
-    expect(result).toEqual([0, 1, 2]);
+
+  describe("data_last", () => {
+    it("map", () => {
+      const result = pipe(
+        [1, 2, 3] as const,
+        map((x) => x * 2),
+      );
+      expect(result).toEqual([2, 4, 6]);
+    });
+    it("map.indexed", () => {
+      const result = pipe(
+        [0, 0, 0] as const,
+        map.indexed((_, i) => i),
+      );
+      expect(result).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe("pipe", () => {
+    it("with take", () => {
+      const count = vi.fn();
+      const result = pipe(
+        [1, 2, 3] as const,
+        map((x) => {
+          count();
+          return x * 10;
+        }),
+        take(2),
+      );
+      expect(count).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([10, 20]);
+    });
+
+    it("indexed", () => {
+      const count = vi.fn();
+      const result = pipe(
+        [0, 0, 0] as const,
+        map.indexed((_, i) => {
+          count();
+          return i;
+        }),
+        take(2),
+      );
+      expect(count).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([0, 1]);
+    });
+
+    it("indexed: check index and items", () => {
+      const indexes1: Array<number> = [];
+      const indexes2: Array<number> = [];
+      const anyItems1: Array<Array<number>> = [];
+      const anyItems2: Array<Array<number>> = [];
+      const result = pipe(
+        [1, 2, 3, 4, 5] as const,
+        map.indexed((x, i, items) => {
+          anyItems1.push([...items]);
+          indexes1.push(i);
+          return x;
+        }),
+        filter((x) => x % 2 === 1),
+        map.indexed((x, i, items) => {
+          anyItems2.push([...items]);
+          indexes2.push(i);
+          return x;
+        }),
+      );
+      expect(result).toEqual([1, 3, 5]);
+      expect(indexes1).toEqual([0, 1, 2, 3, 4]);
+      expect(indexes2).toEqual([0, 1, 2]);
+      expect(anyItems1).toEqual([
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [1, 2, 3, 4],
+        [1, 2, 3, 4, 5],
+      ]);
+      expect(anyItems2).toEqual([[1], [1, 3], [1, 3, 5]]);
+    });
+  });
+
+  it("number array", () => {
+    expect(map([1, 2, 3], (x) => x + 1)).toEqual([2, 3, 4]);
+  });
+
+  it("mixed type tuple", () => {
+    expect(map([1, "2", true], constant(1))).toEqual([1, 1, 1]);
+  });
+
+  it("complex variadic number array", () => {
+    const input = [
+      "hello",
+      "world",
+      1,
+      "testing",
+      "testing",
+      "testing",
+      123,
+      true,
+    ];
+    expect(map(input, identity)).toEqual(input);
+  });
+
+  describe("Indexed", () => {
+    it("number array", () => {
+      expect(map.indexed([1, 2, 3], (x, index) => x + index)).toEqual([
+        1, 3, 5,
+      ]);
+    });
+
+    it("mixed type tuple", () => {
+      expect(map.indexed([1, "2", true], (_, index) => index)).toEqual([
+        0, 1, 2,
+      ]);
+    });
+
+    it("complex variadic number array", () => {
+      const input = [
+        "hello",
+        "world",
+        1,
+        "testing",
+        "testing",
+        "testing",
+        123,
+        true,
+      ];
+      expect(map.indexed(input, identity)).toEqual(input);
+    });
   });
 });
 
-describe("data_last", () => {
-  it("map", () => {
-    const result = pipe(
-      [1, 2, 3] as const,
-      map((x) => x * 2),
-    );
-    expect(result).toEqual([2, 4, 6]);
-  });
-  it("map.indexed", () => {
-    const result = pipe(
-      [0, 0, 0] as const,
-      map.indexed((_, i) => i),
-    );
-    expect(result).toEqual([0, 1, 2]);
-  });
-});
-
-describe("pipe", () => {
-  it("with take", () => {
-    const count = vi.fn();
-    const result = pipe(
-      [1, 2, 3] as const,
-      map((x) => {
-        count();
-        return x * 10;
-      }),
-      take(2),
-    );
-    expect(count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([10, 20]);
-  });
-
-  it("indexed", () => {
-    const count = vi.fn();
-    const result = pipe(
-      [0, 0, 0] as const,
-      map.indexed((_, i) => {
-        count();
-        return i;
-      }),
-      take(2),
-    );
-    expect(count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([0, 1]);
-  });
-
-  it("indexed: check index and items", () => {
-    const indexes1: Array<number> = [];
-    const indexes2: Array<number> = [];
-    const anyItems1: Array<Array<number>> = [];
-    const anyItems2: Array<Array<number>> = [];
-    const result = pipe(
-      [1, 2, 3, 4, 5] as const,
-      map.indexed((x, i, items) => {
-        anyItems1.push([...items]);
-        indexes1.push(i);
-        return x;
-      }),
-      filter((x) => x % 2 === 1),
-      map.indexed((x, i, items) => {
-        anyItems2.push([...items]);
-        indexes2.push(i);
-        return x;
-      }),
-    );
-    expect(result).toEqual([1, 3, 5]);
-    expect(indexes1).toEqual([0, 1, 2, 3, 4]);
-    expect(indexes2).toEqual([0, 1, 2]);
-    expect(anyItems1).toEqual([
-      [1],
-      [1, 2],
-      [1, 2, 3],
-      [1, 2, 3, 4],
-      [1, 2, 3, 4, 5],
-    ]);
-    expect(anyItems2).toEqual([[1], [1, 3], [1, 3, 5]]);
-  });
-});
-
-describe("Strict", () => {
+describe("typing", () => {
   it("number array", () => {
     const input: Array<number> = [1, 2, 3];
     const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("readonly number array", () => {
@@ -107,14 +159,12 @@ describe("Strict", () => {
     const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("number 3-tuple", () => {
     const input: [number, number, number] = [1, 2, 3];
     const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("readonly number 3-tuple", () => {
@@ -122,7 +172,6 @@ describe("Strict", () => {
     const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("named number 3-tuple", () => {
@@ -133,14 +182,12 @@ describe("Strict", () => {
     expectTypeOf(result).toEqualTypeOf<
       [item1: number, item2: number, item3: number]
     >();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("mixed type tuple", () => {
     const input: [number, string, boolean] = [1, "2", true];
     const result = map(input, () => 1);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 1, 1]);
   });
 
   it("readonly mixed type tuple", () => {
@@ -148,14 +195,12 @@ describe("Strict", () => {
     const result = map(input, () => 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 1, 1]);
   });
 
   it("nonempty (tail) number array", () => {
     const input: [number, ...Array<number>] = [1, 2, 3];
     const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("nonempty (tail) readonly number array", () => {
@@ -163,14 +208,12 @@ describe("Strict", () => {
     const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("nonempty (head) number array", () => {
     const input: [...Array<number>, number] = [1, 2, 3];
     const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("nonempty readonly (head) number array", () => {
@@ -178,7 +221,6 @@ describe("Strict", () => {
     const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([2, 3, 4]);
   });
 
   it("complex variadic number array", () => {
@@ -194,110 +236,97 @@ describe("Strict", () => {
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean | number | string>, boolean | number | string]
     >();
-    expect(result).toEqual(input);
-  });
-});
-
-describe("Strict Indexed", () => {
-  it("number array", () => {
-    const input: Array<number> = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([1, 3, 5]);
   });
 
-  it("readonly number array", () => {
-    const input: ReadonlyArray<number> = [1, 2, 3] as const;
-    const result = map.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+  describe("Indexed", () => {
+    it("number array", () => {
+      const input: Array<number> = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    });
 
-  it("number 3-tuple", () => {
-    const input: [number, number, number] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("readonly number array", () => {
+      const input: ReadonlyArray<number> = [1, 2, 3] as const;
+      const result = map.indexed(input, (x, index) => x + index);
+      // readonlyness is stripped
+      expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    });
 
-  it("readonly number 3-tuple", () => {
-    const input: readonly [number, number, number] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("number 3-tuple", () => {
+      const input: [number, number, number] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    });
 
-  it("named number 3-tuple", () => {
-    const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    // There's no way to test this, but notice that the names are copied to the
-    // output here...
-    expectTypeOf(result).toEqualTypeOf<
-      [item1: number, item2: number, item3: number]
-    >();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("readonly number 3-tuple", () => {
+      const input: readonly [number, number, number] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      // readonlyness is stripped
+      expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    });
 
-  it("mixed type tuple", () => {
-    const input: [number, string, boolean] = [1, "2", true];
-    const result = map.indexed(input, (_, index) => index);
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([0, 1, 2]);
-  });
+    it("named number 3-tuple", () => {
+      const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      // There's no way to test this, but notice that the names are copied to the
+      // output here...
+      expectTypeOf(result).toEqualTypeOf<
+        [item1: number, item2: number, item3: number]
+      >();
+    });
 
-  it("readonly mixed type tuple", () => {
-    const input: readonly [number, string, boolean] = [1, "2", true];
-    const result = map.indexed(input, (_, index) => index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
-    expect(result).toEqual([0, 1, 2]);
-  });
+    it("mixed type tuple", () => {
+      const input: [number, string, boolean] = [1, "2", true];
+      const result = map.indexed(input, (_, index) => index);
+      expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    });
 
-  it("nonempty (tail) number array", () => {
-    const input: [number, ...Array<number>] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("readonly mixed type tuple", () => {
+      const input: readonly [number, string, boolean] = [1, "2", true];
+      const result = map.indexed(input, (_, index) => index);
+      // readonlyness is stripped
+      expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
+    });
 
-  it("nonempty (tail) readonly number array", () => {
-    const input: readonly [number, ...Array<number>] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("nonempty (tail) number array", () => {
+      const input: [number, ...Array<number>] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+    });
 
-  it("nonempty (head) number array", () => {
-    const input: [...Array<number>, number] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("nonempty (tail) readonly number array", () => {
+      const input: readonly [number, ...Array<number>] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      // readonlyness is stripped
+      expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+    });
 
-  it("nonempty readonly (head) number array", () => {
-    const input: readonly [...Array<number>, number] = [1, 2, 3];
-    const result = map.indexed(input, (x, index) => x + index);
-    // readonlyness is stripped
-    expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
-    expect(result).toEqual([1, 3, 5]);
-  });
+    it("nonempty (head) number array", () => {
+      const input: [...Array<number>, number] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+    });
 
-  it("complex variadic number array", () => {
-    const input: [
-      ...Array<"hello">,
-      "world",
-      ...Array<number>,
-      string,
-      ...Array<number>,
-      boolean,
-    ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
-    const result = map.indexed(input, identity);
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean | number | string>, boolean | number | string]
-    >();
-    expect(result).toEqual(input);
+    it("nonempty readonly (head) number array", () => {
+      const input: readonly [...Array<number>, number] = [1, 2, 3];
+      const result = map.indexed(input, (x, index) => x + index);
+      // readonlyness is stripped
+      expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+    });
+
+    it("complex variadic number array", () => {
+      const input: [
+        ...Array<"hello">,
+        "world",
+        ...Array<number>,
+        string,
+        ...Array<number>,
+        boolean,
+      ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
+      const result = map.indexed(input, identity);
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<boolean | number | string>, boolean | number | string]
+      >();
+    });
   });
 });

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -97,14 +97,14 @@ describe("pipe", () => {
 describe("Strict", () => {
   it("number array", () => {
     const input: Array<number> = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
     expect(result).toEqual([2, 3, 4]);
   });
 
   it("readonly number array", () => {
     const input: ReadonlyArray<number> = [1, 2, 3] as const;
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
     expect(result).toEqual([2, 3, 4]);
@@ -112,14 +112,14 @@ describe("Strict", () => {
 
   it("number 3-tuple", () => {
     const input: [number, number, number] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([2, 3, 4]);
   });
 
   it("readonly number 3-tuple", () => {
     const input: readonly [number, number, number] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([2, 3, 4]);
@@ -127,7 +127,7 @@ describe("Strict", () => {
 
   it("named number 3-tuple", () => {
     const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     // There's no way to test this, but notice that the names are copied to the
     // output here...
     expectTypeOf(result).toEqualTypeOf<
@@ -138,14 +138,14 @@ describe("Strict", () => {
 
   it("mixed type tuple", () => {
     const input: [number, string, boolean] = [1, "2", true];
-    const result = map.strict(input, () => 1);
+    const result = map(input, () => 1);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([1, 1, 1]);
   });
 
   it("readonly mixed type tuple", () => {
     const input: readonly [number, string, boolean] = [1, "2", true];
-    const result = map.strict(input, () => 1);
+    const result = map(input, () => 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([1, 1, 1]);
@@ -153,14 +153,14 @@ describe("Strict", () => {
 
   it("nonempty (tail) number array", () => {
     const input: [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
     expect(result).toEqual([2, 3, 4]);
   });
 
   it("nonempty (tail) readonly number array", () => {
     const input: readonly [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
     expect(result).toEqual([2, 3, 4]);
@@ -168,14 +168,14 @@ describe("Strict", () => {
 
   it("nonempty (head) number array", () => {
     const input: [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
     expect(result).toEqual([2, 3, 4]);
   });
 
   it("nonempty readonly (head) number array", () => {
     const input: readonly [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict(input, (x) => x + 1);
+    const result = map(input, (x) => x + 1);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
     expect(result).toEqual([2, 3, 4]);
@@ -190,7 +190,7 @@ describe("Strict", () => {
       ...Array<number>,
       boolean,
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
-    const result = map.strict(input, identity);
+    const result = map(input, identity);
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean | number | string>, boolean | number | string]
     >();
@@ -201,14 +201,14 @@ describe("Strict", () => {
 describe("Strict Indexed", () => {
   it("number array", () => {
     const input: Array<number> = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
     expect(result).toEqual([1, 3, 5]);
   });
 
   it("readonly number array", () => {
     const input: ReadonlyArray<number> = [1, 2, 3] as const;
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
     expect(result).toEqual([1, 3, 5]);
@@ -216,14 +216,14 @@ describe("Strict Indexed", () => {
 
   it("number 3-tuple", () => {
     const input: [number, number, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([1, 3, 5]);
   });
 
   it("readonly number 3-tuple", () => {
     const input: readonly [number, number, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([1, 3, 5]);
@@ -231,7 +231,7 @@ describe("Strict Indexed", () => {
 
   it("named number 3-tuple", () => {
     const input: [item1: number, item2: number, item3: number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     // There's no way to test this, but notice that the names are copied to the
     // output here...
     expectTypeOf(result).toEqualTypeOf<
@@ -242,14 +242,14 @@ describe("Strict Indexed", () => {
 
   it("mixed type tuple", () => {
     const input: [number, string, boolean] = [1, "2", true];
-    const result = map.strict.indexed(input, (_, index) => index);
+    const result = map.indexed(input, (_, index) => index);
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([0, 1, 2]);
   });
 
   it("readonly mixed type tuple", () => {
     const input: readonly [number, string, boolean] = [1, "2", true];
-    const result = map.strict.indexed(input, (_, index) => index);
+    const result = map.indexed(input, (_, index) => index);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
     expect(result).toEqual([0, 1, 2]);
@@ -257,14 +257,14 @@ describe("Strict Indexed", () => {
 
   it("nonempty (tail) number array", () => {
     const input: [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
     expect(result).toEqual([1, 3, 5]);
   });
 
   it("nonempty (tail) readonly number array", () => {
     const input: readonly [number, ...Array<number>] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
     expect(result).toEqual([1, 3, 5]);
@@ -272,14 +272,14 @@ describe("Strict Indexed", () => {
 
   it("nonempty (head) number array", () => {
     const input: [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
     expect(result).toEqual([1, 3, 5]);
   });
 
   it("nonempty readonly (head) number array", () => {
     const input: readonly [...Array<number>, number] = [1, 2, 3];
-    const result = map.strict.indexed(input, (x, index) => x + index);
+    const result = map.indexed(input, (x, index) => x + index);
     // readonlyness is stripped
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
     expect(result).toEqual([1, 3, 5]);
@@ -294,7 +294,7 @@ describe("Strict Indexed", () => {
       ...Array<number>,
       boolean,
     ] = ["hello", "world", 1, "testing", "testing", "testing", 123, true];
-    const result = map.strict.indexed(input, identity);
+    const result = map.indexed(input, identity);
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean | number | string>, boolean | number | string]
     >();

--- a/src/map.ts
+++ b/src/map.ts
@@ -12,8 +12,8 @@ import { purry } from "./purry";
 /**
  * Map each element of an array using a defined callback function.
  *
- * @param array - The array to map.
- * @param fn - The function mapper.
+ * @param data - The array to map.
+ * @param mapper - The function mapper.
  * @returns The new mapped array.
  * @signature
  *    R.map(array, fn)
@@ -27,14 +27,14 @@ import { purry } from "./purry";
  * @category Array
  */
 export function map<T extends IterableContainer, K>(
-  items: T,
+  data: T,
   mapper: (item: T[number]) => K,
 ): Mapped<T, K>;
 
 /**
  * Map each value of an object using a defined callback function.
  *
- * @param fn - The function mapper.
+ * @param mapper - The function mapper.
  * @signature
  *    R.map(fn)(array)
  *    R.map.indexed(fn)(array)

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -1,3 +1,9 @@
+/* eslint-disable @typescript-eslint/ban-types --
+ * We want to match the typing of the built-in Object.entries as much as
+ * possible!
+ */
+
+import type { EntryForKey } from "./entries";
 import { entries } from "./entries";
 import { purry } from "./purry";
 
@@ -5,7 +11,7 @@ import { purry } from "./purry";
  * Maps keys of `object` and keeps the same values.
  *
  * @param data - The object to map.
- * @param fn - The mapping function.
+ * @param keyMapper - The mapping function.
  * @signature
  *    R.mapKeys(object, fn)
  * @example
@@ -13,15 +19,15 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Object
  */
-export function mapKeys<T, S extends PropertyKey>(
+export function mapKeys<T extends {}, S extends PropertyKey>(
   data: T,
-  fn: (key: keyof T, value: Required<T>[keyof T]) => S,
-): Record<S, T[keyof T]>;
+  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
+): Partial<Record<S, T[keyof T]>>;
 
 /**
  * Maps keys of `object` and keeps the same values.
  *
- * @param fn - The mapping function.
+ * @param keyMapper - The mapping function.
  * @signature
  *    R.mapKeys(fn)(object)
  * @example
@@ -29,22 +35,25 @@ export function mapKeys<T, S extends PropertyKey>(
  * @dataLast
  * @category Object
  */
-export function mapKeys<T, S extends PropertyKey>(
-  fn: (key: keyof T, value: Required<T>[keyof T]) => S,
-): (data: T) => Record<S, T[keyof T]>;
+export function mapKeys<T extends {}, S extends PropertyKey>(
+  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
+): (data: T) => Partial<Record<S, T[keyof T]>>;
 
 export function mapKeys(): unknown {
-  return purry(_mapKeys, arguments);
+  return purry(mapKeysImplementation, arguments);
 }
 
-function _mapKeys<T extends object, S extends PropertyKey>(
+function mapKeysImplementation<T extends {}, S extends PropertyKey>(
   data: T,
-  fn: (key: keyof T, value: Required<T>[keyof T]) => S,
-): Record<S, T[keyof T]> {
+  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
+): Partial<Record<S, T[keyof T]>> {
   const out: Partial<Record<S, T[keyof T]>> = {};
+
   for (const [key, value] of entries(data)) {
-    out[fn(key, value)] = value;
+    // @ts-expect-error [ts2345] - Adding `Simplify` to the type of `EntryOf` takes away Typescripts ability to infer that the types match. Because we trust `Simplify` to only change how the type "looks" and not its semantics, we need to suppress the error.
+    const mappedKey = keyMapper(key, value);
+    out[mappedKey] = value;
   }
-  // @ts-expect-error [ts2322] - We build the object incrementally so the type can't represent the final object.
+
   return out;
 }

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -42,7 +42,7 @@ function _mapKeys<T extends object, S extends PropertyKey>(
   fn: (key: keyof T, value: Required<T>[keyof T]) => S,
 ): Record<S, T[keyof T]> {
   const out: Partial<Record<S, T[keyof T]>> = {};
-  for (const [key, value] of entries.strict(data)) {
+  for (const [key, value] of entries(data)) {
     out[fn(key, value)] = value;
   }
   // @ts-expect-error [ts2322] - We build the object incrementally so the type can't represent the final object.

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -3,7 +3,7 @@
  * possible!
  */
 
-import type { EntryForKey } from "./entries";
+import type { ExactRecord } from "./_types";
 import { entries } from "./entries";
 import { purry } from "./purry";
 
@@ -21,8 +21,8 @@ import { purry } from "./purry";
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
-): Partial<Record<S, T[keyof T]>>;
+  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+): ExactRecord<S, T[keyof T]>;
 
 /**
  * Maps keys of `object` and keeps the same values.
@@ -36,8 +36,8 @@ export function mapKeys<T extends {}, S extends PropertyKey>(
  * @category Object
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
-  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
-): (data: T) => Partial<Record<S, T[keyof T]>>;
+  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+): (data: T) => ExactRecord<S, T[keyof T]>;
 
 export function mapKeys(): unknown {
   return purry(mapKeysImplementation, arguments);
@@ -45,8 +45,8 @@ export function mapKeys(): unknown {
 
 function mapKeysImplementation<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: <K extends keyof T>(...entry: Readonly<EntryForKey<T, K>>) => S,
-): Partial<Record<S, T[keyof T]>> {
+  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+): ExactRecord<S, T[keyof T]> {
   const out: Partial<Record<S, T[keyof T]>> = {};
 
   for (const [key, value] of entries(data)) {
@@ -55,5 +55,5 @@ function mapKeysImplementation<T extends {}, S extends PropertyKey>(
     out[mappedKey] = value;
   }
 
-  return out;
+  return out as ExactRecord<S, T[keyof T]>;
 }

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -43,7 +43,7 @@ function _mapValues<T extends Record<PropertyKey, unknown>, S>(
   fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S,
 ): Record<ObjectKeys<T>, S> {
   const out: Partial<Record<ObjectKeys<T>, S>> = {};
-  for (const [key, value] of entries.strict(data)) {
+  for (const [key, value] of entries(data)) {
     // @ts-expect-error [ts2345] - FIXME!
     const mappedValue = fn(value, key);
     // @ts-expect-error [ts2536] - FIXME!

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -2,11 +2,13 @@ import type { ObjectKeys } from "./_types";
 import { entries } from "./entries";
 import { purry } from "./purry";
 
+type MappedValues<T, S> = { -readonly [P in keyof T]: S };
+
 /**
  * Maps values of `object` and keeps the same keys.
  *
  * @param data - The object to map.
- * @param fn - The mapping function.
+ * @param valueMapper - The mapping function.
  * @signature
  *    R.mapValues(object, fn)
  * @example
@@ -14,15 +16,15 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Object
  */
-export function mapValues<T extends Record<PropertyKey, unknown>, S>(
+export function mapValues<T extends object, S>(
   data: T,
-  fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S,
-): Record<ObjectKeys<T>, S>;
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+): MappedValues<T, S>;
 
 /**
  * Maps values of `object` and keeps the same keys.
  *
- * @param fn - The mapping function.
+ * @param valueMapper - The mapping function.
  * @signature
  *    R.mapValues(fn)(object)
  * @example
@@ -30,25 +32,25 @@ export function mapValues<T extends Record<PropertyKey, unknown>, S>(
  * @dataLast
  * @category Object
  */
-export function mapValues<T extends Record<PropertyKey, unknown>, S>(
-  fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S,
-): (data: T) => Record<ObjectKeys<T>, S>;
+export function mapValues<T extends object, S>(
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+): (data: T) => MappedValues<T, S>;
 
 export function mapValues(): unknown {
-  return purry(_mapValues, arguments);
+  return purry(mapValuesImplementation, arguments);
 }
 
-function _mapValues<T extends Record<PropertyKey, unknown>, S>(
+function mapValuesImplementation<T extends object, S>(
   data: T,
-  fn: (value: T[ObjectKeys<T>], key: ObjectKeys<T>) => S,
-): Record<ObjectKeys<T>, S> {
-  const out: Partial<Record<ObjectKeys<T>, S>> = {};
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+): MappedValues<T, S> {
+  const out: Partial<MappedValues<T, S>> = {};
+
   for (const [key, value] of entries(data)) {
     // @ts-expect-error [ts2345] - FIXME!
-    const mappedValue = fn(value, key);
-    // @ts-expect-error [ts2536] - FIXME!
+    const mappedValue = valueMapper(value, key);
     out[key] = mappedValue;
   }
-  // @ts-expect-error [ts2322] - We build the object incrementally so the type can't represent the final object.
-  return out;
+
+  return out as MappedValues<T, S>;
 }

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -45,7 +45,7 @@ function _omitBy<T>(
 
   const out: Partial<T> = {};
 
-  for (const key of keys.strict(object)) {
+  for (const key of keys(object)) {
     if (!fn(object[key], key)) {
       out[key] = object[key];
     }

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -29,7 +29,7 @@ describe("data last", () => {
   });
 });
 
-describe("strict typing", () => {
+describe("typing", () => {
   test("simple empty array", () => {
     const arr: Array<number> = [];
     const result = only(arr);

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -45,7 +45,7 @@ function _pickBy<T>(
 
   const out: Partial<T> = {};
 
-  for (const key of keys.strict(data)) {
+  for (const key of keys(data)) {
     if (fn(data[key], key)) {
       out[key] = data[key];
     }

--- a/src/sliceString.ts
+++ b/src/sliceString.ts
@@ -14,7 +14,6 @@
  *    R.sliceString(1)(`abcdefghijkl`) // => `bcdefghijkl`
  *    R.sliceString(4, 7)(`abcdefghijkl`) // => `efg`
  * @dataLast
- * @strict
  * @category String
  */
 export const sliceString =

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -18,7 +18,7 @@ describe("data_last", () => {
   });
 });
 
-describe("strict", () => {
+describe("typing", () => {
   it("on empty tuple", () => {
     const array: [] = [];
     const result = sort(array, (a, b) => a - b);

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -21,67 +21,67 @@ describe("data_last", () => {
 describe("strict", () => {
   it("on empty tuple", () => {
     const array: [] = [];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on empty readonly tuple", () => {
     const array: readonly [] = [];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on array", () => {
     const array: Array<number> = [];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on readonly array", () => {
     const array: ReadonlyArray<number> = [];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on tuple", () => {
     const array: [1, 2, 3] = [1, 2, 3];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on readonly tuple", () => {
     const array: readonly [1, 2, 3] = [1, 2, 3];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on tuple with rest tail", () => {
     const array: [number, ...Array<number>] = [1];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on readonly tuple with rest tail", () => {
     const array: readonly [number, ...Array<number>] = [1];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on tuple with rest head", () => {
     const array: [...Array<number>, number] = [1];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on readonly tuple with rest head", () => {
     const array: readonly [...Array<number>, number] = [1];
-    const result = sort.strict(array, (a, b) => a - b);
+    const result = sort(array, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on mixed types tuple", () => {
     const array: [number, string, boolean] = [1, "hello", true];
-    const result = sort.strict(array, () => 1);
+    const result = sort(array, () => 1);
     expectTypeOf(result).toEqualTypeOf<
       [
         boolean | number | string,

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -3,7 +3,7 @@ import { sort } from "./sort";
 
 describe("data_first", () => {
   test("sort", () => {
-    expect(sort([4, 2, 7, 5] as const, (a, b) => a - b)).toEqual([2, 4, 5, 7]);
+    expect(sort([4, 2, 7, 5], (a, b) => a - b)).toEqual([2, 4, 5, 7]);
   });
 });
 
@@ -11,7 +11,7 @@ describe("data_last", () => {
   test("sort", () => {
     expect(
       pipe(
-        [4, 2, 7, 5] as const,
+        [4, 2, 7, 5],
         sort((a, b) => a - b),
       ),
     ).toEqual([2, 4, 5, 7]);
@@ -20,68 +20,66 @@ describe("data_last", () => {
 
 describe("typing", () => {
   it("on empty tuple", () => {
-    const array: [] = [];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([] as [], (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on empty readonly tuple", () => {
-    const array: readonly [] = [];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([] as const, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on array", () => {
-    const array: Array<number> = [];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([] as Array<number>, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on readonly array", () => {
-    const array: ReadonlyArray<number> = [];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([] as ReadonlyArray<number>, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on tuple", () => {
-    const array: [1, 2, 3] = [1, 2, 3];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([1, 2, 3] as [1, 2, 3], (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on readonly tuple", () => {
-    const array: readonly [1, 2, 3] = [1, 2, 3];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([1, 2, 3] as const, (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on tuple with rest tail", () => {
-    const array: [number, ...Array<number>] = [1];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([1] as [number, ...Array<number>], (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on readonly tuple with rest tail", () => {
-    const array: readonly [number, ...Array<number>] = [1];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort(
+      [1] as readonly [number, ...Array<number>],
+      (a, b) => a - b,
+    );
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on tuple with rest head", () => {
-    const array: [...Array<number>, number] = [1];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort([1] as [...Array<number>, number], (a, b) => a - b);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on readonly tuple with rest head", () => {
-    const array: readonly [...Array<number>, number] = [1];
-    const result = sort(array, (a, b) => a - b);
+    const result = sort(
+      [1] as readonly [...Array<number>, number],
+      (a, b) => a - b,
+    );
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on mixed types tuple", () => {
-    const array: [number, string, boolean] = [1, "hello", true];
-    const result = sort(array, () => 1);
+    const result = sort(
+      [1, "hello", true] as [number, string, boolean],
+      () => 1,
+    );
     expectTypeOf(result).toEqualTypeOf<
       [
         boolean | number | string,

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,80 +1,57 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
+type Sorted<T extends IterableContainer> = {
+  -readonly [P in keyof T]: T[number];
+};
+
 /**
- * Sorts an array. The comparator function should accept two values at a time and return a negative number if the first value is smaller, a positive number if it's larger, and zero if they are equal.
- * Sorting is based on a native `sort` function. It's not guaranteed to be stable.
- *
- * If the input array is more complex (non-empty array, tuple, etc...) use the
- * strict mode to maintain it's shape.
+ * Sorts an array. The comparator function should accept two values at a time
+ * and return a negative number if the first value is smaller, a positive number
+ * if it's larger, and zero if they are equal. Sorting is based on a native
+ * `sort` function.
  *
  * @param items - The array to sort.
  * @param cmp - The comparator function.
  * @signature
  *    R.sort(items, cmp)
- *    R.sort.strict(items, cmp)
  * @example
- *    R.sort([4, 2, 7, 5], (a, b) => a - b) // => [2, 4, 5, 7] typed Array<number>
- *    R.sort.strict([4, 2] as [number, number], (a, b) => a - b) // [2, 4] typed [number, number]
+ *    R.sort([4, 2] as [number, number], (a, b) => a - b) // [2, 4] typed [number, number]
  * @dataFirst
- * @strict
  * @category Array
  */
-export function sort<T>(
-  items: ReadonlyArray<T>,
-  cmp: (a: T, b: T) => number,
-): Array<T>;
+export function sort<T extends IterableContainer>(
+  items: T,
+  cmp: (a: T[number], b: T[number]) => number,
+): Sorted<T>;
 
 /**
- * Sorts an array. The comparator function should accept two values at a time and return a negative number if the first value is smaller, a positive number if it's larger, and zero if they are equal.
- * Sorting is based on a native `sort` function. It's not guaranteed to be stable.
- *
- * If the input array is more complex (non-empty array, tuple, etc...) use the
- * strict mode to maintain it's shape.
+ * Sorts an array. The comparator function should accept two values at a time
+ * and return a negative number if the first value is smaller, a positive number
+ * if it's larger, and zero if they are equal. Sorting is based on a native
+ * `sort` function.
  *
  * @param cmp - The comparator function.
  * @signature
  *    R.sort(cmp)(items)
- *    R.sort.strict(cmp)(items)
  * @example
- *    R.pipe([4, 2, 7, 5], R.sort((a, b) => a - b)) // => [2, 4, 5, 7] typed Array<number>
- *    R.pipe([4, 2] as [number, number], R.sort.strict((a, b) => a - b)) // => [2, 4] typed [number, number]
+ *    R.pipe([4, 2] as [number, number], R.sort((a, b) => a - b)) // => [2, 4] typed [number, number]
  * @dataLast
- * @strict
  * @category Array
  */
-export function sort<T>(
-  cmp: (a: T, b: T) => number,
-): (items: ReadonlyArray<T>) => Array<T>;
+export function sort<T extends IterableContainer>(
+  cmp: (a: T[number], b: T[number]) => number,
+): (items: T) => Sorted<T>;
 
 export function sort(): unknown {
-  return purry(_sort, arguments);
+  return purry(sortImplementation, arguments);
 }
 
-function _sort<T>(
-  items: ReadonlyArray<T>,
-  cmp: (a: T, b: T) => number,
-): Array<T> {
+function sortImplementation<T extends IterableContainer>(
+  items: T,
+  cmp: (a: T[number], b: T[number]) => number,
+): Sorted<T> {
   const ret = items.slice();
   ret.sort(cmp);
-  return ret;
-}
-
-type Strict = {
-  <T extends IterableContainer>(
-    items: T,
-    cmp: (a: T[number], b: T[number]) => number,
-  ): Sorted<T>;
-
-  <T extends IterableContainer>(
-    cmp: (a: T[number], b: T[number]) => number,
-  ): (items: T) => Sorted<T>;
-};
-
-type Sorted<T extends IterableContainer> = {
-  -readonly [P in keyof T]: T[number];
-};
-
-export namespace sort {
-  export const strict: Strict = sort;
+  return ret as Sorted<T>;
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,9 +1,5 @@
-import type { IterableContainer } from "./_types";
+import type { IterableContainer, ReorderedArray } from "./_types";
 import { purry } from "./purry";
-
-type Sorted<T extends IterableContainer> = {
-  -readonly [P in keyof T]: T[number];
-};
 
 /**
  * Sorts an array. The comparator function should accept two values at a time
@@ -16,14 +12,14 @@ type Sorted<T extends IterableContainer> = {
  * @signature
  *    R.sort(items, cmp)
  * @example
- *    R.sort([4, 2] as [number, number], (a, b) => a - b) // [2, 4] typed [number, number]
+ *    R.sort([4, 2, 7, 5], (a, b) => a - b); // => [2, 4, 5, 7]
  * @dataFirst
  * @category Array
  */
 export function sort<T extends IterableContainer>(
   items: T,
   cmp: (a: T[number], b: T[number]) => number,
-): Sorted<T>;
+): ReorderedArray<T>;
 
 /**
  * Sorts an array. The comparator function should accept two values at a time
@@ -35,13 +31,13 @@ export function sort<T extends IterableContainer>(
  * @signature
  *    R.sort(cmp)(items)
  * @example
- *    R.pipe([4, 2] as [number, number], R.sort((a, b) => a - b)) // => [2, 4] typed [number, number]
+ *    R.pipe([4, 2, 7, 5], R.sort((a, b) => a - b)) // => [2, 4, 5, 7]
  * @dataLast
  * @category Array
  */
 export function sort<T extends IterableContainer>(
   cmp: (a: T[number], b: T[number]) => number,
-): (items: T) => Sorted<T>;
+): (items: T) => ReorderedArray<T>;
 
 export function sort(): unknown {
   return purry(sortImplementation, arguments);
@@ -50,8 +46,8 @@ export function sort(): unknown {
 function sortImplementation<T extends IterableContainer>(
   items: T,
   cmp: (a: T[number], b: T[number]) => number,
-): Sorted<T> {
+): ReorderedArray<T> {
   const ret = items.slice();
   ret.sort(cmp);
-  return ret as Sorted<T>;
+  return ret as ReorderedArray<T>;
 }

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -142,91 +142,91 @@ describe("data last", () => {
 describe("strict", () => {
   it("on empty tuple", () => {
     const array: [] = [];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on empty readonly tuple", () => {
     const array: readonly [] = [];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on array", () => {
     const array: Array<number> = [];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on readonly array", () => {
     const array: ReadonlyArray<number> = [];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on tuple", () => {
     const array: [1, 2, 3] = [1, 2, 3];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on readonly tuple", () => {
     const array: readonly [1, 2, 3] = [1, 2, 3];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on tuple with rest tail", () => {
     const array: [number, ...Array<number>] = [1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on readonly tuple with rest tail", () => {
     const array: readonly [number, ...Array<number>] = [1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   test("on tuple with rest middle", () => {
     const array: [number, ...Array<number>, number] = [3, 2, 1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>, number]>();
   });
 
   test("on readonly tuple with rest middle", () => {
     const array: readonly [number, ...Array<number>, number] = [3, 2, 1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>, number]>();
   });
 
   it("on tuple with rest head", () => {
     const array: [...Array<number>, number] = [1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on readonly tuple with rest head", () => {
     const array: readonly [...Array<number>, number] = [1];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   test("on tuple with optional values", () => {
     const array: [number?, number?, number?] = [];
-    const result = sortBy.strict(array, () => 0);
+    const result = sortBy(array, () => 0);
     expectTypeOf(result).toEqualTypeOf<[number?, number?, number?]>();
   });
 
   test("on readonly tuple with optional values", () => {
     const array: readonly [number?, number?, number?] = [];
-    const result = sortBy.strict(array, () => 0);
+    const result = sortBy(array, () => 0);
     expectTypeOf(result).toEqualTypeOf<[number?, number?, number?]>();
   });
 
   it("on mixed types tuple", () => {
     const array: [number, string, boolean] = [1, "hello", true];
-    const result = sortBy.strict(array, identity);
+    const result = sortBy(array, identity);
     expectTypeOf(result).toEqualTypeOf<
       [
         boolean | number | string,

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -1,5 +1,7 @@
 import { identity } from "./identity";
+import { map } from "./map";
 import { pipe } from "./pipe";
+import { prop } from "./prop";
 import { sortBy } from "./sortBy";
 
 const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
@@ -99,23 +101,17 @@ describe("data last", () => {
     );
   });
   test("sort objects correctly", () => {
-    const sortFn = sortBy<{ weight: number; color: string }>(
-      (x) => x.weight,
-      (x) => x.color,
-    );
-    expect(sortFn(objects).map((x) => x.color)).toEqual([
-      "green",
-      "purple",
-      "red",
-      "blue",
-    ]);
+    expect(
+      pipe(objects, sortBy(prop("weight"), prop("color")), map(prop("color"))),
+    ).toEqual(["green", "purple", "red", "blue"]);
   });
   test("sort objects correctly by weight asc then color desc", () => {
     expect(
-      sortBy<{ weight: number; color: string }>(
-        [(x) => x.weight, "asc"],
-        [(x) => x.color, "desc"],
-      )(objects).map((x) => x.color),
+      pipe(
+        objects,
+        sortBy([prop("weight"), "asc"], [prop("color"), "desc"]),
+        map(prop("color")),
+      ),
     ).toEqual(["purple", "green", "red", "blue"]);
   });
 

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -1,3 +1,4 @@
+import { constant } from "./constant";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
@@ -31,65 +32,67 @@ const DATA = [
 
 describe("data first", () => {
   test("sort correctly", () => {
-    expect(
-      sortBy([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const, (x) => x.a),
-    ).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]);
+    expect(sortBy([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }], prop("a"))).toEqual(
+      [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }],
+    );
   });
+
   test("sort booleans correctly", () => {
-    expect(
-      sortBy(DATA, [(x) => x.active, "desc"]).map((x) => x.active),
-    ).toEqual([true, true, false, false]);
+    expect(sortBy(DATA, [prop("active"), "desc"]).map(prop("active"))).toEqual([
+      true,
+      true,
+      false,
+      false,
+    ]);
   });
+
   test("sort dates correctly", () => {
-    expect(sortBy(DATA, [(x) => x.date, "desc"]).map((x) => x.id)).toEqual([
+    expect(sortBy(DATA, [prop("date"), "desc"]).map(prop("id"))).toEqual([
       4, 3, 2, 1,
     ]);
   });
+
   test("sort objects correctly", () => {
     expect(
-      sortBy(
-        DATA,
-        (x) => x.weight,
-        (x) => x.color,
-      ).map((x) => x.weight),
+      sortBy(DATA, prop("weight"), prop("color")).map(prop("weight")),
     ).toEqual([1, 1, 2, 3]);
   });
+
   test("sort objects correctly mixing sort pair and sort projection", () => {
     expect(
-      sortBy(DATA, (x) => x.weight, [(x) => x.color, "asc"]).map(
-        (x) => x.weight,
-      ),
+      sortBy(DATA, prop("weight"), [prop("color"), "asc"]).map(prop("weight")),
     ).toEqual([1, 1, 2, 3]);
   });
+
   test("sort objects descending correctly", () => {
-    expect(
-      sortBy(DATA, [(x) => x.weight, "desc"]).map((x) => x.weight),
-    ).toEqual([3, 2, 1, 1]);
+    expect(sortBy(DATA, [prop("weight"), "desc"]).map(prop("weight"))).toEqual([
+      3, 2, 1, 1,
+    ]);
   });
 });
 
 describe("data last", () => {
   test("sort correctly", () => {
     expect(
-      pipe(
-        [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const,
-        sortBy((x) => x.a),
-      ),
+      pipe([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }], sortBy(prop("a"))),
     ).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]);
   });
+
   test('sort correctly using pipe and "desc"', () => {
     expect(
       pipe(
-        [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const,
-        sortBy([(x) => x.a, "desc"]),
+        [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
+        sortBy([prop("a"), "desc"]),
       ),
     ).toEqual([{ a: 7 }, { a: 3 }, { a: 2 }, { a: 1 }]);
   });
+
   test("sort objects correctly", () => {
     expect(
       pipe(DATA, sortBy(prop("weight"), prop("color")), map(prop("color"))),
     ).toEqual(["green", "purple", "red", "blue"]);
   });
+
   test("sort objects correctly by weight asc then color desc", () => {
     expect(
       pipe(
@@ -105,125 +108,116 @@ describe("typing", () => {
   describe("dataFirst", () => {
     test("SortProjection", () => {
       const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
-      const actual = sortBy(items, (x) => x.a);
-      type T = (typeof items)[number];
-      assertType<Array<T>>(actual);
+      const actual = sortBy(items, prop("a"));
+      expectTypeOf(actual).toMatchTypeOf<Array<(typeof items)[number]>>();
     });
 
     test("SortPair", () => {
       const actual = sortBy(DATA, [(x) => x.active, "desc"]);
-      type T = (typeof DATA)[number];
-      assertType<Array<T>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<Array<(typeof DATA)[number]>>();
     });
   });
 
   describe("dataLast", () => {
     test("SortProjection", () => {
       const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
-      const actual = pipe(
-        items,
-        sortBy((x) => x.a),
-      );
-      type T = (typeof items)[number];
-      assertType<Array<T>>(actual);
+      const actual = pipe(items, sortBy(prop("a")));
+      expectTypeOf(actual).toMatchTypeOf<Array<(typeof items)[number]>>();
     });
+
     test("SortPair", () => {
       const actual = pipe(
         DATA,
-        sortBy([(x) => x.weight, "asc"], [(x) => x.color, "desc"]),
+        sortBy([prop("weight"), "asc"], [prop("color"), "desc"]),
       );
-      type T = (typeof DATA)[number];
-      assertType<Array<T>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<Array<(typeof DATA)[number]>>();
     });
   });
 
   it("on empty tuple", () => {
-    const array: [] = [];
-    const result = sortBy(array, identity);
+    const result = sortBy([] as [], identity);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on empty readonly tuple", () => {
-    const array: readonly [] = [];
-    const result = sortBy(array, identity);
+    const result = sortBy([] as const, identity);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   it("on array", () => {
-    const array: Array<number> = [];
-    const result = sortBy(array, identity);
+    const result = sortBy([] as Array<number>, identity);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on readonly array", () => {
-    const array: ReadonlyArray<number> = [];
-    const result = sortBy(array, identity);
+    const result = sortBy([] as ReadonlyArray<number>, identity);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   it("on tuple", () => {
-    const array: [1, 2, 3] = [1, 2, 3];
-    const result = sortBy(array, identity);
+    const result = sortBy([1, 2, 3] as [1, 2, 3], identity);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on readonly tuple", () => {
-    const array: readonly [1, 2, 3] = [1, 2, 3];
-    const result = sortBy(array, identity);
+    const result = sortBy([1, 2, 3] as const, identity);
     expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
   });
 
   it("on tuple with rest tail", () => {
-    const array: [number, ...Array<number>] = [1];
-    const result = sortBy(array, identity);
+    const result = sortBy([1] as [number, ...Array<number>], identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   it("on readonly tuple with rest tail", () => {
-    const array: readonly [number, ...Array<number>] = [1];
-    const result = sortBy(array, identity);
+    const result = sortBy([1] as readonly [number, ...Array<number>], identity);
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
   test("on tuple with rest middle", () => {
-    const array: [number, ...Array<number>, number] = [3, 2, 1];
-    const result = sortBy(array, identity);
+    const result = sortBy(
+      [3, 2, 1] as [number, ...Array<number>, number],
+      identity,
+    );
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>, number]>();
   });
 
   test("on readonly tuple with rest middle", () => {
-    const array: readonly [number, ...Array<number>, number] = [3, 2, 1];
-    const result = sortBy(array, identity);
+    const result = sortBy(
+      [3, 2, 1] as readonly [number, ...Array<number>, number],
+      identity,
+    );
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>, number]>();
   });
 
   it("on tuple with rest head", () => {
-    const array: [...Array<number>, number] = [1];
-    const result = sortBy(array, identity);
+    const result = sortBy([1] as [...Array<number>, number], identity);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   it("on readonly tuple with rest head", () => {
-    const array: readonly [...Array<number>, number] = [1];
-    const result = sortBy(array, identity);
+    const result = sortBy([1] as readonly [...Array<number>, number], identity);
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
   test("on tuple with optional values", () => {
-    const array: [number?, number?, number?] = [];
-    const result = sortBy(array, () => 0);
+    const result = sortBy([] as [number?, number?, number?], constant(0));
     expectTypeOf(result).toEqualTypeOf<[number?, number?, number?]>();
   });
 
   test("on readonly tuple with optional values", () => {
-    const array: readonly [number?, number?, number?] = [];
-    const result = sortBy(array, () => 0);
+    const result = sortBy(
+      [] as readonly [number?, number?, number?],
+      constant(0),
+    );
     expectTypeOf(result).toEqualTypeOf<[number?, number?, number?]>();
   });
 
   it("on mixed types tuple", () => {
-    const array: [number, string, boolean] = [1, "hello", true];
-    const result = sortBy(array, identity);
+    const result = sortBy(
+      [1, "hello", true] as [number, string, boolean],
+      identity,
+    );
     expectTypeOf(result).toEqualTypeOf<
       [
         boolean | number | string,

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -4,11 +4,8 @@ import type {
   CompareFunction,
   IterableContainer,
   NonEmptyArray,
+  ReorderedArray,
 } from "./_types";
-
-type SortedBy<T extends IterableContainer> = {
-  -readonly [P in keyof T]: T[number];
-};
 
 /**
  * Sorts `data` using the provided ordering rules. The `sort` is done via the
@@ -34,15 +31,15 @@ type SortedBy<T extends IterableContainer> = {
  *    R.sortBy(...rules)(data)
  * @example
  *    R.pipe(
- *      [{ a: 1 }, { a: 3 }] as const,
- *      R.sortBy(x => x.a)
- *    ) // => [{ a: 1 }, { a: 3 }] typed [{a: 1 | 3}, {a: 1 | 3}]
+ *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
+ *      R.sortBy(R.prop('a')),
+ *    ); // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]
  * @dataLast
  * @category Array
  */
 export function sortBy<T extends IterableContainer>(
   ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
-): (array: T) => SortedBy<T>;
+): (array: T) => ReorderedArray<T>;
 
 /**
  * Sorts `data` using the provided ordering rules. The `sort` is done via the
@@ -69,32 +66,31 @@ export function sortBy<T extends IterableContainer>(
  *    R.sortBy(data, ...rules)
  * @example
  *    R.sortBy(
- *     [
- *       {color: 'red', weight: 2},
- *       {color: 'blue', weight: 3},
- *       {color: 'green', weight: 1},
- *       {color: 'purple', weight: 1},
- *     ],
- *      [x => x.weight, 'asc'], x => x.color
- *    )
- *    // =>
+ *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
+ *      prop('a'),
+ *    );  // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]
+ *    R.sortBy(
+ *      [
+ *        {color: 'red', weight: 2},
+ *        {color: 'blue', weight: 3},
+ *        {color: 'green', weight: 1},
+ *        {color: 'purple', weight: 1},
+ *      ],
+ *      [prop('weight'), 'asc'],
+ *      prop('color'),
+ *    ); // => [
  *    //   {color: 'green', weight: 1},
  *    //   {color: 'purple', weight: 1},
  *    //   {color: 'red', weight: 2},
  *    //   {color: 'blue', weight: 3},
- *    // typed Array<{color: string, weight: number}>
- *
- *    R.sortBy(
- *      [{ a: 1 }, { a: 3 }] as const,
- *      x => x.a
- *    ); // => [{ a: 1 }, { a: 3 }] typed [{a: 1 | 3}, {a: 1 | 3}]
+ *    // ]
  * @dataFirst
  * @category Array
  */
 export function sortBy<T extends IterableContainer>(
   array: T,
   ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
-): SortedBy<T>;
+): ReorderedArray<T>;
 
 export function sortBy(): unknown {
   return purryOrderRules(sortByImplementation, arguments);

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -6,12 +6,17 @@ import type {
   NonEmptyArray,
 } from "./_types";
 
+type SortedBy<T extends IterableContainer> = {
+  -readonly [P in keyof T]: T[number];
+};
+
 /**
- * Sorts `data` using the provided ordering rules. The `sort` is done via the native `Array.prototype.sort` but is performed on a shallow copy of the array to avoid mutating the original data.
+ * Sorts `data` using the provided ordering rules. The `sort` is done via the
+ * native `Array.prototype.sort` but is performed on a shallow copy of the array
+ * to avoid mutating the original data.
  *
- * To maintain the shape of more complex inputs (like non-empty arrays, tuples, etc...) use the `strict` variant.
- *
- * There are several other functions that take order rules and **bypass** the need to sort the array first (in *O(nlogn)* time):
+ * There are several other functions that take order rules and **bypass** the
+ * need to sort the array first (in *O(nlogn)* time):
  * * `firstBy` === `first(sortBy(data, ...rules))`, O(n).
  * * `takeFirstBy` === `take(sortBy(data, ...rules), k)`, O(nlogk).
  * * `dropFirstBy` === `drop(sortBy(data, ...rules), k)`, O(nlogk).
@@ -19,34 +24,33 @@ import type {
  * * `rankBy` === `sortedIndex(sortBy(data, ...rules), item)`, O(n).
  * Refer to the docs for more details.
  *
- * @param rules - A variadic array of order rules defining the sorting criteria. Each order rule is a projection function that extracts a comparable value from the data. Sorting is based on these extracted values using the native `<` and `>` operators. Earlier rules take precedence over later ones. Use the syntax `[projection, "desc"]` for descending order.
+ * @param rules - A variadic array of order rules defining the sorting criteria.
+ * Each order rule is a projection function that extracts a comparable value
+ * from the data. Sorting is based on these extracted values using the native
+ * `<` and `>` operators. Earlier rules take precedence over later ones. Use the
+ * syntax `[projection, "desc"]` for descending order.
  * @returns A shallow copy of the input array sorted by the provided rules.
  * @signature
  *    R.sortBy(...rules)(data)
- *    R.sortBy.strict(...rules)(data)
  * @example
  *    R.pipe(
- *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
- *      R.sortBy(x => x.a)
- *    ) // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }] typed Array<{a:number}>
- *    R.pipe(
  *      [{ a: 1 }, { a: 3 }] as const,
- *      R.sortBy.strict(x => x.a)
+ *      R.sortBy(x => x.a)
  *    ) // => [{ a: 1 }, { a: 3 }] typed [{a: 1 | 3}, {a: 1 | 3}]
  * @dataLast
- * @strict
  * @category Array
  */
-export function sortBy<T>(
-  ...rules: Readonly<NonEmptyArray<OrderRule<T>>>
-): (data: ReadonlyArray<T>) => Array<T>;
+export function sortBy<T extends IterableContainer>(
+  ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
+): (array: T) => SortedBy<T>;
 
 /**
- * Sorts `data` using the provided ordering rules. The `sort` is done via the native `Array.prototype.sort` but is performed on a shallow copy of the array to avoid mutating the original data.
+ * Sorts `data` using the provided ordering rules. The `sort` is done via the
+ * native `Array.prototype.sort` but is performed on a shallow copy of the array
+ * to avoid mutating the original data.
  *
- * To maintain the shape of more complex inputs (like non-empty arrays, tuples, etc...) use the `strict` variant.
- *
- * There are several other functions that take order rules and **bypass** the need to sort the array first (in *O(nlogn)* time):
+ * There are several other functions that take order rules and **bypass** the
+ * need to sort the array first (in *O(nlogn)* time):
  * * `firstBy` === `first(sortBy(data, ...rules))`, O(n).
  * * `takeFirstBy` === `take(sortBy(data, ...rules), k)`, O(nlogk).
  * * `dropFirstBy` === `drop(sortBy(data, ...rules), k)`, O(nlogk).
@@ -55,18 +59,16 @@ export function sortBy<T>(
  * Refer to the docs for more details.
  *
  * @param array - The input array.
+ * @param rules - A variadic array of order rules defining the sorting criteria.
+ * Each order rule is a projection function that extracts a comparable value
+ * from the data. Sorting is based on these extracted values using the native
+ * `<` and `>` operators. Earlier rules take precedence over later ones. Use the
+ * syntax `[projection, "desc"]` for descending order.
  * @param sortRules - A variadic array of order rules defining the sorting criteria. Each order rule is a projection function that extracts a comparable value from the data. Sorting is based on these extracted values using the native `<` and `>` operators. Earlier rules take precedence over later ones. Use the syntax `[projection, "desc"]` for descending order.
  * @returns A shallow copy of the input array sorted by the provided rules.
  * @signature
  *    R.sortBy(data, ...rules)
- *    R.sortBy.strict(data, ...rules)
  * @example
- *    R.sortBy(
- *      [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
- *      x => x.a
- *    )
- *    // => [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }] typed Array<{a:number}>
- *
  *    R.sortBy(
  *     [
  *       {color: 'red', weight: 2},
@@ -83,46 +85,25 @@ export function sortBy<T>(
  *    //   {color: 'blue', weight: 3},
  *    // typed Array<{color: string, weight: number}>
  *
- *    R.sortBy.strict(
+ *    R.sortBy(
  *      [{ a: 1 }, { a: 3 }] as const,
  *      x => x.a
- *    )
- *    // => [{ a: 1 }, { a: 3 }] typed [{a: 1 | 3}, {a: 1 | 3}]
+ *    ); // => [{ a: 1 }, { a: 3 }] typed [{a: 1 | 3}, {a: 1 | 3}]
  * @dataFirst
- * @strict
  * @category Array
  */
-export function sortBy<T>(
-  array: ReadonlyArray<T>,
-  ...sortRules: Readonly<NonEmptyArray<OrderRule<T>>>
-): Array<T>;
+export function sortBy<T extends IterableContainer>(
+  array: T,
+  ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
+): SortedBy<T>;
 
 export function sortBy(): unknown {
-  return purryOrderRules(_sortBy, arguments);
+  return purryOrderRules(sortByImplementation, arguments);
 }
 
-const _sortBy = <T>(
+const sortByImplementation = <T>(
   data: ReadonlyArray<T>,
   compareFn: CompareFunction<T>,
 ): Array<T> =>
   // Sort is done in-place so we need to copy the array.
   data.slice().sort(compareFn);
-
-type Strict = {
-  <T extends IterableContainer>(
-    ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
-  ): (array: T) => SortedBy<T>;
-
-  <T extends IterableContainer>(
-    array: T,
-    ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
-  ): SortedBy<T>;
-};
-
-type SortedBy<T extends IterableContainer> = {
-  -readonly [P in keyof T]: T[number];
-};
-
-export namespace sortBy {
-  export const strict: Strict = sortBy;
-}

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -24,11 +24,11 @@ type SortedBy<T extends IterableContainer> = {
  * * `rankBy` === `sortedIndex(sortBy(data, ...rules), item)`, O(n).
  * Refer to the docs for more details.
  *
- * @param rules - A variadic array of order rules defining the sorting criteria.
- * Each order rule is a projection function that extracts a comparable value
- * from the data. Sorting is based on these extracted values using the native
- * `<` and `>` operators. Earlier rules take precedence over later ones. Use the
- * syntax `[projection, "desc"]` for descending order.
+ * @param sortRules - A variadic array of order rules defining the sorting
+ * criteria. Each order rule is a projection function that extracts a comparable
+ * value from the data. Sorting is based on these extracted values using the
+ * native `<` and `>` operators. Earlier rules take precedence over later ones.
+ * Use the syntax `[projection, "desc"]` for descending order.
  * @returns A shallow copy of the input array sorted by the provided rules.
  * @signature
  *    R.sortBy(...rules)(data)
@@ -59,12 +59,11 @@ export function sortBy<T extends IterableContainer>(
  * Refer to the docs for more details.
  *
  * @param array - The input array.
- * @param rules - A variadic array of order rules defining the sorting criteria.
- * Each order rule is a projection function that extracts a comparable value
- * from the data. Sorting is based on these extracted values using the native
- * `<` and `>` operators. Earlier rules take precedence over later ones. Use the
- * syntax `[projection, "desc"]` for descending order.
- * @param sortRules - A variadic array of order rules defining the sorting criteria. Each order rule is a projection function that extracts a comparable value from the data. Sorting is based on these extracted values using the native `<` and `>` operators. Earlier rules take precedence over later ones. Use the syntax `[projection, "desc"]` for descending order.
+ * @param sortRules - A variadic array of order rules defining the sorting
+ * criteria. Each order rule is a projection function that extracts a comparable
+ * value from the data. Sorting is based on these extracted values using the
+ * native `<` and `>` operators. Earlier rules take precedence over later ones.
+ * Use the syntax `[projection, "desc"]` for descending order.
  * @returns A shallow copy of the input array sorted by the provided rules.
  * @signature
  *    R.sortBy(data, ...rules)

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -87,62 +87,62 @@ describe("dataLast typings", () => {
 describe("strict dataFirst typings", () => {
   test("on empty tuples", () => {
     const array: [] = [];
-    const result = zip.strict(array, array);
+    const result = zip(array, array);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("on empty readonly tuples", () => {
     const array: readonly [] = [];
-    const result = zip.strict(array, array);
+    const result = zip(array, array);
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("on arrays", () => {
     const array: Array<number> = [];
-    const result = zip.strict(array, array);
+    const result = zip(array, array);
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   test("on mixed typeds array", () => {
     const array1: Array<number> = [];
     const array2: Array<string> = [];
-    const result = zip.strict(array1, array2);
+    const result = zip(array1, array2);
     expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
   });
 
   test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [];
-    const result = zip.strict(array, array);
+    const result = zip(array, array);
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   test("on tuples", () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5, 6] = [4, 5, 6];
-    const result = zip.strict(array1, array2);
+    const result = zip(array1, array2);
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   test("on readonly tuples", () => {
     const array1: readonly [1, 2, 3] = [1, 2, 3];
     const array2: readonly [4, 5, 6] = [4, 5, 6];
-    const result = zip.strict(array1, array2);
+    const result = zip(array1, array2);
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   test("on tuples of different lengths", () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5] = [4, 5];
-    const result1 = zip.strict(array1, array2);
+    const result1 = zip(array1, array2);
     expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
-    const result2 = zip.strict(array2, array1);
+    const result2 = zip(array2, array1);
     expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
   });
 
   test("on variadic tuples", () => {
     const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const result = zip.strict(firstVariadic, secondVariadic);
+    const result = zip(firstVariadic, secondVariadic);
     expectTypeOf(result).toEqualTypeOf<
       [[number, string], ...Array<[string, number]>]
     >();
@@ -152,62 +152,62 @@ describe("strict dataFirst typings", () => {
 describe("strict dataLast typings", () => {
   test("on empty tuples", () => {
     const array: [] = [];
-    const result = pipe(array, zip.strict(array));
+    const result = pipe(array, zip(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("on empty readonly tuples", () => {
     const array: readonly [] = [];
-    const result = pipe(array, zip.strict(array));
+    const result = pipe(array, zip(array));
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
   test("on arrays", () => {
     const array: Array<number> = [];
-    const result = pipe(array, zip.strict(array));
+    const result = pipe(array, zip(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   test("on mixed typeds array", () => {
     const array1: Array<number> = [];
     const array2: Array<string> = [];
-    const result = pipe(array1, zip.strict(array2));
+    const result = pipe(array1, zip(array2));
     expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
   });
 
   test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [];
-    const result = pipe(array, zip.strict(array));
+    const result = pipe(array, zip(array));
     expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
   });
 
   test("on tuples", () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5, 6] = [4, 5, 6];
-    const result = pipe(array1, zip.strict(array2));
+    const result = pipe(array1, zip(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   test("on readonly tuples", () => {
     const array1: readonly [1, 2, 3] = [1, 2, 3];
     const array2: readonly [4, 5, 6] = [4, 5, 6];
-    const result = pipe(array1, zip.strict(array2));
+    const result = pipe(array1, zip(array2));
     expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
   });
 
   test("on tuples of different lengths", () => {
     const array1: [1, 2, 3] = [1, 2, 3];
     const array2: [4, 5] = [4, 5];
-    const result1 = pipe(array1, zip.strict(array2));
+    const result1 = pipe(array1, zip(array2));
     expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
-    const result2 = pipe(array2, zip.strict(array1));
+    const result2 = pipe(array2, zip(array1));
     expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
   });
 
   test("on variadic tuples", () => {
     const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const result = pipe(firstVariadic, zip.strict(secondVariadic));
+    const result = pipe(firstVariadic, zip(secondVariadic));
     expectTypeOf(result).toEqualTypeOf<
       [[number, string], ...Array<[string, number]>]
     >();

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -55,7 +55,9 @@ describe("typing", () => {
   describe("dataFirst", () => {
     test("arrays", () => {
       const actual = zip([1, 2, 3], ["a", "b", "c"]);
-      assertType<Array<[number, string]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<
+        [[number, string], [number, string], [number, string]]
+      >();
     });
 
     test("tuples", () => {
@@ -63,14 +65,16 @@ describe("typing", () => {
         [1, 2, 3] as [1, 2, 3],
         ["a", "b", "c"] as ["a", "b", "c"],
       );
-      assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<[[1, "a"], [2, "b"], [3, "c"]]>();
     });
 
     test("variadic tuples", () => {
       const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
       const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
       const actual = zip(firstVariadic, secondVariadic);
-      assertType<Array<[number | string, number | string]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<
+        [[number, string], ...Array<[string, number]>]
+      >();
     });
 
     test("on empty tuples", () => {
@@ -140,20 +144,24 @@ describe("typing", () => {
   describe("dataLast", () => {
     test("arrays", () => {
       const actual = pipe([1, 2, 3], zip(["a", "b", "c"]));
-      assertType<Array<[number, string]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<
+        [[number, string], [number, string], [number, string]]
+      >();
     });
     test("tuples", () => {
       const actual = pipe(
         [1, 2, 3] as [1, 2, 3],
         zip(["a", "b", "c"] as ["a", "b", "c"]),
       );
-      assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<[[1, "a"], [2, "b"], [3, "c"]]>();
     });
     test("variadic tuples", () => {
       const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
       const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
       const actual = pipe(firstVariadic, zip(secondVariadic));
-      assertType<Array<[number | string, number | string]>>(actual);
+      expectTypeOf(actual).toEqualTypeOf<
+        [[number, string], ...Array<[string, number]>]
+      >();
     });
 
     test("on empty tuples", () => {

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -1,215 +1,222 @@
 import { pipe } from "./pipe";
 import { zip } from "./zip";
 
-const first = [1, 2, 3];
-const second = ["a", "b", "c"];
-const shorterFirst = [1, 2];
-const shorterSecond = ["a", "b"];
+describe("runtime", () => {
+  describe("dataFirst", () => {
+    test("should zip", () => {
+      expect(zip([1, 2, 3], ["a", "b", "c"])).toEqual([
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+      ]);
+    });
 
-describe("dataFirst", () => {
-  test("should zip", () => {
-    expect(zip(first, second)).toEqual([
-      [1, "a"],
-      [2, "b"],
-      [3, "c"],
-    ]);
+    test("should truncate to shorter second", () => {
+      expect(zip([1, 2, 3], ["a", "b"])).toEqual([
+        [1, "a"],
+        [2, "b"],
+      ]);
+    });
+
+    test("should truncate to shorter first", () => {
+      expect(zip([1, 2], ["a", "b", "c"])).toEqual([
+        [1, "a"],
+        [2, "b"],
+      ]);
+    });
   });
-  test("should truncate to shorter second", () => {
-    expect(zip(first, shorterSecond)).toEqual([
-      [1, "a"],
-      [2, "b"],
-    ]);
-  });
-  test("should truncate to shorter first", () => {
-    expect(zip(shorterFirst, second)).toEqual([
-      [1, "a"],
-      [2, "b"],
-    ]);
+
+  describe("dataLast", () => {
+    test("should zip", () => {
+      expect(zip(["a", "b", "c"])([1, 2, 3])).toEqual([
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+      ]);
+    });
+
+    test("should truncate to shorter second", () => {
+      expect(zip(["a", "b"])([1, 2, 3])).toEqual([
+        [1, "a"],
+        [2, "b"],
+      ]);
+    });
+
+    test("should truncate to shorter first", () => {
+      expect(zip(["a", "b", "c"])([1, 2])).toEqual([
+        [1, "a"],
+        [2, "b"],
+      ]);
+    });
   });
 });
 
-describe("dataFirst typings", () => {
-  test("arrays", () => {
-    const actual = zip(first, second);
-    assertType<Array<[number, string]>>(actual);
-  });
-  test("tuples", () => {
-    const actual = zip(first as [1, 2, 3], second as ["a", "b", "c"]);
-    assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
-  });
-  test("variadic tuples", () => {
-    const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
-    const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const actual = zip(firstVariadic, secondVariadic);
-    assertType<Array<[number | string, number | string]>>(actual);
-  });
-});
+describe("typing", () => {
+  describe("dataFirst", () => {
+    test("arrays", () => {
+      const actual = zip([1, 2, 3], ["a", "b", "c"]);
+      assertType<Array<[number, string]>>(actual);
+    });
 
-describe("dataLast", () => {
-  test("should zip", () => {
-    expect(zip(second)(first)).toEqual([
-      [1, "a"],
-      [2, "b"],
-      [3, "c"],
-    ]);
-  });
-  test("should truncate to shorter second", () => {
-    expect(zip(shorterSecond)(first)).toEqual([
-      [1, "a"],
-      [2, "b"],
-    ]);
-  });
-  test("should truncate to shorter first", () => {
-    expect(zip(second)(shorterFirst)).toEqual([
-      [1, "a"],
-      [2, "b"],
-    ]);
-  });
-});
+    test("tuples", () => {
+      const actual = zip(
+        [1, 2, 3] as [1, 2, 3],
+        ["a", "b", "c"] as ["a", "b", "c"],
+      );
+      assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
+    });
 
-describe("dataLast typings", () => {
-  test("arrays", () => {
-    const actual = pipe(first, zip(second));
-    assertType<Array<[number, string]>>(actual);
-  });
-  test("tuples", () => {
-    const actual = pipe(first as [1, 2, 3], zip(second as ["a", "b", "c"]));
-    assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
-  });
-  test("variadic tuples", () => {
-    const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
-    const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const actual = pipe(firstVariadic, zip(secondVariadic));
-    assertType<Array<[number | string, number | string]>>(actual);
-  });
-});
+    test("variadic tuples", () => {
+      const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
+      const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
+      const actual = zip(firstVariadic, secondVariadic);
+      assertType<Array<[number | string, number | string]>>(actual);
+    });
 
-describe("strict dataFirst typings", () => {
-  test("on empty tuples", () => {
-    const array: [] = [];
-    const result = zip(array, array);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
+    test("on empty tuples", () => {
+      const array: [] = [];
+      const result = zip(array, array);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("on empty readonly tuples", () => {
-    const array: readonly [] = [];
-    const result = zip(array, array);
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
+    test("on empty readonly tuples", () => {
+      const array: readonly [] = [];
+      const result = zip(array, array);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("on arrays", () => {
-    const array: Array<number> = [];
-    const result = zip(array, array);
-    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
-  });
+    test("on arrays", () => {
+      const array: Array<number> = [];
+      const result = zip(array, array);
+      expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+    });
 
-  test("on mixed typeds array", () => {
-    const array1: Array<number> = [];
-    const array2: Array<string> = [];
-    const result = zip(array1, array2);
-    expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
-  });
+    test("on mixed typeds array", () => {
+      const array1: Array<number> = [];
+      const array2: Array<string> = [];
+      const result = zip(array1, array2);
+      expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
+    });
 
-  test("on readonly arrays", () => {
-    const array: ReadonlyArray<number> = [];
-    const result = zip(array, array);
-    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+    test("on readonly arrays", () => {
+      const array: ReadonlyArray<number> = [];
+      const result = zip(array, array);
+      expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+    });
+
+    test("on tuples", () => {
+      const array1: [1, 2, 3] = [1, 2, 3];
+      const array2: [4, 5, 6] = [4, 5, 6];
+      const result = zip(array1, array2);
+      expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+    });
+
+    test("on readonly tuples", () => {
+      const array1: readonly [1, 2, 3] = [1, 2, 3];
+      const array2: readonly [4, 5, 6] = [4, 5, 6];
+      const result = zip(array1, array2);
+      expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+    });
+
+    test("on tuples of different lengths", () => {
+      const array1: [1, 2, 3] = [1, 2, 3];
+      const array2: [4, 5] = [4, 5];
+      const result1 = zip(array1, array2);
+      expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
+      const result2 = zip(array2, array1);
+      expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
+    });
+
+    test("on variadic tuples", () => {
+      const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
+      const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
+      const result = zip(firstVariadic, secondVariadic);
+      expectTypeOf(result).toEqualTypeOf<
+        [[number, string], ...Array<[string, number]>]
+      >();
+    });
   });
 
-  test("on tuples", () => {
-    const array1: [1, 2, 3] = [1, 2, 3];
-    const array2: [4, 5, 6] = [4, 5, 6];
-    const result = zip(array1, array2);
-    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
-  });
+  describe("dataLast", () => {
+    test("arrays", () => {
+      const actual = pipe([1, 2, 3], zip(["a", "b", "c"]));
+      assertType<Array<[number, string]>>(actual);
+    });
+    test("tuples", () => {
+      const actual = pipe(
+        [1, 2, 3] as [1, 2, 3],
+        zip(["a", "b", "c"] as ["a", "b", "c"]),
+      );
+      assertType<Array<[1 | 2 | 3, "a" | "b" | "c"]>>(actual);
+    });
+    test("variadic tuples", () => {
+      const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
+      const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
+      const actual = pipe(firstVariadic, zip(secondVariadic));
+      assertType<Array<[number | string, number | string]>>(actual);
+    });
 
-  test("on readonly tuples", () => {
-    const array1: readonly [1, 2, 3] = [1, 2, 3];
-    const array2: readonly [4, 5, 6] = [4, 5, 6];
-    const result = zip(array1, array2);
-    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
-  });
+    test("on empty tuples", () => {
+      const array: [] = [];
+      const result = pipe(array, zip(array));
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("on tuples of different lengths", () => {
-    const array1: [1, 2, 3] = [1, 2, 3];
-    const array2: [4, 5] = [4, 5];
-    const result1 = zip(array1, array2);
-    expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
-    const result2 = zip(array2, array1);
-    expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
-  });
+    test("on empty readonly tuples", () => {
+      const array: readonly [] = [];
+      const result = pipe(array, zip(array));
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
 
-  test("on variadic tuples", () => {
-    const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
-    const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const result = zip(firstVariadic, secondVariadic);
-    expectTypeOf(result).toEqualTypeOf<
-      [[number, string], ...Array<[string, number]>]
-    >();
-  });
-});
+    test("on arrays", () => {
+      const array: Array<number> = [];
+      const result = pipe(array, zip(array));
+      expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+    });
 
-describe("strict dataLast typings", () => {
-  test("on empty tuples", () => {
-    const array: [] = [];
-    const result = pipe(array, zip(array));
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
+    test("on mixed typeds array", () => {
+      const array1: Array<number> = [];
+      const array2: Array<string> = [];
+      const result = pipe(array1, zip(array2));
+      expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
+    });
 
-  test("on empty readonly tuples", () => {
-    const array: readonly [] = [];
-    const result = pipe(array, zip(array));
-    expectTypeOf(result).toEqualTypeOf<[]>();
-  });
+    test("on readonly arrays", () => {
+      const array: ReadonlyArray<number> = [];
+      const result = pipe(array, zip(array));
+      expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
+    });
 
-  test("on arrays", () => {
-    const array: Array<number> = [];
-    const result = pipe(array, zip(array));
-    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
-  });
+    test("on tuples", () => {
+      const array1: [1, 2, 3] = [1, 2, 3];
+      const array2: [4, 5, 6] = [4, 5, 6];
+      const result = pipe(array1, zip(array2));
+      expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+    });
 
-  test("on mixed typeds array", () => {
-    const array1: Array<number> = [];
-    const array2: Array<string> = [];
-    const result = pipe(array1, zip(array2));
-    expectTypeOf(result).toEqualTypeOf<Array<[number, string]>>();
-  });
+    test("on readonly tuples", () => {
+      const array1: readonly [1, 2, 3] = [1, 2, 3];
+      const array2: readonly [4, 5, 6] = [4, 5, 6];
+      const result = pipe(array1, zip(array2));
+      expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
+    });
 
-  test("on readonly arrays", () => {
-    const array: ReadonlyArray<number> = [];
-    const result = pipe(array, zip(array));
-    expectTypeOf(result).toEqualTypeOf<Array<[number, number]>>();
-  });
+    test("on tuples of different lengths", () => {
+      const array1: [1, 2, 3] = [1, 2, 3];
+      const array2: [4, 5] = [4, 5];
+      const result1 = pipe(array1, zip(array2));
+      expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
+      const result2 = pipe(array2, zip(array1));
+      expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
+    });
 
-  test("on tuples", () => {
-    const array1: [1, 2, 3] = [1, 2, 3];
-    const array2: [4, 5, 6] = [4, 5, 6];
-    const result = pipe(array1, zip(array2));
-    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
-  });
-
-  test("on readonly tuples", () => {
-    const array1: readonly [1, 2, 3] = [1, 2, 3];
-    const array2: readonly [4, 5, 6] = [4, 5, 6];
-    const result = pipe(array1, zip(array2));
-    expectTypeOf(result).toEqualTypeOf<[[1, 4], [2, 5], [3, 6]]>();
-  });
-
-  test("on tuples of different lengths", () => {
-    const array1: [1, 2, 3] = [1, 2, 3];
-    const array2: [4, 5] = [4, 5];
-    const result1 = pipe(array1, zip(array2));
-    expectTypeOf(result1).toEqualTypeOf<[[1, 4], [2, 5]]>();
-    const result2 = pipe(array2, zip(array1));
-    expectTypeOf(result2).toEqualTypeOf<[[4, 1], [5, 2]]>();
-  });
-
-  test("on variadic tuples", () => {
-    const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
-    const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
-    const result = pipe(firstVariadic, zip(secondVariadic));
-    expectTypeOf(result).toEqualTypeOf<
-      [[number, string], ...Array<[string, number]>]
-    >();
+    test("on variadic tuples", () => {
+      const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
+      const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];
+      const result = pipe(firstVariadic, zip(secondVariadic));
+      expectTypeOf(result).toEqualTypeOf<
+        [[number, string], ...Array<[string, number]>]
+      >();
+    });
   });
 });

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,80 +1,7 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
 
-/**
- * Creates a new list from two supplied lists by pairing up equally-positioned items.
- * The length of the returned list will match the shortest of the two inputs.
- *
- * If the input array are tuples, you can use the strict option
- * to get another tuple instead of a generic array type.
- *
- * @param first - The first input list.
- * @param second - The second input list.
- * @signature
- *   R.zip(first, second)
- * @example
- *   R.zip([1, 2], ['a', 'b']) // => [[1, 'a'], [2, 'b']] (type: [number, string][])
- *   R.zip.strict([1, 2] as const, ['a', 'b'] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
- * @dataFirst
- * @strict
- * @category Array
- */
-export function zip<F, S>(
-  first: ReadonlyArray<F>,
-  second: ReadonlyArray<S>,
-): Array<[F, S]>;
-
-/**
- * Creates a new list from two supplied lists by pairing up equally-positioned items.
- * The length of the returned list will match the shortest of the two inputs.
- *
- * If the input array are tuples, you can use the strict option
- * to get another tuple instead of a generic array type.
- *
- * @param second - The second input list.
- * @signature
- *   R.zip(second)(first)
- * @example
- *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']] (type: [number, string][])
- *   R.zip.strict(['a', 'b'] as const)([1, 2] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
- * @dataLast
- * @strict
- * @category Array
- */
-export function zip<S>(
-  second: ReadonlyArray<S>,
-): <F>(first: ReadonlyArray<F>) => Array<[F, S]>;
-
-export function zip(): unknown {
-  return purry(_zip, arguments);
-}
-
-function _zip(
-  first: ReadonlyArray<unknown>,
-  second: ReadonlyArray<unknown>,
-): Array<[unknown, unknown]> {
-  const resultLength =
-    first.length > second.length ? second.length : first.length;
-  const result: Array<[unknown, unknown]> = [];
-  for (let i = 0; i < resultLength; i++) {
-    result.push([first[i], second[i]]);
-  }
-
-  return result;
-}
-
-type Strict = {
-  <F extends IterableContainer, S extends IterableContainer>(
-    first: F,
-    second: S,
-  ): Zip<F, S>;
-
-  <S extends IterableContainer>(
-    second: S,
-  ): <F extends IterableContainer>(first: F) => Zip<F, S>;
-};
-
-type Zip<Left extends IterableContainer, Right extends IterableContainer> =
+type Zipped<Left extends IterableContainer, Right extends IterableContainer> =
   // If the array is empty the output is empty, no surprises
   Left extends readonly []
     ? []
@@ -84,18 +11,68 @@ type Zip<Left extends IterableContainer, Right extends IterableContainer> =
         Left extends readonly [infer LeftHead, ...infer LeftRest]
         ? Right extends readonly [infer RightHead, ...infer RightRest]
           ? // ...Then take that first item from both and recurse
-            [[LeftHead, RightHead], ...Zip<LeftRest, RightRest>]
+            [[LeftHead, RightHead], ...Zipped<LeftRest, RightRest>]
           : // Is only one of the inputs a tuple (with a non-rest first item)?
             // Then take that item, and match it with whatever the type of the other *array's* items are.
-            [[LeftHead, Right[number]], ...Zip<LeftRest, Right>]
+            [[LeftHead, Right[number]], ...Zipped<LeftRest, Right>]
         : Right extends readonly [infer RightHead, ...infer RightRest]
-          ? [[Left[number], RightHead], ...Zip<Left, RightRest>]
+          ? [[Left[number], RightHead], ...Zipped<Left, RightRest>]
           : // Both inputs are not tuples (with a non-rest first item, they might be tuples with non-rest last item(s))
             // So the output is just the "trivial" zip result.
             Array<[Left[number], Right[number]]>;
 
-export namespace zip {
-  // @ts-expect-error ts[2322] - The dataLast strict version requires only 1 argument
-  // while zip expects 2, so TS will complain that it's not assignable
-  export const strict: Strict = zip;
+/**
+ * Creates a new list from two supplied lists by pairing up equally-positioned
+ * items. The length of the returned list will match the shortest of the two
+ * inputs.
+ *
+ * @param first - The first input list.
+ * @param second - The second input list.
+ * @signature
+ *   R.zip(first, second)
+ * @example
+ *   R.zip([1, 2] as const, ['a', 'b'] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
+ * @dataFirst
+ * @category Array
+ */
+export function zip<F extends IterableContainer, S extends IterableContainer>(
+  first: F,
+  second: S,
+): Zipped<F, S>;
+
+/**
+ * Creates a new list from two supplied lists by pairing up equally-positioned
+ * items. The length of the returned list will match the shortest of the two
+ * inputs.
+ *
+ * @param second - The second input list.
+ * @signature
+ *   R.zip(second)(first)
+ * @example
+ *   R.zip(['a', 'b'] as const)([1, 2] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
+ * @dataLast
+ * @category Array
+ */
+export function zip<S extends IterableContainer>(
+  second: S,
+): <F extends IterableContainer>(first: F) => Zipped<F, S>;
+
+export function zip(): unknown {
+  return purry(zipImplementation, arguments);
+}
+
+function zipImplementation<
+  F extends IterableContainer,
+  S extends IterableContainer,
+>(first: F, second: S): Zipped<F, S> {
+  const resultLength =
+    first.length > second.length ? second.length : first.length;
+
+  const result: Array<[F[number], S[number]]> = [];
+
+  for (let i = 0; i < resultLength; i++) {
+    result.push([first[i], second[i]]);
+  }
+
+  return result as Zipped<F, S>;
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -31,7 +31,7 @@ type Zipped<Left extends IterableContainer, Right extends IterableContainer> =
  * @signature
  *   R.zip(first, second)
  * @example
- *   R.zip([1, 2] as const, ['a', 'b'] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
+ *   R.zip([1, 2], ['a', 'b']) // => [[1, 'a'], [2, 'b']]
  * @dataFirst
  * @category Array
  */
@@ -49,7 +49,7 @@ export function zip<F extends IterableContainer, S extends IterableContainer>(
  * @signature
  *   R.zip(second)(first)
  * @example
- *   R.zip(['a', 'b'] as const)([1, 2] as const) // => [[1, 'a'], [2, 'b']]  (type: [[1, 'a'], [2, 'b']])
+ *   R.zip(['a', 'b'])([1, 2]) // => [[1, 'a'], [2, 'b']]
  * @dataLast
  * @category Array
  */

--- a/test/lazy_invocation_counter.ts
+++ b/test/lazy_invocation_counter.ts
@@ -5,7 +5,7 @@ export const createLazyInvocationCounter = () => {
   return {
     count,
     fn: <T>() =>
-      map<T, T>((x) => {
+      map<ReadonlyArray<T>, T>((x) => {
         count();
         return x;
       }),


### PR DESCRIPTION
Use the strict typings (and implementations) as the main ones for any function that used them.