### PR TITLE
fix(hasAtLeast): dont narrow on non-literal minimum

### DIFF
--- a/src/hasAtLeast.test.ts
+++ b/src/hasAtLeast.test.ts
@@ -180,14 +180,6 @@ describe("typing", () => {
     });
   });
 
-  it("LEGACY: doesn't allow when minimum isn't literal", () => {
-    // TODO: Remove this in V2
-    const array = [] as Array<number>;
-    if (hasAtLeast(array, 5 as number)) {
-      expectTypeOf(array).toEqualTypeOf<Array<number>>();
-    }
-  });
-
   it("fails on N > array length", () => {
     const array = ["hello", "world"] as const;
     if (hasAtLeast(array, 3)) {
@@ -227,6 +219,27 @@ describe("typing", () => {
       expectTypeOf(array).toEqualTypeOf<
         readonly [string, string, string, ...Array<string>]
       >();
+    }
+  });
+
+  it("only narrows on literal numbers", () => {
+    const array = [] as Array<number>;
+    if (hasAtLeast(array, 3 as number)) {
+      expectTypeOf(array).toEqualTypeOf<Array<number>>();
+    } else {
+      expectTypeOf(array).toEqualTypeOf<Array<number>>();
+    }
+  });
+
+  it("can narrow on a literal union", () => {
+    const array = [] as Array<number>;
+    if (hasAtLeast(array, 3 as 3 | 4)) {
+      // The narrowing would result in taking the minimum
+      expectTypeOf(array).toEqualTypeOf<
+        [number, number, number, ...Array<number>]
+      >();
+    } else {
+      expectTypeOf(array).toEqualTypeOf<Array<number>>();
     }
   });
 });

--- a/src/hasAtLeast.ts
+++ b/src/hasAtLeast.ts
@@ -1,55 +1,58 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
+import type { IsNumericLiteral } from "./type-fest/is-literal";
 
 type ArraySetRequired<
   T extends IterableContainer,
-  N extends number,
+  Min extends number,
   Iteration extends ReadonlyArray<unknown> = [],
-> = Iteration["length"] extends N
-  ? // We've reached the end condition for the recursion, T has all N items
-    // required.
-    T
-  : T extends readonly []
-    ? // The array doesn't have enough items to have N required items.
-      never
-    : T extends [infer Head, ...infer Rest]
-      ? // The input is a *MUTABLE* tuple, we copy the head to the output and
-        // recurse on rest of the tuple...
-        [Head, ...ArraySetRequired<Rest, N, [unknown, ...Iteration]>]
-      : T extends readonly [infer Head, ...infer Rest]
-        ? // The input is a *READONLY* tuple, we copy the head to the output and
+> = number extends Min
+  ? // There is no semantic meaning to having a non-literal number as Min
+    never
+  : Iteration["length"] extends Min
+    ? // We've reached the end condition for the recursion, T has all N items
+      // required.
+      T
+    : T extends readonly []
+      ? // The array doesn't have enough items to have N required items.
+        never
+      : T extends [infer Head, ...infer Rest]
+        ? // The input is a *MUTABLE* tuple, we copy the head to the output and
           // recurse on rest of the tuple...
-          readonly [Head, ...ArraySetRequired<Rest, N, [unknown, ...Iteration]>]
-        : T extends Array<infer Item>
-          ? // The input is a regular **MUTABLE** array, we need to fill the
-            // output with items until we reach the required size.
-            [Item, ...ArraySetRequired<T, N, [unknown, ...Iteration]>]
-          : T extends ReadonlyArray<infer Item>
-            ? // The input is a regular **READONLY** array, we need to fill the
+          [Head, ...ArraySetRequired<Rest, Min, [unknown, ...Iteration]>]
+        : T extends readonly [infer Head, ...infer Rest]
+          ? // The input is a *READONLY* tuple, we copy the head to the output and
+            // recurse on rest of the tuple...
+            readonly [
+              Head,
+              ...ArraySetRequired<Rest, Min, [unknown, ...Iteration]>,
+            ]
+          : T extends Array<infer Item>
+            ? // The input is a regular **MUTABLE** array, we need to fill the
               // output with items until we reach the required size.
