### PR TITLE
feat: add indexed versions

### DIFF
--- a/src/dropLastWhile.ts
+++ b/src/dropLastWhile.ts
@@ -16,7 +16,7 @@ import { purry } from "./purry";
  */
 export function dropLastWhile<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
@@ -33,19 +33,19 @@ export function dropLastWhile<T>(
  * @category Array
  */
 export function dropLastWhile<T>(
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
 export function dropLastWhile(): unknown {
-  return purry(_dropLastWhile, arguments);
+  return purry(dropLastWhileImplementation, arguments);
 }
 
-function _dropLastWhile<T>(
+function dropLastWhileImplementation<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T> {
   for (let i = data.length - 1; i >= 0; i--) {
-    if (!predicate(data[i]!)) {
+    if (!predicate(data[i]!, i, data)) {
       return data.slice(0, i + 1);
     }
   }

--- a/src/dropWhile.ts
+++ b/src/dropWhile.ts
@@ -16,7 +16,7 @@ import { purry } from "./purry";
  */
 export function dropWhile<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
@@ -33,19 +33,19 @@ export function dropWhile<T>(
  * @category Array
  */
 export function dropWhile<T>(
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
 export function dropWhile(): unknown {
-  return purry(_dropWhile, arguments);
+  return purry(dropWhileImplementation, arguments);
 }
 
-function _dropWhile<T>(
+function dropWhileImplementation<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T> {
   for (let i = 0; i < data.length; i++) {
-    if (!predicate(data[i]!)) {
+    if (!predicate(data[i]!, i, data)) {
       return data.slice(i);
     }
   }

--- a/src/flatMap.ts
+++ b/src/flatMap.ts
@@ -3,12 +3,20 @@ import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
 /**
- * Map each element of an array using a defined callback function and flatten the mapped result.
+ * Returns a new array formed by applying a given callback function to each
+ * element of the array, and then flattening the result by one level. It is
+ * identical to a `map` followed by a `flat` of depth 1
+ * (`flat(map(data, ...args))`), but slightly more efficient than calling those
+ * two methods separately. Equivalent to `Array.prototype.flatMap`.
  *
- * @param array - The array to map.
- * @param fn - The function mapper.
+ * @param data - The items to map and flatten.
+ * @param callbackfn - A function to execute for each element in the array. It
+ * should return an array containing new elements of the new array, or a single
+ * non-array value to be added to the new array.
+ * @returns A new array with each element being the result of the callback
+ * function and flattened by a depth of 1.
  * @signature
- *    R.flatMap(array, fn)
+ *    R.flatMap(data, callbackfn)
  * @example
  *    R.flatMap([1, 2, 3], x => [x, x * 10]) // => [1, 10, 2, 20, 3, 30]
  * @dataFirst
@@ -16,16 +24,28 @@ import { purry } from "./purry";
  * @category Array
  */
 export function flatMap<T, K>(
-  array: ReadonlyArray<T>,
-  fn: (input: T) => K | ReadonlyArray<K>,
+  data: ReadonlyArray<T>,
+  callbackfn: (
+    input: T,
+    index: number,
+    data: ReadonlyArray<T>,
+  ) => K | ReadonlyArray<K>,
 ): Array<K>;
 
 /**
- * Map each element of an array using a defined callback function and flatten the mapped result.
+ * Returns a new array formed by applying a given callback function to each
+ * element of the array, and then flattening the result by one level. It is
+ * identical to a `map` followed by a `flat` of depth 1
+ * (`flat(map(data, ...args))`), but slightly more efficient than calling those
+ * two methods separately. Equivalent to `Array.prototype.flatMap`.
  *
- * @param fn - The function mapper.
+ * @param callbackfn - A function to execute for each element in the array. It
+ * should return an array containing new elements of the new array, or a single
+ * non-array value to be added to the new array.
+ * @returns A new array with each element being the result of the callback
+ * function and flattened by a depth of 1.
  * @signature
- *    R.flatMap(fn)(array)
+ *    R.flatMap(callbackfn)(data)
  * @example
  *    R.pipe([1, 2, 3], R.flatMap(x => [x, x * 10])) // => [1, 10, 2, 20, 3, 30]
  * @dataLast
@@ -33,28 +53,41 @@ export function flatMap<T, K>(
  * @category Array
  */
 export function flatMap<T, K>(
-  fn: (input: T) => K | ReadonlyArray<K>,
-): (array: ReadonlyArray<T>) => Array<K>;
+  callbackfn: (
+    input: T,
+    index: number,
+    data: ReadonlyArray<T>,
+  ) => K | ReadonlyArray<K>,
+): (data: ReadonlyArray<T>) => Array<K>;
 
 export function flatMap(): unknown {
-  return purry(_flatMap, arguments, flatMap.lazy);
+  return purry(flatMapImplementation, arguments, lazyImplementation);
 }
 
-function _flatMap<T, K>(
-  array: ReadonlyArray<T>,
-  fn: (input: T) => ReadonlyArray<K>,
+function flatMapImplementation<T, K>(
+  data: ReadonlyArray<T>,
+  callbackfn: (
+    input: T,
+    index: number,
+    data: ReadonlyArray<T>,
+  ) => ReadonlyArray<K>,
 ): Array<K> {
-  return flatten(array.map((item) => fn(item)));
+  // TODO: Use flatMap directly once we bump our TypeScript target version.
+  return flatten(data.map(callbackfn));
 }
 
-export namespace flatMap {
-  export const lazy =
-    <T, K>(fn: (input: T) => K | ReadonlyArray<K>): LazyEvaluator<T, K> =>
-    // @ts-expect-error [ts2322] - We need to make LazyMany better so it accommodate the typing here...
-    (value) => {
-      const next = fn(value);
-      return Array.isArray(next)
-        ? { done: false, hasNext: true, hasMany: true, next }
-        : { done: false, hasNext: true, next };
-    };
-}
+export const lazyImplementation =
+  <T, K>(
+    callbackfn: (
+      input: T,
+      index: number,
+      data: ReadonlyArray<T>,
+    ) => K | ReadonlyArray<K>,
+  ): LazyEvaluator<T, K> =>
+  // @ts-expect-error [ts2322] - We need to make LazyMany better so it accommodate the typing here...
+  (value, index, data) => {
+    const next = callbackfn(value, index, data);
+    return Array.isArray(next)
+      ? { done: false, hasNext: true, hasMany: true, next }
+      : { done: false, hasNext: true, next };
+  };

--- a/src/fromKeys.ts
+++ b/src/fromKeys.ts
@@ -43,7 +43,7 @@ type FromKeys<T extends IterableContainer, V> = T extends readonly []
  */
 export function fromKeys<T extends IterableContainer<PropertyKey>, V>(
   data: T,
-  mapper: (item: T[number]) => V,
+  mapper: (item: T[number], index: number, data: T) => V,
 ): Simplify<FromKeys<T, V>>;
 
 /**
@@ -70,7 +70,7 @@ export function fromKeys<T extends IterableContainer<PropertyKey>, V>(
  * @category Object
  */
 export function fromKeys<T extends IterableContainer<PropertyKey>, V>(
-  mapper: (item: T[number]) => V,
+  mapper: (item: T[number], index: number, data: T) => V,
 ): (data: T) => Simplify<FromKeys<T, V>>;
 
 export function fromKeys(): unknown {
@@ -79,13 +79,15 @@ export function fromKeys(): unknown {
 
 function fromKeysImplementation<T extends IterableContainer<PropertyKey>, V>(
   data: T,
-  mapper: (item: T[number]) => V,
+  mapper: (item: T[number], index: number, data: T) => V,
 ): FromKeys<T, V> {
   const result: Partial<FromKeys<T, V>> = {};
 
-  for (const key of data) {
+  for (let i = 0; i < data.length; i++) {
+    // TODO: Use entries once we bump our typescript target.
+    const key = data[i]!;
     // @ts-expect-error [ts7053] - There's no easy way to make Typescript aware that the items in T would be keys in the output object because it's type is built recursively and the "being an item of an array" property of a type is not "carried over" in the recursive type definition.
-    result[key] = mapper(key);
+    result[key] = mapper(key, i, data);
   }
 
   return result as FromKeys<T, V>;

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -24,7 +24,7 @@ import { purry } from "./purry";
  */
 export function indexBy<T, K extends PropertyKey>(
   data: ReadonlyArray<T>,
-  mapper: (item: T) => K,
+  mapper: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): ExactRecord<K, T>;
 
 /**
@@ -51,7 +51,7 @@ export function indexBy<T, K extends PropertyKey>(
  * @category Array
  */
 export function indexBy<T, K extends PropertyKey>(
-  mapper: (item: T) => K,
+  mapper: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): (data: ReadonlyArray<T>) => ExactRecord<K, T>;
 
 export function indexBy(): unknown {
@@ -60,12 +60,14 @@ export function indexBy(): unknown {
 
 function indexByImplementation<T, K extends PropertyKey>(
   data: ReadonlyArray<T>,
-  mapper: (item: T) => K,
+  mapper: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): ExactRecord<K, T> {
   const out: Partial<Record<K, T>> = {};
 
-  for (const item of data) {
-    const key = mapper(item);
+  for (let i = 0; i < data.length; i++) {
+    // TODO: Use entries directly once we bump our typescript target version.
+    const item = data[i]!;
+    const key = mapper(item, i, data);
     out[key] = item;
   }
 

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -21,7 +21,7 @@ import { purry } from "./purry";
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+  keyMapper: (key: keyof T, value: Required<T>[keyof T], data: T) => S,
 ): ExactRecord<S, T[keyof T]>;
 
 /**
@@ -36,7 +36,7 @@ export function mapKeys<T extends {}, S extends PropertyKey>(
  * @category Object
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
-  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+  keyMapper: (key: keyof T, value: Required<T>[keyof T], data: T) => S,
 ): (data: T) => ExactRecord<S, T[keyof T]>;
 
 export function mapKeys(): unknown {
@@ -45,13 +45,13 @@ export function mapKeys(): unknown {
 
 function mapKeysImplementation<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: (key: keyof T, value: Required<T>[keyof T]) => S,
+  keyMapper: (key: keyof T, value: Required<T>[keyof T], data: T) => S,
 ): ExactRecord<S, T[keyof T]> {
   const out: Partial<Record<S, T[keyof T]>> = {};
 
   for (const [key, value] of entries(data)) {
     // @ts-expect-error [ts2345] - Adding `Simplify` to the type of `EntryOf` takes away Typescripts ability to infer that the types match. Because we trust `Simplify` to only change how the type "looks" and not its semantics, we need to suppress the error.
-    const mappedKey = keyMapper(key, value);
+    const mappedKey = keyMapper(key, value, data);
     out[mappedKey] = value;
   }
 

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -18,7 +18,7 @@ type MappedValues<T, S> = { -readonly [P in keyof T]: S };
  */
 export function mapValues<T extends object, S>(
   data: T,
-  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>, data: T) => S,
 ): MappedValues<T, S>;
 
 /**
@@ -33,7 +33,7 @@ export function mapValues<T extends object, S>(
  * @category Object
  */
 export function mapValues<T extends object, S>(
-  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>, data: T) => S,
 ): (data: T) => MappedValues<T, S>;
 
 export function mapValues(): unknown {
@@ -42,13 +42,13 @@ export function mapValues(): unknown {
 
 function mapValuesImplementation<T extends object, S>(
   data: T,
-  valueMapper: (value: T[keyof T], key: ObjectKeys<T>) => S,
+  valueMapper: (value: T[keyof T], key: ObjectKeys<T>, data: T) => S,
 ): MappedValues<T, S> {
   const out: Partial<MappedValues<T, S>> = {};
 
   for (const [key, value] of entries(data)) {
     // @ts-expect-error [ts2345] - FIXME!
-    const mappedValue = valueMapper(value, key);
+    const mappedValue = valueMapper(value, key, data);
     out[key] = mappedValue;
   }
 

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -4,8 +4,8 @@ import { purry } from "./purry";
 /**
  * Returns a partial copy of an object omitting the keys matching predicate.
  *
- * @param object - The target object.
- * @param fn - The predicate.
+ * @param data - The target object.
+ * @param predicate - The predicate.
  * @signature R.omitBy(object, fn)
  * @example
  *    R.omitBy({a: 1, b: 2, A: 3, B: 4}, (val, key) => key.toUpperCase() === key) // => {a: 1, b: 2}
@@ -13,14 +13,14 @@ import { purry } from "./purry";
  * @category Object
  */
 export function omitBy<T>(
-  object: T,
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
+  data: T,
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
 /**
  * Returns a partial copy of an object omitting the keys matching predicate.
  *
- * @param fn - The predicate.
+ * @param predicate - The predicate.
  * @signature R.omitBy(fn)(object)
  * @example
  *    R.omitBy((val, key) => key.toUpperCase() === key)({a: 1, b: 2, A: 3, B: 4}) // => {a: 1, b: 2}
@@ -28,26 +28,26 @@ export function omitBy<T>(
  * @category Object
  */
 export function omitBy<T>(
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
-): (object: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
+): (data: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
 export function omitBy(): unknown {
-  return purry(_omitBy, arguments);
+  return purry(omitByImplementation, arguments);
 }
 
-function _omitBy<T>(
-  object: T,
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
+function omitByImplementation<T>(
+  data: T,
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): Partial<T> {
-  if (object === undefined || object === null) {
-    return object;
+  if (data === undefined || data === null) {
+    return data;
   }
 
   const out: Partial<T> = {};
 
-  for (const key of keys(object)) {
-    if (!fn(object[key], key)) {
-      out[key] = object[key];
+  for (const key of keys(data)) {
+    if (!predicate(data[key], key, data)) {
+      out[key] = data[key];
     }
   }
 

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -4,8 +4,8 @@ import { purry } from "./purry";
 /**
  * Creates an object composed of the picked `object` properties.
  *
- * @param object - The target object.
- * @param fn - The predicate.
+ * @param data - The target object.
+ * @param predicate - The predicate.
  * @signature R.pickBy(object, fn)
  * @example
  *    R.pickBy({a: 1, b: 2, A: 3, B: 4}, (val, key) => key.toUpperCase() === key) // => {A: 3, B: 4}
@@ -13,14 +13,14 @@ import { purry } from "./purry";
  * @category Object
  */
 export function pickBy<T>(
-  object: T,
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
+  data: T,
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
 /**
  * Creates an object composed of the picked `object` properties.
  *
- * @param fn - The predicate.
+ * @param predicate - The predicate.
  * @signature R.pickBy(fn)(object)
  * @example
  *    R.pickBy((val, key) => key.toUpperCase() === key)({a: 1, b: 2, A: 3, B: 4}) // => {A: 3, B: 4}
@@ -28,16 +28,16 @@ export function pickBy<T>(
  * @category Object
  */
 export function pickBy<T>(
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
-): (object: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
+): (data: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
 export function pickBy(): unknown {
-  return purry(_pickBy, arguments);
+  return purry(pickByImplementation, arguments);
 }
 
-function _pickBy<T>(
+function pickByImplementation<T>(
   data: T,
-  fn: <K extends keyof T>(value: T[K], key: K) => boolean,
+  predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): Partial<T> {
   if (data === null || data === undefined) {
     return {};
@@ -46,7 +46,7 @@ function _pickBy<T>(
   const out: Partial<T> = {};
 
   for (const key of keys(data)) {
-    if (fn(data[key], key)) {
+    if (predicate(data[key], key, data)) {
       out[key] = data[key];
     }
   }

--- a/src/pullObject.ts
+++ b/src/pullObject.ts
@@ -38,8 +38,8 @@ export function pullObject<
   V,
 >(
   data: T,
-  keyExtractor: (item: T[number]) => K,
-  valueExtractor: (item: T[number]) => V,
+  keyExtractor: (item: T[number], index: number, data: T) => K,
+  valueExtractor: (item: T[number], index: number, data: T) => V,
 ): Partial<Record<K, V>>;
 
 /**
@@ -76,8 +76,8 @@ export function pullObject<
   K extends PropertyKey,
   V,
 >(
-  keyExtractor: (item: T[number]) => K,
-  valueExtractor: (item: T[number]) => V,
+  keyExtractor: (item: T[number], index: number, data: T) => K,
+  valueExtractor: (item: T[number], index: number, data: T) => V,
 ): (data: T) => Partial<Record<K, V>>;
 
 export function pullObject(): unknown {
@@ -90,14 +90,16 @@ function pullObjectImplementation<
   V,
 >(
   data: T,
-  keyExtractor: (item: T[number]) => K,
-  valueExtractor: (item: T[number]) => V,
+  keyExtractor: (item: T[number], index: number, data: T) => K,
+  valueExtractor: (item: T[number], index: number, data: T) => V,
 ): Partial<Record<K, V>> {
   const result: Partial<Record<K, V>> = {};
 
-  for (const item of data) {
-    const key = keyExtractor(item);
-    const value = valueExtractor(item);
+  for (let i = 0; i < data.length; i++) {
+    // TODO: use entries once we bump our typescript target.
+    const item = data[i]!;
+    const key = keyExtractor(item, i, data);
+    const value = valueExtractor(item, i, data);
     result[key] = value;
   }
 

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -4,8 +4,8 @@ import { purry } from "./purry";
 /**
  * Splits a given array at the first index where the given predicate returns true.
  *
- * @param array - The array to split.
- * @param fn - The predicate.
+ * @param data - The array to split.
+ * @param predicate - The predicate.
  * @signature
  *    R.splitWhen(array, fn)
  * @example
@@ -14,14 +14,14 @@ import { purry } from "./purry";
  * @category Array
  */
 export function splitWhen<T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => boolean,
+  data: ReadonlyArray<T>,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): [Array<T>, Array<T>];
 
 /**
  * Splits a given array at an index where the given predicate returns true.
  *
- * @param fn - The predicate.
+ * @param predicate - The predicate.
  * @signature
  *    R.splitWhen(fn)(array)
  * @example
@@ -30,25 +30,25 @@ export function splitWhen<T>(
  * @category Array
  */
 export function splitWhen<T>(
-  fn: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
 export function splitWhen(): unknown {
-  return purry(_splitWhen, arguments);
+  return purry(splitWhenImplementation, arguments);
 }
 
-function _splitWhen<T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => boolean,
+function splitWhenImplementation<T>(
+  data: ReadonlyArray<T>,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): [Array<T>, Array<T>] {
-  for (let i = 0; i < array.length; i++) {
+  for (let i = 0; i < data.length; i++) {
     // TODO: Use `Array.prototype.entries` once we bump our TS target so we
     // can get both the index and the item at the same time, and don't need
     // the non-null assertion.
-    if (fn(array[i]!)) {
-      return splitAt(array, i);
+    if (predicate(data[i]!, i, data)) {
+      return splitAt(data, i);
     }
   }
 
-  return [array.slice(), []];
+  return [data.slice(), []];
 }

--- a/src/takeLastWhile.ts
+++ b/src/takeLastWhile.ts
@@ -15,7 +15,7 @@ import { purry } from "./purry";
  */
 export function takeLastWhile<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
@@ -31,19 +31,19 @@ export function takeLastWhile<T>(
  * @category Array
  */
 export function takeLastWhile<T>(
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
 export function takeLastWhile(): unknown {
-  return purry(_takeLastWhile, arguments);
+  return purry(takeLastWhileImplementation, arguments);
 }
 
-function _takeLastWhile<T>(
+function takeLastWhileImplementation<T>(
   data: ReadonlyArray<T>,
-  predicate: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T> {
   for (let i = data.length - 1; i >= 0; i--) {
-    if (!predicate(data[i]!)) {
+    if (!predicate(data[i]!, i, data)) {
       return data.slice(i + 1);
     }
   }

--- a/src/takeWhile.ts
+++ b/src/takeWhile.ts
@@ -3,46 +3,48 @@ import { purry } from "./purry";
 /**
  * Returns elements from the array until predicate returns false.
  *
- * @param array - The array.
- * @param fn - The predicate.
+ * @param data - The array.
+ * @param predicate - The predicate.
  * @signature
- *    R.takeWhile(array, fn)
+ *    R.takeWhile(data, predicate)
  * @example
  *    R.takeWhile([1, 2, 3, 4, 3, 2, 1], x => x !== 4) // => [1, 2, 3]
  * @dataFirst
  * @category Array
  */
 export function takeWhile<T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => boolean,
+  data: ReadonlyArray<T>,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T>;
 
 /**
  * Returns elements from the array until predicate returns false.
  *
- * @param fn - The predicate.
+ * @param predicate - The predicate.
  * @signature
- *    R.takeWhile(fn)(array)
+ *    R.takeWhile(predicate)(data)
  * @example
  *    R.pipe([1, 2, 3, 4, 3, 2, 1], R.takeWhile(x => x !== 4))  // => [1, 2, 3]
  * @dataLast
  * @category Array
  */
 export function takeWhile<T>(
-  fn: (item: T) => boolean,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => Array<T>;
 
 export function takeWhile(): unknown {
-  return purry(_takeWhile, arguments);
+  return purry(takeWhileImplementation, arguments);
 }
 
-function _takeWhile<T>(
-  array: ReadonlyArray<T>,
-  fn: (item: T) => boolean,
+function takeWhileImplementation<T>(
+  data: ReadonlyArray<T>,
+  predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): Array<T> {
   const ret: Array<T> = [];
-  for (const item of array) {
-    if (!fn(item)) {
+  for (let i = 0; i < data.length; i++) {
+    // TODO: Use entries once we bump our typescript target.
+    const item = data[i]!;
+    if (!predicate(item, i, data)) {
       break;
     }
     ret.push(item);

--- a/src/uniqueBy.ts
+++ b/src/uniqueBy.ts
@@ -9,7 +9,7 @@ import { purry } from "./purry";
  * @param data - The array to filter.
  * @param keyFunction - Extracts a value that would be used to compare elements.
  * @signature
- *    R.uniqueBy(array, fn)
+ *    R.uniqueBy(data, keyFunction)
  * @example
  *    R.uniqueBy(
  *     [{ n: 1 }, { n: 2 }, { n: 2 }, { n: 5 }, { n: 1 }, { n: 6 }, { n: 7 }],
@@ -21,7 +21,7 @@ import { purry } from "./purry";
  */
 export function uniqueBy<T, K>(
   data: ReadonlyArray<T>,
-  keyFunction: (item: T) => K,
+  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): Array<T>;
 
 /**
@@ -30,7 +30,7 @@ export function uniqueBy<T, K>(
  *
  * @param keyFunction - Extracts a value that would be used to compare elements.
  * @signature
- *    R.uniqueBy(fn)(array)
+ *    R.uniqueBy(keyFunction)(data)
  * @example
  *    R.pipe(
  *      [{n: 1}, {n: 2}, {n: 2}, {n: 5}, {n: 1}, {n: 6}, {n: 7}], // only 4 iterations
@@ -42,24 +42,24 @@ export function uniqueBy<T, K>(
  * @category Array
  */
 export function uniqueBy<T, K>(
-  keyFunction: (item: T) => K,
+  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
 export function uniqueBy(): unknown {
-  return purry(uniqueByImplementation, arguments, lazyUniqueBy);
+  return purry(uniqueByImplementation, arguments, lazyImplementation);
 }
 
-function uniqueByImplementation<T, K>(
+const uniqueByImplementation = <T, K>(
   data: ReadonlyArray<T>,
-  keyFunction: (item: T) => K,
-): Array<T> {
-  return _reduceLazy(data, lazyUniqueBy(keyFunction));
-}
+  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
+): Array<T> => _reduceLazy(data, lazyImplementation(keyFunction));
 
-function lazyUniqueBy<T, K>(keyFunction: (item: T) => K): LazyEvaluator<T> {
+function lazyImplementation<T, K>(
+  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
+): LazyEvaluator<T> {
   const set = new Set<K>();
-  return (value) => {
-    const key = keyFunction(value);
+  return (value, index, data) => {
+    const key = keyFunction(value, index, data);
     if (set.has(key)) {
       return { done: false, hasNext: false };
     }

--- a/src/zipWith.ts
+++ b/src/zipWith.ts
@@ -1,4 +1,9 @@
-type ZippingFunction<F = unknown, S = unknown, R = unknown> = (f: F, s: S) => R;
+type ZippingFunction<T1 = unknown, T2 = unknown, Value = unknown> = (
+  first: T1,
+  second: T2,
+  index: number,
+  data: readonly [first: ReadonlyArray<T1>, second: ReadonlyArray<T2>],
+) => Value;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -14,11 +19,11 @@ type ZippingFunction<F = unknown, S = unknown, R = unknown> = (f: F, s: S) => R;
  * @dataFirst
  * @category Array
  */
-export function zipWith<F, S, R>(
-  first: ReadonlyArray<F>,
-  second: ReadonlyArray<S>,
-  fn: ZippingFunction<F, S, R>,
-): Array<R>;
+export function zipWith<T1, T2, Value>(
+  first: ReadonlyArray<T1>,
+  second: ReadonlyArray<T2>,
+  fn: ZippingFunction<T1, T2, Value>,
+): Array<Value>;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -32,9 +37,9 @@ export function zipWith<F, S, R>(
  * @dataLast
  * @category Array
  */
-export function zipWith<F, S, R>(
-  fn: ZippingFunction<F, S, R>,
-): (first: ReadonlyArray<F>, second: ReadonlyArray<S>) => Array<R>;
+export function zipWith<T1, T2, Value>(
+  fn: ZippingFunction<T1, T2, Value>,
+): (first: ReadonlyArray<T1>, second: ReadonlyArray<T2>) => Array<Value>;
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -49,10 +54,10 @@ export function zipWith<F, S, R>(
  * @dataLast
  * @category Array
  */
-export function zipWith<F, S, R>(
-  fn: ZippingFunction<F, S, R>,
-  second: ReadonlyArray<S>,
-): (first: ReadonlyArray<F>) => Array<R>;
+export function zipWith<T1, T2, Value>(
+  fn: ZippingFunction<T1, T2, Value>,
+  second: ReadonlyArray<T2>,
+): (first: ReadonlyArray<T1>) => Array<Value>;
 
 export function zipWith(
   arg0: ReadonlyArray<unknown> | ZippingFunction,
@@ -62,27 +67,29 @@ export function zipWith(
   if (typeof arg0 === "function") {
     return arg1 === undefined
       ? (f: ReadonlyArray<unknown>, s: ReadonlyArray<unknown>) =>
-          _zipWith(f, s, arg0)
-      : (f: ReadonlyArray<unknown>) => _zipWith(f, arg1, arg0);
+          zipWithImplementation(f, s, arg0)
+      : (f: ReadonlyArray<unknown>) => zipWithImplementation(f, arg1, arg0);
   }
 
   if (arg1 === undefined || arg2 === undefined) {
     throw new Error("zipWith: Missing arguments in dataFirst function call");
   }
 
-  return _zipWith(arg0, arg1, arg2);
+  return zipWithImplementation(arg0, arg1, arg2);
 }
 
-function _zipWith<F, S, R>(
-  first: ReadonlyArray<F>,
-  second: ReadonlyArray<S>,
-  fn: ZippingFunction<F, S, R>,
-): Array<R> {
+function zipWithImplementation<T1, T2, Value>(
+  first: ReadonlyArray<T1>,
+  second: ReadonlyArray<T2>,
+  fn: ZippingFunction<T1, T2, Value>,
+): Array<Value> {
+  const datum = [first, second] as const;
+
   const resultLength =
     first.length > second.length ? second.length : first.length;
   const result = [];
   for (let i = 0; i < resultLength; i++) {
-    result.push(fn(first[i]!, second[i]!));
+    result.push(fn(first[i]!, second[i]!, i, datum));
   }
 
   return result;


### PR DESCRIPTION
Adding the params needed to make all predicate/mapper functions conform to the standard where we include the index and the full array as the last 2 params.