### PR TITLE
fix(build): make type-fest a depedency so it's always installed for users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "remeda",
       "version": "2.0.0",
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.14.0"
+      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.2",
         "@eslint/js": "^8.57.0",
@@ -25,7 +28,6 @@
         "publint": "^0.2.7",
         "semantic-release": "^23.0.2",
         "tsup": "^8.0.2",
-        "type-fest": "^4.14.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^7.1.0",
         "vitest": "^1.3.1"
@@ -10425,7 +10427,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
       "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
-      "dev": true,
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -64,11 +64,14 @@
     "typeCheck": "tsc",
     "typeCheck:dist": "tsc --project tsconfig.dist.json"
   },
+  "dependencies": {
+    "type-fest": "^4.14.0"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.2",
     "@eslint/js": "^8.57.0",
-    "@types/eslint__js": "^8.42.3",
     "@types/eslint-config-prettier": "^6.11.3",
+    "@types/eslint__js": "^8.42.3",
     "@types/node": "^20.11.30",
     "@vitest/coverage-v8": "^1.3.1",
     "eslint": "^8.57.0",
@@ -81,7 +84,6 @@
     "publint": "^0.2.7",
     "semantic-release": "^23.0.2",
     "tsup": "^8.0.2",
-    "type-fest": "^4.14.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^7.1.0",
     "vitest": "^1.3.1"


### PR DESCRIPTION
We need to make sure type-fest is also installed whenever remeda is installed so that the types could be used.