### PR TITLE
docs(evolve): Clarify what happens to unused values in `evolve`

### DIFF
--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -62,7 +62,7 @@ type Evolved<T, E> = T extends object
  *
  * Functions included in `evolver` object will not be invoked
  * if its corresponding key does not exist in the `data` object.
- * Also, values included in `data` object will not be used
+ * Also, values included in `data` object will be kept as is
  * if its corresponding key does not exist in the `evolver` object.
  *
  * @param object - Object whose value is applied to the corresponding function


### PR DESCRIPTION
Tiny change to the `evolve` description.

I got confused as to what happens to values in `obj` when the corresponding key is not included in `evolver` and had to actually check the source code to figure it out. Examples are correct, but the original phrasing made it sound like they might be getting stripped away ("unused"). 

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
