### PR TITLE
fix(isIncludedIn): handle literal unions

### DIFF
--- a/src/isIncludedIn.test.ts
+++ b/src/isIncludedIn.test.ts
@@ -107,6 +107,7 @@ describe("typing", () => {
 
   describe("narrowing", () => {
     test("data is single literal, container is pure tuple === NARROWED", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const data = 1 as const;
       if (isIncludedIn(data, [1] as const)) {
         expectTypeOf(data).toEqualTypeOf<1>();
@@ -125,6 +126,7 @@ describe("typing", () => {
     });
 
     test("data is single literal, container is array === NOT NARROWED", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const data = 1 as const;
       if (isIncludedIn(data, [1] as Array<1>)) {
         expectTypeOf(data).toEqualTypeOf<1>();
@@ -204,13 +206,12 @@ describe("typing", () => {
         expectTypeOf(data).toEqualTypeOf<number | string>();
       }
     });
-  });
 
-  describe("KNOWN ISSUES", () => {
-    test("pure tuples with literal unions break typing", () => {
+    test("pure tuples with literal unions", () => {
       const data = 1 as 1 | 2 | 3;
-      if (!isIncludedIn(data, [1] as [1 | 2])) {
-        // @ts-expect-error [ts2344] - Because we don't know if 1 or 2 is in the container, the rejected type should contain both of them!
+      if (isIncludedIn(data, [1] as [1 | 2])) {
+        expectTypeOf(data).toEqualTypeOf<1 | 2 | 3>();
+      } else {
         expectTypeOf(data).toEqualTypeOf<1 | 2 | 3>();
       }
     });

--- a/src/isIncludedIn.ts
+++ b/src/isIncludedIn.ts
@@ -1,5 +1,5 @@
 import type { IterableContainer } from "./_types";
-import type { IsNotFalse } from "./type-fest/internal";
+import type { IsNotFalse, IsUnion } from "./type-fest/internal";
 import type { IsLiteral } from "./type-fest/is-literal";
 
 /**
@@ -8,8 +8,10 @@ import type { IsLiteral } from "./type-fest/is-literal";
  */
 type IsPureTuple<T extends IterableContainer> = T extends readonly []
   ? true
-  : T extends readonly [unknown, ...infer Rest]
-    ? IsPureTuple<Rest>
+  : T extends readonly [infer Head, ...infer Rest]
+    ? IsUnion<Head> extends true
+      ? false
+      : IsPureTuple<Rest>
     : false;
 
 /**

--- a/src/type-fest/internal.ts
+++ b/src/type-fest/internal.ts
@@ -1,5 +1,26 @@
+import type { IsNever } from "./is-never";
 import type { Primitive } from "./primitive";
 
 export type IsNotFalse<T extends boolean> = [T] extends [false] ? false : true;
 
 export type IsPrimitive<T> = [T] extends [Primitive] ? true : false;
+
+export type IsUnion<T> = InternalIsUnion<T>;
+
+type InternalIsUnion<T, U = T> = (
+  IsNever<T> extends true
+    ? false
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      T extends any
+      ? [U] extends [T]
+        ? false
+        : true
+      : never
+) extends infer Result
+  ? // In some cases `Result` will return `false | true` which is `boolean`,
+    // that means `T` has at least two types and it's a union type,
+    // so we will return `true` instead of `boolean`.
+    boolean extends Result
+    ? true
+    : Result
+  : never; // Should never happen


### PR DESCRIPTION
Type-fest has a `IsUnion` utility, this allows us to avoid the only known caveat our type previously had.