### PR TITLE
fix(build): remeda fails to import in next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts"
-      },
-      "require": {
-        "types": "./dist/index.d.cts"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.cjs",


### PR DESCRIPTION
When trying out the beta I encountered issues with importing remeda in next.js.

This is ChatGPTs suggestions for a fix... ¯\_(ツ)_/¯