### PR TITLE
fix: Stop using IArguments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,12 +37,6 @@ export default config(
       // @see https://tkdodo.eu/blog/array-types-in-type-script
       "@typescript-eslint/array-type": ["error", { default: "generic" }],
 
-      // TODO: Once we bump our Typescript target version to ES2015 or above we
-      // can migrate all `argument` to variadic rest params. This will remove
-      // a step currently done in all purried functions to convert the arguments
-      // into an array.
-      "prefer-rest-params": "off",
-
       // This isn't very useful in a utility library, a lot of utilities need to
       // access arrays in a random-access way.
       // TODO: Once we bump our typescript `target` we should enable this rule again, go over all the non-null-assertions, and see which ones are due to a for loop which could use `Array.prototype.entries` instead.

--- a/src/_purryOn.ts
+++ b/src/_purryOn.ts
@@ -11,13 +11,11 @@ export function purryOn<T>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Function inference in typescript relies on `any` to work, it doesn't work with `unknown`
     ...args: any
   ) => unknown,
-  args: IArguments,
+  args: ReadonlyArray<unknown>,
 ): unknown {
-  // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
-  const callArgs = Array.from(args) as ReadonlyArray<unknown>;
   return isArg(args[0])
     ? // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      (data: unknown) => implementation(data, ...callArgs)
+      (data: unknown) => implementation(data, ...args)
     : // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      implementation(...callArgs);
+      implementation(...args);
 }

