### PR TITLE
chore: drop Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 The first "data-first" and "data-last" utility library designed especially for TypeScript.
 
 ![GitHub CI](https://img.shields.io/github/actions/workflow/status/remeda/remeda/ci.yml?branch=master&label=github-ci)
-[![Travis CI](https://img.shields.io/travis/remeda/remeda/master?label=travis-ci)](https://travis-ci.org/remeda/remeda)
 [![Codecov](https://img.shields.io/codecov/c/github/remeda/remeda/master)](https://codecov.io/gh/remeda/remeda)
 [![NPM](https://img.shields.io/npm/v/remeda)](https://www.npmjs.org/package/remeda)
 ![Dependencies](https://img.shields.io/librariesio/release/npm/remeda)


### PR DESCRIPTION
Our tag in the readme shows that the service is unavailable, and the status of the travis integration in github shows that the endpoint is getting 503 requests. It also still uses node 10(?!) so i'm guessing this is some legacy thing that isn't even working anymore.
