### PR TITLE
chore: Update node18 related TODOs

### DIFF
--- a/src/findLast.ts
+++ b/src/findLast.ts
@@ -71,7 +71,6 @@ export function findLast<T = never>(
 ): (data: ReadonlyArray<T>) => T | undefined;
 
 export function findLast(...args: ReadonlyArray<unknown>): unknown {
-  // TODO: Use Array.prototype.findLast once we bump our target to ES2023+
   return purry(findLastImplementation, args);
 }
 
@@ -79,6 +78,8 @@ const findLastImplementation = <T, S extends T>(
   data: ReadonlyArray<T>,
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => value is S,
 ): S | undefined => {
+  // TODO [2025-05-01]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.findLast` here.
+
   for (let i = data.length - 1; i >= 0; i--) {
     const item = data[i]!;
     if (predicate(item, i, data)) {

--- a/src/findLastIndex.ts
+++ b/src/findLastIndex.ts
@@ -54,7 +54,6 @@ export function findLastIndex<T>(
 ): (array: ReadonlyArray<T>) => number;
 
 export function findLastIndex(...args: ReadonlyArray<unknown>): unknown {
-  // TODO: Use Array.prototype.findLastIndex once we bump our target to ES2023+
   return purry(findLastIndexImplementation, args);
 }
 
@@ -62,6 +61,8 @@ const findLastIndexImplementation = <T>(
   data: ReadonlyArray<T>,
   predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
 ): number => {
+  // TODO [2025-05-01]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.findLastIndex` here.
+
   for (let i = data.length - 1; i >= 0; i--) {
     if (predicate(data[i]!, i, data)) {
       return i;

--- a/src/reverse.ts
+++ b/src/reverse.ts
@@ -45,6 +45,6 @@ export function reverse(...args: ReadonlyArray<unknown>): unknown {
 }
 
 function reverseImplementation<T>(array: ReadonlyArray<T>): Array<T> {
-  // TODO: Use `Array.prototype.toReversed` once we bump our target/lib beyond ES2022.
+  // TODO [2025-05-01]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.toReversed` here.
   return [...array].reverse();
 }

--- a/src/sortBy.ts
+++ b/src/sortBy.ts
@@ -99,5 +99,5 @@ const sortByImplementation = <T>(
   data: ReadonlyArray<T>,
   compareFn: CompareFunction<T>,
 ): Array<T> =>
-  // TODO: Use `Array.prototype.toSorted` once we bump our target/lib beyond ES2022.
+  // TODO [2025-05-01]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.toSorted` here.
   [...data].sort(compareFn);

--- a/src/splice.ts
+++ b/src/splice.ts
@@ -52,7 +52,7 @@ function _splice<T>(
   deleteCount: number,
   replacement: ReadonlyArray<T>,
 ): Array<T> {
-  // TODO: Use `Array.prototype.toSpliced` once we bump our target/lib beyond ES2022.
+  // TODO [2025-05-01]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.toSpliced` here.
   const result = [...items];
   result.splice(start, deleteCount, ...replacement);
   return result;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
     "isolatedModules": true,
 
     // LANGUAGE and ENVIRONMENT
+    // TODO [2025-05-01]: These are defined by the minimum still-supported Node.JS version, which is currently 18.
     "target": "ES2022",
     "lib": ["ES2022"],
 


### PR DESCRIPTION
Node 18's last API version is ES2022, and being LTS it would be supported until May 2025, this gives us an expiry date for these TODOs