--- a/src/_purryOrderRules.ts
+++ b/src/_purryOrderRules.ts
@@ -59,15 +59,16 @@ type ComparablePrimitive = boolean | number | string;
  */
 export function purryOrderRules<T>(
   func: (data: ReadonlyArray<T>, compareFn: CompareFunction<T>) => unknown,
-  inputArgs: IArguments | ReadonlyArray<unknown>,
+  inputArgs: ReadonlyArray<unknown>,
 ): unknown {
   // We rely on casting blindly here, but we rely on casting blindly everywhere
   // else when we call purry so it's fine...
-  const [dataOrRule, ...rules] = (
-    Array.isArray(inputArgs) ? inputArgs : Array.from(inputArgs)
-  ) as
+  const [dataOrRule, ...rules] = inputArgs as
     | Readonly<NonEmptyArray<OrderRule<T>>>
-    | [data: ReadonlyArray<T>, ...rules: Readonly<NonEmptyArray<OrderRule<T>>>];
+    | [
+        data: OrderRule<T> | ReadonlyArray<T>,
+        ...rules: Readonly<NonEmptyArray<OrderRule<T>>>,
+      ];
 
   if (!isOrderRule<T>(dataOrRule)) {
     // dataFirst!
@@ -98,12 +99,8 @@ export function purryOrderRulesWithArgument(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Function inference in typescript relies on `any` to work, it doesn't work with `unknown`
     arg: any,
   ) => unknown,
-  inputArgs: IArguments,
+  [first, second, ...rest]: ReadonlyArray<unknown>,
 ): unknown {
-  const [first, second, ...rest] = Array.from(
-    inputArgs,
-  ) as ReadonlyArray<unknown>;
-
   // We need to pull the `n` argument out to make it work with purryOrderRules.
   let arg: unknown;
   let argRemoved: ReadonlyArray<unknown>;

--- a/src/add.ts
+++ b/src/add.ts
@@ -31,8 +31,8 @@ export function add(value: number, addend: number): number;
  */
 export function add(addend: number): (value: number) => number;
 
-export function add(): unknown {
-  return purry(_add, arguments);
+export function add(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_add, args);
 }
 
 function _add(value: number, addend: number): number {

--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -37,8 +37,8 @@ export function addProp<
   V,
 >(prop: K, value: V): (obj: T) => T & { [x in K]: V };
 
-export function addProp(): unknown {
-  return purry(_addProp, arguments);
+export function addProp(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_addProp, args);
 }
 
 function _addProp<T extends Record<PropertyKey, unknown>, K extends string, V>(

--- a/src/allPass.ts
+++ b/src/allPass.ts
@@ -40,8 +40,8 @@ export function allPass<T>(
   fns: ReadonlyArray<(data: T) => boolean>,
 ): (data: T) => boolean;
 
-export function allPass(): unknown {
-  return purry(_allPass, arguments);
+export function allPass(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_allPass, args);
 }
 
 function _allPass<T>(

--- a/src/anyPass.ts
+++ b/src/anyPass.ts
@@ -40,8 +40,8 @@ export function anyPass<T>(
   fns: ReadonlyArray<(data: T) => boolean>,
 ): (data: T) => boolean;
 
-export function anyPass(): unknown {
-  return purry(_anyPass, arguments);
+export function anyPass(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_anyPass, args);
 }
 
 function _anyPass<T>(

--- a/src/ceil.ts
+++ b/src/ceil.ts
@@ -38,6 +38,6 @@ export function ceil(value: number, precision: number): number;
  */
 export function ceil(precision: number): (value: number) => number;
 
-export function ceil(): unknown {
-  return purry(_withPrecision(Math.ceil), arguments);
+export function ceil(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_withPrecision(Math.ceil), args);
 }

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -43,8 +43,8 @@ export function chunk<T extends IterableContainer>(
   size: number,
 ): (array: T) => Chunked<T>;
 
-export function chunk(): unknown {
-  return purry(_chunk, arguments);
+export function chunk(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_chunk, args);
 }
 
 function _chunk<T>(array: ReadonlyArray<T>, size: number): Array<Array<T>> {

--- a/src/clamp.ts
+++ b/src/clamp.ts
@@ -36,8 +36,8 @@ export function clamp(value: number, limits: Limits): number;
  */
 export function clamp(limits: Limits): (value: number) => number;
 
-export function clamp(): unknown {
-  return purry(_clamp, arguments);
+export function clamp(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_clamp, args);
 }
 
 function _clamp(value: number, { min, max }: Limits): number {

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -32,8 +32,8 @@ export function concat<T, K>(
   arr2: ReadonlyArray<K>,
 ): (arr1: ReadonlyArray<T>) => Array<K | T>;
 
-export function concat(): unknown {
-  return purry(_concat, arguments);
+export function concat(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_concat, args);
 }
 
 function _concat<T, K>(

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -187,8 +187,8 @@ export function conditional<
   | Return8
   | Return9;
 
-export function conditional(): unknown {
-  return purryOn(isCase, conditionalImplementation, arguments);
+export function conditional(...args: ReadonlyArray<unknown>): unknown {
+  return purryOn(isCase, conditionalImplementation, args);
 }
 
 function conditionalImplementation<In, Out>(

--- a/src/differenceWith.ts
+++ b/src/differenceWith.ts
@@ -56,8 +56,8 @@ export function differenceWith<TFirst, TSecond>(
   isEquals: IsEquals<TFirst, TSecond>,
 ): (array: ReadonlyArray<TFirst>) => Array<TFirst>;
 
-export function differenceWith(): unknown {
-  return purry(differenceWithImplementation, arguments, lazyImplementation);
+export function differenceWith(...args: ReadonlyArray<unknown>): unknown {
+  return purry(differenceWithImplementation, args, lazyImplementation);
 }
 
 function differenceWithImplementation<TFirst, TSecond>(

--- a/src/divide.ts
+++ b/src/divide.ts
@@ -29,8 +29,8 @@ export function divide(value: number, divisor: number): number;
  */
 export function divide(divisor: number): (value: number) => number;
 
-export function divide(): unknown {
-  return purry(_divide, arguments);
+export function divide(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_divide, args);
 }
 
 function _divide(value: number, divisor: number): number {

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -31,8 +31,8 @@ export function drop<T>(array: ReadonlyArray<T>, n: number): Array<T>;
  */
 export function drop<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
-export function drop(): unknown {
-  return purry(dropImplementation, arguments, lazyImplementation);
+export function drop(...args: ReadonlyArray<unknown>): unknown {
+  return purry(dropImplementation, args, lazyImplementation);
 }
 
 function dropImplementation<T>(array: ReadonlyArray<T>, n: number): Array<T> {

--- a/src/dropFirstBy.ts
+++ b/src/dropFirstBy.ts
@@ -45,8 +45,8 @@ export function dropFirstBy<T>(
   ...rules: Readonly<NonEmptyArray<OrderRule<T>>>
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function dropFirstBy(): unknown {
-  return purryOrderRulesWithArgument(dropFirstByImplementation, arguments);
+export function dropFirstBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRulesWithArgument(dropFirstByImplementation, args);
 }
 
 function dropFirstByImplementation<T>(

--- a/src/dropLast.ts
+++ b/src/dropLast.ts
@@ -27,8 +27,8 @@ export function dropLast<T>(array: ReadonlyArray<T>, n: number): Array<T>;
  */
 export function dropLast<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
-export function dropLast(): unknown {
-  return purry(_dropLast, arguments);
+export function dropLast(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_dropLast, args);
 }
 
 function _dropLast<T>(array: ReadonlyArray<T>, n: number): Array<T> {

--- a/src/dropLastWhile.ts
+++ b/src/dropLastWhile.ts
@@ -36,8 +36,8 @@ export function dropLastWhile<T>(
   predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function dropLastWhile(): unknown {
-  return purry(dropLastWhileImplementation, arguments);
+export function dropLastWhile(...args: ReadonlyArray<unknown>): unknown {
+  return purry(dropLastWhileImplementation, args);
 }
 
 function dropLastWhileImplementation<T>(

--- a/src/dropWhile.ts
+++ b/src/dropWhile.ts
@@ -36,8 +36,8 @@ export function dropWhile<T>(
   predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function dropWhile(): unknown {
-  return purry(dropWhileImplementation, arguments);
+export function dropWhile(...args: ReadonlyArray<unknown>): unknown {
+  return purry(dropWhileImplementation, args);
 }
 
 function dropWhileImplementation<T>(

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -35,6 +35,6 @@ export function entries<T extends {}>(data: T): Array<Entry<T>>;
  */
 export function entries(): <T extends {}>(data: T) => Array<Entry<T>>;
 
-export function entries(): unknown {
-  return purry(Object.entries, arguments);
+export function entries(...args: ReadonlyArray<unknown>): unknown {
+  return purry(Object.entries, args);
 }

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -131,8 +131,8 @@ export function evolve<T extends object, E extends Evolver<T>>(
   evolver: E,
 ): (object: T) => Evolved<T, E>;
 
-export function evolve(): unknown {
-  return purry(_evolve, arguments);
+export function evolve(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_evolve, args);
 }
 
 function _evolve(data: unknown, evolver: GenericEvolver): unknown {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -54,8 +54,8 @@ export function filter<T>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function filter(): unknown {
-  return purry(filterImplementation, arguments, lazyImplementation);
+export function filter(...args: ReadonlyArray<unknown>): unknown {
+  return purry(filterImplementation, args, lazyImplementation);
 }
 
 const filterImplementation = <T>(

--- a/src/find.ts
+++ b/src/find.ts
@@ -74,8 +74,8 @@ export function find<T>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => T | undefined;
 
-export function find(): unknown {
-  return purry(findImplementation, arguments, _toSingle(lazyImplementation));
+export function find(...args: ReadonlyArray<unknown>): unknown {
+  return purry(findImplementation, args, _toSingle(lazyImplementation));
 }
 
 const findImplementation = <T, S extends T>(

--- a/src/findIndex.ts
+++ b/src/findIndex.ts
@@ -53,8 +53,8 @@ export function findIndex<T>(
   predicate: (value: T, index: number, obj: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => number;
 
-export function findIndex(): unknown {
-  return purry(findIndexImplementation, arguments);
+export function findIndex(...args: ReadonlyArray<unknown>): unknown {
+  return purry(findIndexImplementation, args);
 }
 
 const findIndexImplementation = <T>(

--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -70,9 +70,9 @@ export function findLast<T = never>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => T | undefined;
 
-export function findLast(): unknown {
+export function findLast(...args: ReadonlyArray<unknown>): unknown {
   // TODO: Use Array.prototype.findLast once we bump our typescript target
-  return purry(findLastImplementation, arguments);
+  return purry(findLastImplementation, args);
 }
 
 const findLastImplementation = <T, S extends T>(

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -53,9 +53,9 @@ export function findLastIndex<T>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => number;
 
-export function findLastIndex(): unknown {
+export function findLastIndex(...args: ReadonlyArray<unknown>): unknown {
   // TODO: Use `Array.prototype.findLastIndex` once we bump our Typescript target.
-  return purry(findLastIndexImplementation, arguments);
+  return purry(findLastIndexImplementation, args);
 }
 
 const findLastIndexImplementation = <T>(

--- a/src/first.ts
+++ b/src/first.ts
@@ -46,8 +46,8 @@ export function first<T extends IterableContainer>(data: T): First<T>;
  */
 export function first(): <T extends IterableContainer>(data: T) => First<T>;
 
-export function first(): unknown {
-  return purry(firstImplementation, arguments, _toSingle(lazyImplementation));
+export function first(...args: ReadonlyArray<unknown>): unknown {
+  return purry(firstImplementation, args, _toSingle(lazyImplementation));
 }
 
 const firstImplementation = <T>([item]: ReadonlyArray<T>): T | undefined =>

--- a/src/firstBy.ts
+++ b/src/firstBy.ts
@@ -73,8 +73,8 @@ export function firstBy<T extends IterableContainer>(
   ...rules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
 ): FirstBy<T>;
 
-export function firstBy(): unknown {
-  return purryOrderRules(firstByImplementation, arguments);
+export function firstBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRules(firstByImplementation, args);
 }
 
 function firstByImplementation<T>(

--- a/src/flatMap.ts
+++ b/src/flatMap.ts
@@ -60,8 +60,8 @@ export function flatMap<T, K>(
   ) => K | ReadonlyArray<K>,
 ): (data: ReadonlyArray<T>) => Array<K>;
 
-export function flatMap(): unknown {
-  return purry(flatMapImplementation, arguments, lazyImplementation);
+export function flatMap(...args: ReadonlyArray<unknown>): unknown {
+  return purry(flatMapImplementation, args, lazyImplementation);
 }
 
 function flatMapImplementation<T, K>(

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -34,8 +34,8 @@ export function flatten<T>(items: ReadonlyArray<T>): Array<Flatten<T>>;
  */
 export function flatten<T>(): (items: ReadonlyArray<T>) => Array<Flatten<T>>;
 
-export function flatten(): unknown {
-  return purry(flattenImplementation, arguments, lazyImplementation);
+export function flatten(...args: ReadonlyArray<unknown>): unknown {
+  return purry(flattenImplementation, args, lazyImplementation);
 }
 
 const flattenImplementation = <T>(items: ReadonlyArray<T>): Array<Flatten<T>> =>

--- a/src/flattenDeep.ts
+++ b/src/flattenDeep.ts
@@ -40,8 +40,8 @@ export function flattenDeep<T>(): (
   items: ReadonlyArray<T>,
 ) => Array<FlattenDeep<T>>;
 
-export function flattenDeep(): unknown {
-  return purry(flattenDeepImplementation, arguments, lazyImplementation);
+export function flattenDeep(...args: ReadonlyArray<unknown>): unknown {
+  return purry(flattenDeepImplementation, args, lazyImplementation);
 }
 
 const flattenDeepImplementation = <T>(

--- a/src/floor.ts
+++ b/src/floor.ts
@@ -38,6 +38,6 @@ export function floor(value: number, precision: number): number;
  */
 export function floor(precision: number): (value: number) => number;
 
-export function floor(): unknown {
-  return purry(_withPrecision(Math.floor), arguments);
+export function floor(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_withPrecision(Math.floor), args);
 }

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -54,8 +54,8 @@ export function forEach<T>(
   callbackfn: (value: T, index: number, data: ReadonlyArray<T>) => void,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function forEach(): unknown {
-  return purry(forEachImplementation, arguments, lazyImplementation);
+export function forEach(...args: ReadonlyArray<unknown>): unknown {
+  return purry(forEachImplementation, args, lazyImplementation);
 }
 
 function forEachImplementation<T>(

--- a/src/forEachObj.ts
+++ b/src/forEachObj.ts
@@ -46,8 +46,8 @@ export function forEachObj<T extends Record<PropertyKey, unknown>>(
   callbackfn: (value: T[keyof T], key: keyof T, obj: T) => void,
 ): (object: T) => T;
 
-export function forEachObj(): unknown {
-  return purry(forEachObjImplementation, arguments);
+export function forEachObj(...args: ReadonlyArray<unknown>): unknown {
+  return purry(forEachObjImplementation, args);
 }
 
 function forEachObjImplementation<T extends Record<PropertyKey, unknown>>(

--- a/src/fromEntries.ts
+++ b/src/fromEntries.ts
@@ -137,9 +137,9 @@ export function fromEntries(): <Entries extends IterableContainer<Entry>>(
   entries: Entries,
 ) => Simplify<FromEntries<Entries>>;
 
-export function fromEntries(): unknown {
+export function fromEntries(...args: ReadonlyArray<unknown>): unknown {
   // TODO: When we bump the typescript target beyond ES2019 we can use Object.fromEntries directly here instead of our user-space implementation.
-  return purry(fromEntriesImplementation, arguments);
+  return purry(fromEntriesImplementation, args);
 }
 
 function fromEntriesImplementation<Entries extends IterableContainer<Entry>>(

--- a/src/fromKeys.ts
+++ b/src/fromKeys.ts
@@ -73,8 +73,8 @@ export function fromKeys<T extends IterableContainer<PropertyKey>, V>(
   mapper: (item: T[number], index: number, data: T) => V,
 ): (data: T) => Simplify<FromKeys<T, V>>;
 
-export function fromKeys(): unknown {
-  return purry(fromKeysImplementation, arguments);
+export function fromKeys(...args: ReadonlyArray<unknown>): unknown {
+  return purry(fromKeysImplementation, args);
 }
 
 function fromKeysImplementation<T extends IterableContainer<PropertyKey>, V>(

--- a/src/groupBy.ts
+++ b/src/groupBy.ts
@@ -67,8 +67,8 @@ export function groupBy<T, Key extends PropertyKey = PropertyKey>(
   ) => Key | undefined,
 ): (items: ReadonlyArray<T>) => ExactRecord<Key, NonEmptyArray<T>>;
 
-export function groupBy(): unknown {
-  return purry(groupByImplementation, arguments);
+export function groupBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(groupByImplementation, args);
 }
 
 const groupByImplementation = <T, Key extends PropertyKey = PropertyKey>(

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -43,8 +43,8 @@ export function hasSubObject<T, S extends Partial<T>>(
   subObject: S,
 ): (data: T) => data is Simplify<S & T>;
 
-export function hasSubObject(): unknown {
-  return purry(_hasSubObject, arguments);
+export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_hasSubObject, args);
 }
 
 function _hasSubObject<T, S extends Partial<T>>(

--- a/src/indexBy.ts
+++ b/src/indexBy.ts
@@ -54,8 +54,8 @@ export function indexBy<T, K extends PropertyKey>(
   mapper: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): (data: ReadonlyArray<T>) => ExactRecord<K, T>;
 
-export function indexBy(): unknown {
-  return purry(indexByImplementation, arguments);
+export function indexBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(indexByImplementation, args);
 }
 
 function indexByImplementation<T, K extends PropertyKey>(

--- a/src/intersectionWith.ts
+++ b/src/intersectionWith.ts
@@ -61,8 +61,8 @@ export function intersectionWith<TFirst, TSecond>(
   comparator: Comparator<TFirst, TSecond>,
 ): (array: ReadonlyArray<TFirst>) => Array<TFirst>;
 
-export function intersectionWith(): unknown {
-  return purry(intersectionWithImplementation, arguments, lazyImplementation);
+export function intersectionWith(...args: ReadonlyArray<unknown>): unknown {
+  return purry(intersectionWithImplementation, args, lazyImplementation);
 }
 
 const intersectionWithImplementation = <TFirst, TSecond>(

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -33,8 +33,8 @@ export function invert<T extends object>(object: T): Inverted<T>;
  */
 export function invert<T extends object>(): (object: T) => Inverted<T>;
 
-export function invert(): unknown {
-  return purry(_invert, arguments);
+export function invert(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_invert, args);
 }
 
 function _invert(

--- a/src/isDeepEqual.ts
+++ b/src/isDeepEqual.ts
@@ -55,8 +55,8 @@ export function isDeepEqual<T, S extends T = T>(
   other: S,
 ): (data: T) => data is S;
 
-export function isDeepEqual(): unknown {
-  return purry(isDeepEqualImplementation, arguments);
+export function isDeepEqual(...args: ReadonlyArray<unknown>): unknown {
+  return purry(isDeepEqualImplementation, args);
 }
 
 function isDeepEqualImplementation<T, S>(data: S | T, other: S): data is S {

--- a/src/isIncludedIn.ts
+++ b/src/isIncludedIn.ts
@@ -73,5 +73,5 @@ export function isIncludedIn(
   }
 
   // === dataFirst ===
-  return container.includes(dataOrContainer);
+  return container.indexOf(dataOrContainer) >= 0;
 }

--- a/src/isIncludedIn.ts
+++ b/src/isIncludedIn.ts
@@ -73,5 +73,5 @@ export function isIncludedIn(
   }
 
   // === dataFirst ===
-  return container.indexOf(dataOrContainer) >= 0;
+  return container.includes(dataOrContainer);
 }

--- a/src/join.ts
+++ b/src/join.ts
@@ -76,8 +76,8 @@ export function join<
   Glue extends string,
 >(glue: Glue): (data: T) => Joined<T, Glue>;
 
-export function join(): unknown {
-  return purry(joinImplementation, arguments);
+export function join(...args: ReadonlyArray<unknown>): unknown {
+  return purry(joinImplementation, args);
 }
 
 const joinImplementation = (

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -80,6 +80,6 @@ export function keys<T extends object>(data: T): Keys<T>;
  */
 export function keys(): <T extends object>(data: T) => Keys<T>;
 
-export function keys(): unknown {
-  return purry(Object.keys, arguments);
+export function keys(...args: ReadonlyArray<unknown>): unknown {
+  return purry(Object.keys, args);
 }

--- a/src/last.ts
+++ b/src/last.ts
@@ -35,8 +35,8 @@ export function last<T>(array: ReadonlyArray<T>): T | undefined;
  */
 export function last<T>(): (array: ReadonlyArray<T>) => T | undefined;
 
-export function last(): unknown {
-  return purry(_last, arguments);
+export function last(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_last, args);
 }
 
 function _last<T>(array: ReadonlyArray<T>): T | undefined {

--- a/src/length.ts
+++ b/src/length.ts
@@ -27,17 +27,8 @@ export function length<T>(items: Enumerable<T>): number;
  */
 export function length<T>(): (items: Enumerable<T>) => number;
 
-/**
- * Counts values of the collection or iterable.
- *
- * @signature
- *    R.length()(array)
- * @example
- *    R.pipe([1, 2, 3], R.length()) // => 3
- * @category Array
- */
-export function length(): unknown {
-  return purry(_length, arguments);
+export function length(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_length, args);
 }
 
 function _length<T>(items: Enumerable<T>): number {

--- a/src/map.ts
+++ b/src/map.ts
@@ -48,8 +48,8 @@ export function map<T extends IterableContainer, U>(
   callbackfn: (value: T[number], index: number, data: T) => U,
 ): (data: T) => Mapped<T, U>;
 
-export function map(): unknown {
-  return purry(mapImplementation, arguments, lazyImplementation);
+export function map(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mapImplementation, args, lazyImplementation);
 }
 
 const mapImplementation = <T, U>(

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -39,8 +39,8 @@ export function mapKeys<T extends {}, S extends PropertyKey>(
   keyMapper: (key: keyof T, value: Required<T>[keyof T], data: T) => S,
 ): (data: T) => ExactRecord<S, T[keyof T]>;
 
-export function mapKeys(): unknown {
-  return purry(mapKeysImplementation, arguments);
+export function mapKeys(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mapKeysImplementation, args);
 }
 
 function mapKeysImplementation<T extends {}, S extends PropertyKey>(

--- a/src/mapToObj.ts
+++ b/src/mapToObj.ts
@@ -53,8 +53,8 @@ export function mapToObj<T, K extends PropertyKey, V>(
   fn: (value: T, index: number, data: ReadonlyArray<T>) => [K, V],
 ): (array: ReadonlyArray<T>) => Record<K, V>;
 
-export function mapToObj(): unknown {
-  return purry(mapToObjImplementation, arguments);
+export function mapToObj(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mapToObjImplementation, args);
 }
 
 function mapToObjImplementation(

--- a/src/mapValues.ts
+++ b/src/mapValues.ts
@@ -36,8 +36,8 @@ export function mapValues<T extends object, S>(
   valueMapper: (value: T[keyof T], key: ObjectKeys<T>, data: T) => S,
 ): (data: T) => MappedValues<T, S>;
 
-export function mapValues(): unknown {
-  return purry(mapValuesImplementation, arguments);
+export function mapValues(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mapValuesImplementation, args);
 }
 
 function mapValuesImplementation<T extends object, S>(

--- a/src/mapWithFeedback.ts
+++ b/src/mapWithFeedback.ts
@@ -68,8 +68,8 @@ export function mapWithFeedback<T extends IterableContainer, U>(
   initialValue: U,
 ): (data: T) => Mapped<T, U>;
 
-export function mapWithFeedback(): unknown {
-  return purry(mapWithFeedbackImplementation, arguments, lazyImplementation);
+export function mapWithFeedback(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mapWithFeedbackImplementation, args, lazyImplementation);
 }
 
 const mapWithFeedbackImplementation = <T, U>(

--- a/src/meanBy.ts
+++ b/src/meanBy.ts
@@ -40,8 +40,8 @@ export function meanBy<T>(
   fn: (value: T, index: number, data: ReadonlyArray<T>) => number,
 ): number;
 
-export function meanBy(): unknown {
-  return purry(meanByImplementation, arguments);
+export function meanBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(meanByImplementation, args);
 }
 
 const meanByImplementation = <T>(

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -53,8 +53,8 @@ export function merge<T, Source>(data: T, source: Source): Merge<T, Source>;
  */
 export function merge<Source>(source: Source): <T>(data: T) => Merge<T, Source>;
 
-export function merge(): unknown {
-  return purry(_merge, arguments);
+export function merge(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_merge, args);
 }
 
 function _merge<T, Source>(data: T, source: Source): Merge<T, Source> {

--- a/src/mergeDeep.ts
+++ b/src/mergeDeep.ts
@@ -39,8 +39,8 @@ export function mergeDeep<
   Source extends Record<string, unknown>,
 >(source: Source): (target: Destination) => MergeDeep<Destination, Source>;
 
-export function mergeDeep(): unknown {
-  return purry(mergeDeepImplementation, arguments);
+export function mergeDeep(...args: ReadonlyArray<unknown>): unknown {
+  return purry(mergeDeepImplementation, args);
 }
 
 function mergeDeepImplementation<

--- a/src/multiply.ts
+++ b/src/multiply.ts
@@ -29,8 +29,8 @@ export function multiply(value: number, multiplicand: number): number;
  */
 export function multiply(multiplicand: number): (value: number) => number;
 
-export function multiply(): unknown {
-  return purry(_multiply, arguments);
+export function multiply(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_multiply, args);
 }
 
 function _multiply(value: number, multiplicand: number): number {

--- a/src/nthBy.ts
+++ b/src/nthBy.ts
@@ -49,8 +49,8 @@ export function nthBy<T extends IterableContainer>(
   ...rules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
 ): (data: T) => T[number] | undefined;
 
-export function nthBy(): unknown {
-  return purryOrderRulesWithArgument(nthByImplementation, arguments);
+export function nthBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRulesWithArgument(nthByImplementation, args);
 }
 
 const nthByImplementation = <T>(

--- a/src/objOf.ts
+++ b/src/objOf.ts
@@ -27,8 +27,8 @@ export function objOf<T, K extends string>(
   key: K,
 ): (value: T) => { [x in K]: T };
 
-export function objOf(): unknown {
-  return purry(_objOf, arguments);
+export function objOf(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_objOf, args);
 }
 
 function _objOf<T, K extends string>(value: T, key: K): { [x in K]: T } {

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -34,8 +34,8 @@ export function omit<T extends object, K extends keyof T>(
   propNames: ReadonlyArray<K>,
 ): Omit<T, K>;
 
-export function omit(): unknown {
-  return purry(_omit, arguments);
+export function omit(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_omit, args);
 }
 
 function _omit<T extends object, K extends keyof T>(

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -31,8 +31,8 @@ export function omitBy<T>(
   predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): (data: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
-export function omitBy(): unknown {
-  return purry(omitByImplementation, arguments);
+export function omitBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(omitByImplementation, args);
 }
 
 function omitByImplementation<T>(

--- a/src/only.ts
+++ b/src/only.ts
@@ -44,8 +44,8 @@ export function only<T extends IterableContainer>(): (
   array: Readonly<T>,
 ) => Only<T>;
 
-export function only(): unknown {
-  return purry(_only, arguments);
+export function only(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_only, args);
 }
 
 function _only<T>(array: ReadonlyArray<T>): T | undefined {

--- a/src/partition.ts
+++ b/src/partition.ts
@@ -59,8 +59,8 @@ export function partition<T>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
-export function partition(): unknown {
-  return purry(partitionImplementation, arguments);
+export function partition(...args: ReadonlyArray<unknown>): unknown {
+  return purry(partitionImplementation, args);
 }
 
 const partitionImplementation = <T, S extends T>(

--- a/src/pathOr.ts
+++ b/src/pathOr.ts
@@ -144,8 +144,8 @@ export function pathOr<
   defaultValue: PathValue3<T, A, B, C>,
 ): (object: T) => PathValue3<T, A, B, C>;
 
-export function pathOr(): unknown {
-  return purry(_pathOr, arguments);
+export function pathOr(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_pathOr, args);
 }
 
 function _pathOr(

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -30,8 +30,8 @@ export function pick<T extends object, K extends keyof T>(
   names: ReadonlyArray<K>,
 ): Pick<T, K>;
 
-export function pick(): unknown {
-  return purry(_pick, arguments);
+export function pick(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_pick, args);
 }
 
 function _pick<T extends object, K extends keyof T>(

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -31,8 +31,8 @@ export function pickBy<T>(
   predicate: <K extends keyof T>(value: T[K], key: K, data: T) => boolean,
 ): (data: T) => T extends Record<keyof T, T[keyof T]> ? T : Partial<T>;
 
-export function pickBy(): unknown {
-  return purry(pickByImplementation, arguments);
+export function pickBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(pickByImplementation, args);
 }
 
 function pickByImplementation<T>(

--- a/src/product.ts
+++ b/src/product.ts
@@ -31,8 +31,8 @@ export function product(data: ReadonlyArray<number>): number;
  */
 export function product(): (data: ReadonlyArray<number>) => number;
 
-export function product(): unknown {
-  return purry(productImplementation, arguments);
+export function product(...args: ReadonlyArray<unknown>): unknown {
+  return purry(productImplementation, args);
 }
 
 function productImplementation(data: ReadonlyArray<number>): number {

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -27,8 +27,8 @@ export function prop<T, K extends keyof T>(data: T, key: K): T[K];
  */
 export function prop<T, K extends keyof T>(key: K): (data: T) => T[K];
 
-export function prop(): unknown {
-  return purry(propImplementation, arguments);
+export function prop(...args: ReadonlyArray<unknown>): unknown {
+  return purry(propImplementation, args);
 }
 
 export function propImplementation<T, K extends keyof T>(

--- a/src/pullObject.ts
+++ b/src/pullObject.ts
@@ -80,8 +80,8 @@ export function pullObject<
   valueExtractor: (item: T[number], index: number, data: T) => V,
 ): (data: T) => Partial<Record<K, V>>;
 
-export function pullObject(): unknown {
-  return purry(pullObjectImplementation, arguments);
+export function pullObject(...args: ReadonlyArray<unknown>): unknown {
+  return purry(pullObjectImplementation, args);
 }
 
 function pullObjectImplementation<

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -36,7 +36,7 @@ import type { LazyEvaluator } from "./pipe";
  *    // data-last
  *    function findIndex<T>(fn: (item: T) => boolean): (array: T[]) => number;
  *
- *    function findIndex() {
+ *    function findIndex(...args: unknown[]) {
  *      return R.purry(_findIndex, args);
  *    }
  * @category Function

--- a/src/purry.ts
+++ b/src/purry.ts
@@ -19,7 +19,7 @@ import type { LazyEvaluator } from "./pipe";
  * @param fn - The function to purry.
  * @param args - The arguments.
  * @param lazy - A lazy version of the function to purry.
- * @signature R.purry(fn, arguments);
+ * @signature R.purry(fn, args);
  * @example
  *    function _findIndex(array, fn) {
  *      for (let i = 0; i < array.length; i++) {
@@ -37,25 +37,22 @@ import type { LazyEvaluator } from "./pipe";
  *    function findIndex<T>(fn: (item: T) => boolean): (array: T[]) => number;
  *
  *    function findIndex() {
- *      return R.purry(_findIndex, arguments);
+ *      return R.purry(_findIndex, args);
  *    }
  * @category Function
  */
 export function purry(
   fn: (...args: any) => unknown,
-  args: IArguments | ReadonlyArray<unknown>,
+  args: ReadonlyArray<unknown>,
   lazy?: (...args: any) => LazyEvaluator,
 ): unknown {
-  // TODO: Once we bump our target beyond ES5 we can spread the args array directly and don't need this...
-  const callArgs = Array.from(args) as ReadonlyArray<unknown>;
-
   const diff = fn.length - args.length;
   if (diff === 0) {
-    return fn(...callArgs);
+    return fn(...args);
   }
 
   if (diff === 1) {
-    const ret = (data: unknown): unknown => fn(data, ...callArgs);
+    const ret = (data: unknown): unknown => fn(data, ...args);
     return lazy === undefined
       ? ret
       : Object.assign(ret, { lazy, lazyArgs: args });

--- a/src/randomString.ts
+++ b/src/randomString.ts
@@ -33,22 +33,8 @@ export function randomString(length: number): string;
  */
 export function randomString(): (length: number) => string;
 
-/**
- * Random a non-cryptographic random string from characters a-zA-Z0-9.
- *
- * @returns The random string.
- * @signature
- *   R.randomString()(length)
- * @example
- *    R.pipe(5, R.randomString()) // => aB92J
- * @dataLast
- * @category String
- */
-// TODO: Add this back when we deprecate headless calls in V2 of Remeda. Currently the dataLast overload breaks the typing for the headless version of the function, which is used widely in the wild.
-// export function randomString(): (length: number) => string;
-
-export function randomString(): unknown {
-  return purry(randomStringImplementation, arguments);
+export function randomString(...args: ReadonlyArray<unknown>): unknown {
+  return purry(randomStringImplementation, args);
 }
 
 function randomStringImplementation(length: number): string {

--- a/src/range.ts
+++ b/src/range.ts
@@ -25,8 +25,8 @@ export function range(start: number, end: number): Array<number>;
  */
 export function range(end: number): (start: number) => Array<number>;
 
-export function range(): unknown {
-  return purry(_range, arguments);
+export function range(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_range, args);
 }
 
 function _range(start: number, end: number): Array<number> {

--- a/src/rankBy.ts
+++ b/src/rankBy.ts
@@ -48,8 +48,8 @@ export function rankBy<T>(
   ...rules: Readonly<NonEmptyArray<OrderRule<T>>>
 ): (data: ReadonlyArray<T>) => number;
 
-export function rankBy(): unknown {
-  return purryOrderRulesWithArgument(rankByImplementation, arguments);
+export function rankBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRulesWithArgument(rankByImplementation, args);
 }
 
 function rankByImplementation<T>(

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -68,8 +68,8 @@ export function reduce<T, U>(
   initialValue: U,
 ): (data: ReadonlyArray<T>) => U;
 
-export function reduce(): unknown {
-  return purry(reduceImplementation, arguments);
+export function reduce(...args: ReadonlyArray<unknown>): unknown {
+  return purry(reduceImplementation, args);
 }
 
 const reduceImplementation = <T, U>(

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -40,8 +40,8 @@ export function reverse<T extends ReadonlyArray<unknown>>(): (
   array: T,
 ) => Reverse<T>;
 
-export function reverse(): unknown {
-  return purry(_reverse, arguments);
+export function reverse(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_reverse, args);
 }
 
 function _reverse<T>(array: ReadonlyArray<T>): Array<T> {

--- a/src/round.ts
+++ b/src/round.ts
@@ -38,6 +38,6 @@ export function round(value: number, precision: number): number;
  */
 export function round(precision: number): (value: number) => number;
 
-export function round(): unknown {
-  return purry(_withPrecision(Math.round), arguments);
+export function round(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_withPrecision(Math.round), args);
 }

--- a/src/set.ts
+++ b/src/set.ts
@@ -29,8 +29,8 @@ export function set<T, K extends keyof T>(obj: T, prop: K, value: T[K]): T;
  */
 export function set<T, K extends keyof T>(prop: K, value: T[K]): (obj: T) => T;
 
-export function set(): unknown {
-  return purry(_set, arguments);
+export function set(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_set, args);
 }
 
 function _set<T, K extends keyof T>(obj: T, prop: K, value: T[K]): T {

--- a/src/setPath.ts
+++ b/src/setPath.ts
@@ -38,8 +38,8 @@ export function setPath<TPath extends Array<PropertyKey>, Value>(
   value: Value,
 ): <Obj>(object: SupportsValueAtPath<Obj, TPath, Value>) => Obj;
 
-export function setPath(): unknown {
-  return purry(_setPath, arguments);
+export function setPath(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_setPath, args);
 }
 
 export function _setPath(

--- a/src/shuffle.ts
+++ b/src/shuffle.ts
@@ -25,8 +25,8 @@ export function shuffle<T>(items: ReadonlyArray<T>): Array<T>;
  */
 export function shuffle<T>(): (items: ReadonlyArray<T>) => Array<T>;
 
-export function shuffle(): unknown {
-  return purry(_shuffle, arguments);
+export function shuffle(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_shuffle, args);
 }
 
 function _shuffle<T>(items: ReadonlyArray<T>): Array<T> {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -39,8 +39,8 @@ export function sort<T extends IterableContainer>(
   cmp: (a: T[number], b: T[number]) => number,
 ): (items: T) => ReorderedArray<T>;
 
-export function sort(): unknown {
-  return purry(sortImplementation, arguments);
+export function sort(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sortImplementation, args);
 }
 
 function sortImplementation<T extends IterableContainer>(

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -92,8 +92,8 @@ export function sortBy<T extends IterableContainer>(
   ...sortRules: Readonly<NonEmptyArray<OrderRule<T[number]>>>
 ): ReorderedArray<T>;
 
-export function sortBy(): unknown {
-  return purryOrderRules(sortByImplementation, arguments);
+export function sortBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRules(sortByImplementation, args);
 }
 
 const sortByImplementation = <T>(

--- a/src/sortedIndex.ts
+++ b/src/sortedIndex.ts
@@ -44,8 +44,8 @@ export function sortedIndex<T>(data: ReadonlyArray<T>, item: T): number;
  */
 export function sortedIndex<T>(item: T): (data: ReadonlyArray<T>) => number;
 
-export function sortedIndex(): unknown {
-  return purry(sortedIndexImplementation, arguments);
+export function sortedIndex(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sortedIndexImplementation, args);
 }
 
 const sortedIndexImplementation = <T>(

--- a/src/sortedIndexBy.ts
+++ b/src/sortedIndexBy.ts
@@ -84,8 +84,8 @@ export function sortedIndexBy<T>(
   ) => NonNullable<unknown>,
 ): (data: ReadonlyArray<T>) => number;
 
-export function sortedIndexBy(): unknown {
-  return purry(sortedIndexByImplementation, arguments);
+export function sortedIndexBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sortedIndexByImplementation, args);
 }
 
 function sortedIndexByImplementation<T>(

--- a/src/sortedIndexWith.ts
+++ b/src/sortedIndexWith.ts
@@ -76,6 +76,6 @@ export function sortedIndexWith<T>(
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => number;
 
-export function sortedIndexWith(): unknown {
-  return purry(_binarySearchCutoffIndex, arguments);
+export function sortedIndexWith(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_binarySearchCutoffIndex, args);
 }

--- a/src/sortedLastIndex.ts
+++ b/src/sortedLastIndex.ts
@@ -44,8 +44,8 @@ export function sortedLastIndex<T>(data: ReadonlyArray<T>, item: T): number;
  */
 export function sortedLastIndex<T>(item: T): (data: ReadonlyArray<T>) => number;
 
-export function sortedLastIndex(): unknown {
-  return purry(sortedLastIndexImplementation, arguments);
+export function sortedLastIndex(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sortedLastIndexImplementation, args);
 }
 
 const sortedLastIndexImplementation = <T>(

--- a/src/sortedLastIndexBy.ts
+++ b/src/sortedLastIndexBy.ts
@@ -86,8 +86,8 @@ export function sortedLastIndexBy<T>(
   ) => NonNullable<unknown>,
 ): (data: ReadonlyArray<T>) => number;
 
-export function sortedLastIndexBy(): unknown {
-  return purry(sortedLastIndexByImplementation, arguments);
+export function sortedLastIndexBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sortedLastIndexByImplementation, args);
 }
 
 function sortedLastIndexByImplementation<T>(

--- a/src/splice.ts
+++ b/src/splice.ts
@@ -42,8 +42,8 @@ export function splice<T>(
   replacement: ReadonlyArray<T>,
 ): (items: ReadonlyArray<T>) => Array<T>;
 
-export function splice(): unknown {
-  return purry(_splice, arguments);
+export function splice(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_splice, args);
 }
 
 function _splice<T>(

--- a/src/splitAt.ts
+++ b/src/splitAt.ts
@@ -34,8 +34,8 @@ export function splitAt<T>(
   index: number,
 ): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
-export function splitAt(): unknown {
-  return purry(_splitAt, arguments);
+export function splitAt(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_splitAt, args);
 }
 
 function _splitAt<T>(

--- a/src/splitWhen.ts
+++ b/src/splitWhen.ts
@@ -33,8 +33,8 @@ export function splitWhen<T>(
   predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => [Array<T>, Array<T>];
 
-export function splitWhen(): unknown {
-  return purry(splitWhenImplementation, arguments);
+export function splitWhen(...args: ReadonlyArray<unknown>): unknown {
+  return purry(splitWhenImplementation, args);
 }
 
 function splitWhenImplementation<T>(

--- a/src/subtract.ts
+++ b/src/subtract.ts
@@ -31,8 +31,8 @@ export function subtract(value: number, subtrahend: number): number;
  */
 export function subtract(subtrahend: number): (value: number) => number;
 
-export function subtract(): unknown {
-  return purry(_subtract, arguments);
+export function subtract(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_subtract, args);
 }
 
 function _subtract(value: number, subtrahend: number): number {

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -29,8 +29,8 @@ export function sum(data: ReadonlyArray<number>): number;
  */
 export function sum(): (data: ReadonlyArray<number>) => number;
 
-export function sum(): unknown {
-  return purry(sumImplementation, arguments);
+export function sum(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sumImplementation, args);
 }
 
 function sumImplementation(data: ReadonlyArray<number>): number {

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -40,8 +40,8 @@ export function sumBy<T>(
   callbackfn: (value: T, index: number, data: ReadonlyArray<T>) => number,
 ): number;
 
-export function sumBy(): unknown {
-  return purry(sumByImplementation, arguments);
+export function sumBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(sumByImplementation, args);
 }
 
 const sumByImplementation = <T>(

--- a/src/swapIndices.ts
+++ b/src/swapIndices.ts
@@ -152,8 +152,8 @@ export function swapIndices<K1 extends number, K2 extends number>(
   index2: K2,
 ): <T extends IterableContainer | string>(data: T) => SwappedIndices<T, K1, K2>;
 
-export function swapIndices(): unknown {
-  return purry(_swapIndices, arguments);
+export function swapIndices(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_swapIndices, args);
 }
 
 function _swapIndices(

--- a/src/swapProps.ts
+++ b/src/swapProps.ts
@@ -43,8 +43,8 @@ export function swapProps<
   K2 extends keyof T,
 >(key1: K1, key2: K2): (data: T) => SwappedProps<T, K1, K2>;
 
-export function swapProps(): unknown {
-  return purry(_swapProps, arguments);
+export function swapProps(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_swapProps, args);
 }
 
 function _swapProps<T extends object, K1 extends keyof T, K2 extends keyof T>(

--- a/src/take.ts
+++ b/src/take.ts
@@ -31,8 +31,8 @@ export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
  */
 export function take<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
 
-export function take(): unknown {
-  return purry(takeImplementation, arguments, lazyImplementation);
+export function take(...args: ReadonlyArray<unknown>): unknown {
+  return purry(takeImplementation, args, lazyImplementation);
 }
 
 const takeImplementation = <T>(array: ReadonlyArray<T>, n: number): Array<T> =>

--- a/src/takeFirstBy.ts
+++ b/src/takeFirstBy.ts
@@ -45,8 +45,8 @@ export function takeFirstBy<T>(
   ...rules: Readonly<NonEmptyArray<OrderRule<T>>>
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function takeFirstBy(): unknown {
-  return purryOrderRulesWithArgument(takeFirstByImplementation, arguments);
+export function takeFirstBy(...args: ReadonlyArray<unknown>): unknown {
+  return purryOrderRulesWithArgument(takeFirstByImplementation, args);
 }
 
 function takeFirstByImplementation<T>(

--- a/src/takeLastWhile.ts
+++ b/src/takeLastWhile.ts
@@ -34,8 +34,8 @@ export function takeLastWhile<T>(
   predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function takeLastWhile(): unknown {
-  return purry(takeLastWhileImplementation, arguments);
+export function takeLastWhile(...args: ReadonlyArray<unknown>): unknown {
+  return purry(takeLastWhileImplementation, args);
 }
 
 function takeLastWhileImplementation<T>(

--- a/src/takeWhile.ts
+++ b/src/takeWhile.ts
@@ -32,8 +32,8 @@ export function takeWhile<T>(
   predicate: (item: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): (array: ReadonlyArray<T>) => Array<T>;
 
-export function takeWhile(): unknown {
-  return purry(takeWhileImplementation, arguments);
+export function takeWhile(...args: ReadonlyArray<unknown>): unknown {
+  return purry(takeWhileImplementation, args);
 }
 
 function takeWhileImplementation<T>(

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -40,8 +40,8 @@ export function tap<T>(value: T, fn: (value: T) => void): T;
  */
 export function tap<T, F extends (value: T) => unknown>(fn: F): (value: T) => T;
 
-export function tap(): unknown {
-  return purry(_tap, arguments);
+export function tap(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_tap, args);
 }
 
 function _tap<T>(value: T, fn: (value: T) => void): T {

--- a/src/times.ts
+++ b/src/times.ts
@@ -29,8 +29,8 @@ export function times<T>(count: number, fn: (n: number) => T): Array<T>;
  */
 export function times<T>(fn: (n: number) => T): (count: number) => Array<T>;
 
-export function times(): unknown {
-  return purry(_times, arguments);
+export function times(...args: ReadonlyArray<unknown>): unknown {
+  return purry(_times, args);
 }
 
 function _times<T>(count: number, fn: (n: number) => T): Array<T> {

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -35,8 +35,8 @@ export function unique<T>(array: ReadonlyArray<T>): Array<T>;
  */
 export function unique<T>(): (array: ReadonlyArray<T>) => Array<T>;
 
-export function unique(): unknown {
-  return purry(uniqueImplementation, arguments, lazyImplementation);
+export function unique(...args: ReadonlyArray<unknown>): unknown {
+  return purry(uniqueImplementation, args, lazyImplementation);
 }
 
 const uniqueImplementation = <T>(array: ReadonlyArray<T>): Array<T> =>

--- a/src/uniqueBy.ts
+++ b/src/uniqueBy.ts
@@ -45,8 +45,8 @@ export function uniqueBy<T, K>(
   keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function uniqueBy(): unknown {
-  return purry(uniqueByImplementation, arguments, lazyImplementation);
+export function uniqueBy(...args: ReadonlyArray<unknown>): unknown {
+  return purry(uniqueByImplementation, args, lazyImplementation);
 }
 
 const uniqueByImplementation = <T, K>(

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -47,8 +47,8 @@ export function uniqueWith<T>(
   isEquals: IsEquals<T>,
 ): (data: ReadonlyArray<T>) => Array<T>;
 
-export function uniqueWith(): unknown {
-  return purry(uniqueWithImplementation, arguments, lazyImplementation);
+export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
+  return purry(uniqueWithImplementation, args, lazyImplementation);
 }
 
 const uniqueWithImplementation = <T>(

--- a/src/values.ts
+++ b/src/values.ts
@@ -38,6 +38,6 @@ export function values<T extends object>(data: T): Values<T>;
  */
 export function values(): <T extends object>(data: T) => Values<T>;
 
-export function values(): unknown {
-  return purry(Object.values, arguments);
+export function values(...args: ReadonlyArray<unknown>): unknown {
+  return purry(Object.values, args);
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -57,8 +57,8 @@ export function zip<S extends IterableContainer>(
   second: S,
 ): <F extends IterableContainer>(first: F) => Zipped<F, S>;
 
-export function zip(): unknown {
-  return purry(zipImplementation, arguments);
+export function zip(...args: ReadonlyArray<unknown>): unknown {
+  return purry(zipImplementation, args);
 }
 
 function zipImplementation<


### PR DESCRIPTION
Modern javascript can handle arguments via a variadic spread param. This means that we get the engine to build and manage the arrays needed for handling it. It removes a step from our purrying.