### PR TITLE
fix: remove lazy from function impl

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,10 +29,6 @@ export default config(
       reportUnusedDisableDirectives: true,
     },
     rules: {
-      // We provide function extensions (e.g. lazy, indexed, sub-functions,
-      // etc...) via namespaces by design.
-      "@typescript-eslint/no-namespace": "off",
-
       // Whenever we call a built-in function we want to be as transparent as
       // possible so we pass the callback directly without wrapping it with an
       // arrow function. Our typing provides the safety needed here.

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -219,6 +219,7 @@ function isCase(maybeCase: unknown): maybeCase is Case<unknown, unknown> {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace conditional {
   /**
    * A simplified case that accepts all data. Put this as the last case to

--- a/src/differenceWith.ts
+++ b/src/differenceWith.ts
@@ -57,26 +57,23 @@ export function differenceWith<TFirst, TSecond>(
 ): (array: ReadonlyArray<TFirst>) => Array<TFirst>;
 
 export function differenceWith(): unknown {
-  return purry(_differenceWith, arguments, differenceWith.lazy);
+  return purry(differenceWithImplementation, arguments, lazyImplementation);
 }
 
-function _differenceWith<TFirst, TSecond>(
+function differenceWithImplementation<TFirst, TSecond>(
   array: ReadonlyArray<TFirst>,
   other: ReadonlyArray<TSecond>,
   isEquals: IsEquals<TFirst, TSecond>,
 ): Array<TFirst> {
-  const lazy = differenceWith.lazy(other, isEquals);
-  return _reduceLazy(array, lazy);
+  return _reduceLazy(array, lazyImplementation(other, isEquals));
 }
 
-export namespace differenceWith {
-  export const lazy =
-    <TFirst, TSecond>(
-      other: ReadonlyArray<TSecond>,
-      isEquals: IsEquals<TFirst, TSecond>,
-    ): LazyEvaluator<TFirst> =>
-    (value) =>
-      other.every((otherValue) => !isEquals(value, otherValue))
-        ? { done: false, hasNext: true, next: value }
-        : { done: false, hasNext: false };
-}
+const lazyImplementation =
+  <TFirst, TSecond>(
+    other: ReadonlyArray<TSecond>,
+    isEquals: IsEquals<TFirst, TSecond>,
+  ): LazyEvaluator<TFirst> =>
+  (value) =>
+    other.every((otherValue) => !isEquals(value, otherValue))
+      ? { done: false, hasNext: true, next: value }
+      : { done: false, hasNext: false };

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -32,22 +32,20 @@ export function drop<T>(array: ReadonlyArray<T>, n: number): Array<T>;
 export function drop<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
 export function drop(): unknown {
-  return purry(_drop, arguments, drop.lazy);
+  return purry(dropImplementation, arguments, lazyImplementation);
 }
 
-function _drop<T>(array: ReadonlyArray<T>, n: number): Array<T> {
-  return _reduceLazy(array, drop.lazy(n));
+function dropImplementation<T>(array: ReadonlyArray<T>, n: number): Array<T> {
+  return _reduceLazy(array, lazyImplementation(n));
 }
 
-export namespace drop {
-  export function lazy<T>(n: number): LazyEvaluator<T> {
-    let left = n;
-    return (value) => {
-      if (left > 0) {
-        left -= 1;
-        return { done: false, hasNext: false };
-      }
-      return { done: false, hasNext: true, next: value };
-    };
-  }
+function lazyImplementation<T>(n: number): LazyEvaluator<T> {
+  let left = n;
+  return (value) => {
+    if (left > 0) {
+      left -= 1;
+      return { done: false, hasNext: false };
+    }
+    return { done: false, hasNext: true, next: value };
+  };
 }

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -18,18 +18,6 @@ test("empty array", () => {
 });
 
 describe("pipe", () => {
-  test("as no-fn", () => {
-    const counter = createLazyInvocationCounter();
-    const result = pipe(
-      [1, 2, 3, 4, 5, 6] as const,
-      counter.fn(),
-      first,
-      (x) => x,
-    );
-    expect(counter.count).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(1);
-  });
-
   test("as fn", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe([1, 2, 3, 4, 5, 6] as const, counter.fn(), first());

--- a/src/first.ts
+++ b/src/first.ts
@@ -1,3 +1,4 @@
+import { _toSingle } from "./_toSingle";
 import type { IterableContainer } from "./_types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
@@ -46,19 +47,13 @@ export function first<T extends IterableContainer>(data: T): First<T>;
 export function first(): <T extends IterableContainer>(data: T) => First<T>;
 
 export function first(): unknown {
-  return purry(_first, arguments, first.lazy);
+  return purry(firstImplementation, arguments, _toSingle(lazyImplementation));
 }
 
-function _first<T>([item]: ReadonlyArray<T>): T | undefined {
-  return item;
-}
+const firstImplementation = <T>([item]: ReadonlyArray<T>): T | undefined =>
+  item;
 
-export namespace first {
-  export function lazy<T>(): LazyEvaluator<T> {
-    return (value) => ({ done: true, hasNext: true, next: value });
-  }
-
-  export namespace lazy {
-    export const single = true;
-  }
-}
+const lazyImplementation =
+  <T>(): LazyEvaluator<T> =>
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- TODO
+  (value) => ({ done: true, hasNext: true, next: value });

--- a/src/flatMap.ts
+++ b/src/flatMap.ts
@@ -76,7 +76,7 @@ function flatMapImplementation<T, K>(
   return flatten(data.map(callbackfn));
 }
 
-export const lazyImplementation =
+const lazyImplementation =
   <T, K>(
     callbackfn: (
       input: T,

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -35,20 +35,17 @@ export function flatten<T>(items: ReadonlyArray<T>): Array<Flatten<T>>;
 export function flatten<T>(): (items: ReadonlyArray<T>) => Array<Flatten<T>>;
 
 export function flatten(): unknown {
-  return purry(_flatten, arguments, flatten.lazy);
+  return purry(flattenImplementation, arguments, lazyImplementation);
 }
 
-function _flatten<T>(items: ReadonlyArray<T>): Array<Flatten<T>> {
-  return _reduceLazy(items, flatten.lazy());
-}
+const flattenImplementation = <T>(items: ReadonlyArray<T>): Array<Flatten<T>> =>
+  _reduceLazy(items, lazyImplementation());
 
-export namespace flatten {
-  export const lazy =
-    <T>(): LazyEvaluator<T, Flatten<T>> =>
-    // eslint-disable-next-line unicorn/consistent-function-scoping -- I tried pulling the function out but I couldn't get the `<T>` to get inferred correctly.
-    (item) =>
-      // @ts-expect-error [ts2322] - We need to make LazyMany better so it accommodate the typing here...
-      Array.isArray(item)
-        ? { done: false, hasNext: true, hasMany: true, next: item }
-        : { done: false, hasNext: true, next: item };
-}
+const lazyImplementation =
+  <T>(): LazyEvaluator<T, Flatten<T>> =>
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- I tried pulling the function out but I couldn't get the `<T>` to get inferred correctly.
+  (item) =>
+    // @ts-expect-error [ts2322] - We need to make LazyMany better so it accommodate the typing here...
+    Array.isArray(item)
+      ? { done: false, hasNext: true, hasMany: true, next: item }
+      : { done: false, hasNext: true, next: item };

--- a/src/intersectionWith.ts
+++ b/src/intersectionWith.ts
@@ -62,26 +62,21 @@ export function intersectionWith<TFirst, TSecond>(
 ): (array: ReadonlyArray<TFirst>) => Array<TFirst>;
 
 export function intersectionWith(): unknown {
-  return purry(_intersectionWith, arguments, intersectionWith.lazy);
+  return purry(intersectionWithImplementation, arguments, lazyImplementation);
 }
 
-function _intersectionWith<TFirst, TSecond>(
+const intersectionWithImplementation = <TFirst, TSecond>(
   array: ReadonlyArray<TFirst>,
   other: ReadonlyArray<TSecond>,
   comparator: Comparator<TFirst, TSecond>,
-): Array<TFirst> {
-  const lazy = intersectionWith.lazy(other, comparator);
-  return _reduceLazy(array, lazy);
-}
+): Array<TFirst> => _reduceLazy(array, lazyImplementation(other, comparator));
 
-export namespace intersectionWith {
-  export const lazy =
-    <TFirst, TSecond>(
-      other: ReadonlyArray<TSecond>,
-      comparator: Comparator<TFirst, TSecond>,
-    ): LazyEvaluator<TFirst> =>
-    (value) =>
-      other.some((otherValue) => comparator(value, otherValue))
-        ? { done: false, hasNext: true, next: value }
-        : { done: false, hasNext: false };
-}
+const lazyImplementation =
+  <TFirst, TSecond>(
+    other: ReadonlyArray<TSecond>,
+    comparator: Comparator<TFirst, TSecond>,
+  ): LazyEvaluator<TFirst> =>
+  (value) =>
+    other.some((otherValue) => comparator(value, otherValue))
+      ? { done: false, hasNext: true, next: value }
+      : { done: false, hasNext: false };

--- a/src/isIncludedIn.ts
+++ b/src/isIncludedIn.ts
@@ -73,5 +73,5 @@ export function isIncludedIn(
   }
 
   // === dataFirst ===
-  return container.includes(dataOrContainer);
+  return container.indexOf(dataOrContainer) >= 0;
 }

--- a/src/isIncludedIn.ts
+++ b/src/isIncludedIn.ts
@@ -73,5 +73,5 @@ export function isIncludedIn(
   }
 
   // === dataFirst ===
-  return container.indexOf(dataOrContainer) >= 0;
+  return container.includes(dataOrContainer);
 }

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -4,11 +4,6 @@ import type { LazyEvaluator } from "./pipe";
 
 type LazyEvaluatorFactory = (...args: any) => LazyEvaluator;
 
-type MaybeLazyFunction = {
-  (...args: any): unknown;
-  readonly lazy?: LazyEvaluatorFactory;
-};
-
 /**
  * Creates a function with `dataFirst` and `dataLast` signatures.
  *
@@ -25,7 +20,7 @@ type MaybeLazyFunction = {
  *
  * @param fn - The function to purry.
  * @param args - The arguments.
- * @param lazyFactory - A lazy version of the function to purry.
+ * @param lazy - A lazy version of the function to purry.
  * @signature R.purry(fn, arguments);
  * @example
  *    function _findIndex(array, fn) {
@@ -49,9 +44,9 @@ type MaybeLazyFunction = {
  * @category Function
  */
 export function purry(
-  fn: MaybeLazyFunction,
+  fn: (...args: any) => unknown,
   args: IArguments | ReadonlyArray<unknown>,
-  lazyFactory?: LazyEvaluatorFactory,
+  lazy?: LazyEvaluatorFactory,
 ): unknown {
   // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
   const callArgs = Array.from(args) as ReadonlyArray<unknown>;
@@ -63,7 +58,6 @@ export function purry(
 
   if (diff === 1) {
     const ret = (data: unknown): unknown => fn(data, ...callArgs);
-    const lazy = lazyFactory ?? fn.lazy;
     return lazy === undefined
       ? ret
       : Object.assign(ret, { lazy, lazyArgs: args });

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -2,8 +2,6 @@
 
 import type { LazyEvaluator } from "./pipe";
 
-type LazyEvaluatorFactory = (...args: any) => LazyEvaluator;
-
 /**
  * Creates a function with `dataFirst` and `dataLast` signatures.
  *
@@ -46,7 +44,7 @@ type LazyEvaluatorFactory = (...args: any) => LazyEvaluator;
 export function purry(
   fn: (...args: any) => unknown,
   args: IArguments | ReadonlyArray<unknown>,
-  lazy?: LazyEvaluatorFactory,
+  lazy?: (...args: any) => LazyEvaluator,
 ): unknown {
   // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
   const callArgs = Array.from(args) as ReadonlyArray<unknown>;

--- a/src/take.ts
+++ b/src/take.ts
@@ -32,23 +32,20 @@ export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
 export function take<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
 export function take(): unknown {
-  return purry(_take, arguments, take.lazy);
+  return purry(takeImplementation, arguments, lazyImplementation);
 }
 
-function _take<T>(array: ReadonlyArray<T>, n: number): Array<T> {
-  return _reduceLazy(array, take.lazy(n));
-}
+const takeImplementation = <T>(array: ReadonlyArray<T>, n: number): Array<T> =>
+  _reduceLazy(array, lazyImplementation(n));
 
-export namespace take {
-  export function lazy<T>(n: number): LazyEvaluator<T> {
-    if (n <= 0) {
-      return () => ({ done: true, hasNext: false });
-    }
-
-    let remaining = n;
-    return (value) => {
-      remaining -= 1;
-      return { done: remaining <= 0, hasNext: true, next: value };
-    };
+function lazyImplementation<T>(n: number): LazyEvaluator<T> {
+  if (n <= 0) {
+    return () => ({ done: true, hasNext: false });
   }
+
+  let remaining = n;
+  return (value) => {
+    remaining -= 1;
+    return { done: remaining <= 0, hasNext: true, next: value };
+  };
 }

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -36,22 +36,19 @@ export function unique<T>(array: ReadonlyArray<T>): Array<T>;
 export function unique<T>(): (array: ReadonlyArray<T>) => Array<T>;
 
 export function unique(): unknown {
-  return purry(uniqueImplementation, arguments, unique.lazy);
+  return purry(uniqueImplementation, arguments, lazyImplementation);
 }
 
-function uniqueImplementation<T>(array: ReadonlyArray<T>): Array<T> {
-  return _reduceLazy(array, unique.lazy());
-}
+const uniqueImplementation = <T>(array: ReadonlyArray<T>): Array<T> =>
+  _reduceLazy(array, lazyImplementation());
 
-export namespace unique {
-  export function lazy<T>(): LazyEvaluator<T> {
-    const set = new Set<T>();
-    return (value) => {
-      if (set.has(value)) {
-        return { done: false, hasNext: false };
-      }
-      set.add(value);
-      return { done: false, hasNext: true, next: value };
-    };
-  }
+function lazyImplementation<T>(): LazyEvaluator<T> {
+  const set = new Set<T>();
+  return (value) => {
+    if (set.has(value)) {
+      return { done: false, hasNext: false };
+    }
+    set.add(value);
+    return { done: false, hasNext: true, next: value };
+  };
 }


### PR DESCRIPTION
Simpliyfing the purry/pipe model by removing direct "lazy" extending. It wasn't used directly anyway, as purry always "made sure" to bridge the gap for any other function anyway