-              readonly [
-                Item,
-                ...ArraySetRequired<T, N, [unknown, ...Iteration]>,
-              ]
-            : // The input is not a tuple, an array or an empty array, what is
-              // it?!
-              never;
-
-// TODO: In V2 we need to enable this type and use it as the type for the
-// `minimum` param to prevent usage of the guard when it's output can't be
-// narrowed properly, and then add an overloaded function that just returns
-// `true` with the original signature to enable a non-narrowing version of this
-// function for those cases.
-// type Literal<N extends number> = number extends N ? never : N;
+              [Item, ...ArraySetRequired<T, Min, [unknown, ...Iteration]>]
+            : T extends ReadonlyArray<infer Item>
+              ? // The input is a regular **READONLY** array, we need to fill the
+                // output with items until we reach the required size.
+                readonly [
+                  Item,
+                  ...ArraySetRequired<T, Min, [unknown, ...Iteration]>,
+                ]
+              : // The input is not a tuple, an array or an empty array, what is
+                // it?!
+                never;
 
 /**
- * Checks if the given array has at least the defined number of elements, and
- * refines the output type accordingly so that those indices are defined when
- * accessing the array even when using typescript's 'noUncheckedIndexAccess'.
+ * Checks if the given array has at least the defined number of elements. When
+ * the minimum used is a literal (e.g. `3`) the output is refined accordingly so
+ * that those indices are defined when accessing the array even when using
+ * typescript's 'noUncheckedIndexAccess'.
  *
  * @param data - The input array.
  * @param minimum - The minimum number of elements the array must have.
- * @returns True if the array's length is *at least* `minimum`.
+ * @returns True if the array's length is *at least* `minimum`. When `minimum`
+ * is a literal value, the output is narrowed to ensure the first items are
+ * guaranteed.
  * @signature
  *   R.hasAtLeast(data, minimum)
  * @example
@@ -63,16 +66,20 @@ type ArraySetRequired<
  */
 export function hasAtLeast<T extends IterableContainer, N extends number>(
   data: IterableContainer | T,
-  minimum: N,
+  minimum: IsNumericLiteral<N> extends true ? N : never,
 ): data is ArraySetRequired<T, N>;
+export function hasAtLeast(data: IterableContainer, minimum: number): boolean;
 
 /**
- * Checks if the given array has at least the defined number of elements, and
- * refines the output type accordingly so that those indices are defined when
- * accessing the array even when using typescript's 'noUncheckedIndexAccess'.
+ * Checks if the given array has at least the defined number of elements. When
+ * the minimum used is a literal (e.g. `3`) the output is refined accordingly so
+ * that those indices are defined when accessing the array even when using
+ * typescript's 'noUncheckedIndexAccess'.
  *
  * @param minimum - The minimum number of elements the array must have.
- * @returns True if the array's length is *at least* `minimum`.
+ * @returns True if the array's length is *at least* `minimum`. When `minimum`
+ * is a literal value, the output is narrowed to ensure the first items are
+ * guaranteed.
  * @signature
  *   R.hasAtLeast(minimum)(data)
  * @example
@@ -88,19 +95,19 @@ export function hasAtLeast<T extends IterableContainer, N extends number>(
  * @category Array
  */
 export function hasAtLeast<N extends number>(
-  minimum: N,
+  minimum: IsNumericLiteral<N> extends true ? N : never,
 ): <T extends IterableContainer>(
   data: IterableContainer | T,
 ) => data is ArraySetRequired<T, N>;
+export function hasAtLeast(
+  minimum: number,
+): (data: IterableContainer) => boolean;
 
 export function hasAtLeast(...args: ReadonlyArray<unknown>): unknown {
   return purry(hasAtLeastImplementation, args);
 }
 
-const hasAtLeastImplementation = <
-  T extends IterableContainer,
-  N extends number,
->(
-  data: IterableContainer | T,
-  minimum: N,
-): data is ArraySetRequired<T, N> => data.length >= minimum;
+const hasAtLeastImplementation = (
+  data: IterableContainer,
+  minimum: number,
+): boolean => data.length >= minimum;


### PR DESCRIPTION
Initially I thought this fix would have to wait for v2 because I wanted to disable the guard from working on non-literal numbers.

With the recent work I did for `isIncludedIn` I realized that we can simply "turn off" the guard-ness for those cases.

With this solution this change could be considered a fix and not a breaking change, so could be merged into v1.