### PR TITLE
fix(last): Improve `last` typings for tuples

### DIFF
--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -9,7 +9,7 @@ function defaultTo<T>(d: T) {
   };
 }
 
-test("should return last", () => {
+test("should return first", () => {
   expect(first([1, 2, 3] as const)).toEqual(1);
 });
 

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -47,25 +47,16 @@ describe("last", () => {
       assertType<undefined>(data);
     });
 
-    test("cannot know enough about mixed-type arrays", () => {
-      const input = [3, "a", false];
-      const data = last(input);
-      assertType<boolean | number | string | undefined>(data);
-    });
-
     test("can infer last type from const arrays", () => {
       const input = [3, "a", false] as const;
       const data = last(input);
       assertType<false>(data);
     });
 
-    test("falls back to union if const array length exceeds 20", () => {
-      const input = [
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25,
-      ] as const;
+    test("more complex example", () => {
+      const input = [["a", 1] as const, true, { foo: "bar" }] as const;
       const data = last(input);
-      assertType<number>(data);
+      assertType<{ foo: "bar" }>(data);
     });
   });
 });

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -53,7 +53,7 @@ describe("last", () => {
       assertType<false>(data);
     });
 
-    test("more complex example", () => {
+    test("a bit more complex example", () => {
       const input = [["a", 1] as const, true, { foo: "bar" }] as const;
       const data = last(input);
       assertType<{ foo: "bar" }>(data);

--- a/src/last.test.ts
+++ b/src/last.test.ts
@@ -40,5 +40,32 @@ describe("last", () => {
       const data = pipe("this is a text", (text) => text.split(""), last());
       assertType<string | undefined>(data);
     });
+
+    test("should return undefined for empty tuples", () => {
+      const input = [] as const;
+      const data = last(input);
+      assertType<undefined>(data);
+    });
+
+    test("cannot know enough about mixed-type arrays", () => {
+      const input = [3, "a", false];
+      const data = last(input);
+      assertType<boolean | number | string | undefined>(data);
+    });
+
+    test("can infer last type from const arrays", () => {
+      const input = [3, "a", false] as const;
+      const data = last(input);
+      assertType<false>(data);
+    });
+
+    test("falls back to union if const array length exceeds 20", () => {
+      const input = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25,
+      ] as const;
+      const data = last(input);
+      assertType<number>(data);
+    });
   });
 });

--- a/src/last.ts
+++ b/src/last.ts
@@ -1,10 +1,48 @@
-import type { NonEmptyArray } from "./_types";
+import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
+
+type OneLess<Than extends number> = [
+  -1,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...Array<number>,
+][Than];
+
+// will work for readonly arrays of length up to 20, then falls back to union
+type Last<T extends IterableContainer> = T extends readonly []
+  ? undefined
+  : T extends { length: infer L extends number }
+    ? // for non-empty, we know we can get T[length-1] directly
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      T extends readonly [infer _Head, ...infer _Tail]
+      ? T[OneLess<L>]
+      : // otherwise we add | undefined
+        T[OneLess<L>] | undefined
+    : undefined;
 
 /**
  * Gets the last element of `array`.
  *
- * @param array - The array.
+ * @param data - The array.
  * @signature
  *    R.last(array)
  * @example
@@ -14,8 +52,8 @@ import { purry } from "./purry";
  * @pipeable
  * @category Array
  */
-export function last<T>(array: Readonly<NonEmptyArray<T>>): T;
-export function last<T>(array: ReadonlyArray<T>): T | undefined;
+export function last<T extends IterableContainer>(data: T): Last<T>;
+// export function last<T>(array: ReadonlyArray<T>): T | undefined;
 
 /**
  * Gets the last element of `array`.
@@ -33,12 +71,12 @@ export function last<T>(array: ReadonlyArray<T>): T | undefined;
  * @pipeable
  * @category Array
  */
-export function last<T>(): (array: ReadonlyArray<T>) => T | undefined;
+export function last<T extends IterableContainer>(): (data: T) => Last<T>;
 
 export function last(): unknown {
   return purry(_last, arguments);
 }
 
-function _last<T>(array: ReadonlyArray<T>): T | undefined {
-  return array[array.length - 1];
+function _last<T extends IterableContainer>(data: T): Last<T> | undefined {
+  return data[data.length - 1] as Last<T> | undefined;
 }

--- a/src/last.ts
+++ b/src/last.ts
@@ -1,45 +1,6 @@
 import type { IterableContainer } from "./_types";
 import { purry } from "./purry";
-
-type OneLess<Than extends number> = [
-  -1,
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14,
-  15,
-  16,
-  17,
-  18,
-  19,
-  20,
-  ...Array<number>,
-][Than];
-
-// will work for readonly arrays of length up to 20, then falls back to union
-type Last<T extends IterableContainer> = T extends readonly []
-  ? undefined
-  : T extends { length: infer L }
-    ? L extends number
-      ? // for non-empty, we know we can get T[length-1] directly
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        T extends readonly [infer _Head, ...infer _Tail]
-        ? T[OneLess<L>]
-        : // otherwise we add | undefined
-          T[OneLess<L>] | undefined
-      : undefined
-    : undefined;
+import type { LastArrayElement } from "./type-fest/last-array-element";
 
 /**
  * Gets the last element of `array`.
@@ -54,8 +15,7 @@ type Last<T extends IterableContainer> = T extends readonly []
  * @pipeable
  * @category Array
  */
-export function last<T extends IterableContainer>(data: T): Last<T>;
-// export function last<T>(array: ReadonlyArray<T>): T | undefined;
+export function last<T extends IterableContainer>(data: T): LastArrayElement<T>;
 
 /**
  * Gets the last element of `array`.
@@ -73,12 +33,16 @@ export function last<T extends IterableContainer>(data: T): Last<T>;
  * @pipeable
  * @category Array
  */
-export function last<T extends IterableContainer>(): (data: T) => Last<T>;
+export function last<T extends IterableContainer>(): (
+  data: T,
+) => LastArrayElement<T>;
 
 export function last(): unknown {
   return purry(_last, arguments);
 }
 
-function _last<T extends IterableContainer>(data: T): Last<T> | undefined {
-  return data[data.length - 1] as Last<T> | undefined;
+function _last<T extends IterableContainer>(
+  data: T,
+): LastArrayElement<T> | undefined {
+  return data[data.length - 1] as LastArrayElement<T> | undefined;
 }

--- a/src/last.ts
+++ b/src/last.ts
@@ -30,13 +30,15 @@ type OneLess<Than extends number> = [
 // will work for readonly arrays of length up to 20, then falls back to union
 type Last<T extends IterableContainer> = T extends readonly []
   ? undefined
-  : T extends { length: infer L extends number }
-    ? // for non-empty, we know we can get T[length-1] directly
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      T extends readonly [infer _Head, ...infer _Tail]
-      ? T[OneLess<L>]
-      : // otherwise we add | undefined
-        T[OneLess<L>] | undefined
+  : T extends { length: infer L }
+    ? L extends number
+      ? // for non-empty, we know we can get T[length-1] directly
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        T extends readonly [infer _Head, ...infer _Tail]
+        ? T[OneLess<L>]
+        : // otherwise we add | undefined
+          T[OneLess<L>] | undefined
+      : undefined
     : undefined;
 
 /**

--- a/src/type-fest/last-array-element.ts
+++ b/src/type-fest/last-array-element.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Returns the last element of an array or tuple
+// Returns `undefined` for empty const tuples
+// Does not add `| undefined` for non-empty const tuples
+export type LastArrayElement<
+  Elements extends ReadonlyArray<unknown>,
+  ElementBeforeTailingSpreadElement = undefined,
+> =
+  // If the last element of an array is a spread element, the `LastArrayElement` result should be `'the type of the element before the spread element' | 'the type of the spread element'`.
+  Elements extends readonly []
+    ? ElementBeforeTailingSpreadElement
+    : Elements extends readonly [...infer _U, infer V]
+      ? V
+      : Elements extends readonly [infer U, ...infer V]
+        ? // If we return `V[number] | U` directly, it would be wrong for `[[string, boolean, object, ...number[]]`.
+          // So we need to recurse type `V` and carry over the type of the element before the spread element.
+          LastArrayElement<V, U>
+        : Elements extends ReadonlyArray<infer U>
+          ? ElementBeforeTailingSpreadElement | U
+          : never;


### PR DESCRIPTION
An attempt to consolidate typings and some naming conventions between `first` and `last`. I tried catching all cases with tests but let me know if you spot a problem that might be solvable.

Would it be beneficial to have a look at typings for `take` and `drop` in a similar manner?

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
