### PR TITLE
fix(stringToPath): Fix broken types for `stringToPath`

### DIFF
--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -47,15 +47,6 @@ describe("types", () => {
     expectTypeOf(data).toEqualTypeOf<["foo", "bar.baz", "qui"]>();
   });
 
-  test("string constructed from const strings are inferred", () => {
-    const bar = "bar";
-    const baz = "baz";
-    const qui = "qui";
-    const input = `foo[${bar}.${baz}].${qui}.che`;
-    const data = stringToPath(input);
-    expectTypeOf(data).toEqualTypeOf<["foo", "bar.baz", "qui", "che"]>();
-  });
-
   test("dynamic strings cannot be inferred", () => {
     const bar = "bar" as string;
     const input = `foo.${bar}[baz]`;

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -20,24 +20,6 @@ describe("runtime", () => {
     const res = stringToPath("foo.bar[3]");
     expect(res).toEqual(["foo", "bar", "3"]);
   });
-
-  test("should handle relatively long paths without performance issues", () => {
-    const res = stringToPath(
-      "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
-    );
-    expect(res).toEqual([
-      "lorem",
-      "ipsum",
-      "dolor.sit",
-      "amet",
-      "con",
-      "sec",
-      "tetur",
-      "adi.pisc.ing",
-      "elit",
-      "42",
-    ]);
-  });
 });
 
 describe("types", () => {
@@ -47,10 +29,30 @@ describe("types", () => {
     expectTypeOf(data).toEqualTypeOf<["foo", "bar.baz", "qui"]>();
   });
 
+  test("should handle relatively long paths without performance issues", () => {
+    const res = stringToPath(
+      "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
+    );
+    expectTypeOf(res).toEqualTypeOf<
+      [
+        "lorem",
+        "ipsum",
+        "dolor.sit",
+        "amet",
+        "con",
+        "sec",
+        "tetur",
+        "adi.pisc.ing",
+        "elit",
+        "42",
+      ]
+    >();
+  });
+
   test("dynamic strings cannot be inferred", () => {
     const bar = "bar" as string;
     const input = `foo.${bar}[baz]`;
     const data = stringToPath(input);
-    expectTypeOf(data).toEqualTypeOf<Array<string>>();
+    expectTypeOf(data).toEqualTypeOf<never>();
   });
 });

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -1,57 +1,68 @@
 import { stringToPath } from "./stringToPath";
 
-test("should convert a string to a deeply nested path", () => {
-  const res = stringToPath("foo.bar[3].baz");
-  expect<["foo", "bar", "3", "baz"]>(res).toEqual(["foo", "bar", "3", "baz"]);
-});
+describe("stringToPath", () => {
+  describe("implementation", () => {
+    test("should convert a string to a deeply nested path", () => {
+      const res = stringToPath("foo.bar[3].baz");
+      expect(res).toEqual(["foo", "bar", "3", "baz"]);
+    });
 
-test("should handle nested dot paths", () => {
-  const res = stringToPath("foo[bar.baz].qui.che");
-  expect<["foo", "bar.baz", "qui", "che"]>(res).toEqual([
-    "foo",
-    "bar.baz",
-    "qui",
-    "che",
-  ]);
-});
+    test("should handle nested dot paths", () => {
+      const res = stringToPath("foo[bar.baz].qui.che");
+      expect(res).toEqual(["foo", "bar.baz", "qui", "che"]);
+    });
 
-test("should handle short path with only bracket access", () => {
-  const res = stringToPath("foo[bar]");
-  expect<["foo", "bar"]>(res).toEqual(["foo", "bar"]);
-});
+    test("should handle short path with only bracket access", () => {
+      const res = stringToPath("foo[bar]");
+      expect(res).toEqual(["foo", "bar"]);
+    });
 
-test("should handle bracket access at the end", () => {
-  const res = stringToPath("foo.bar[3]");
-  expect<["foo", "bar", "3"]>(res).toEqual(["foo", "bar", "3"]);
-});
+    test("should handle bracket access at the end", () => {
+      const res = stringToPath("foo.bar[3]");
+      expect(res).toEqual(["foo", "bar", "3"]);
+    });
 
-test("should handle relatively long paths without performance issues", () => {
-  const res = stringToPath(
-    "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
-  );
-  expect<
-    [
-      "lorem",
-      "ipsum",
-      "dolor.sit",
-      "amet",
-      "con",
-      "sec",
-      "tetur",
-      "adi.pisc.ing",
-      "elit",
-      "42",
-    ]
-  >(res).toEqual([
-    "lorem",
-    "ipsum",
-    "dolor.sit",
-    "amet",
-    "con",
-    "sec",
-    "tetur",
-    "adi.pisc.ing",
-    "elit",
-    "42",
-  ]);
+    test("should handle relatively long paths without performance issues", () => {
+      const res = stringToPath(
+        "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
+      );
+      expect(res).toEqual([
+        "lorem",
+        "ipsum",
+        "dolor.sit",
+        "amet",
+        "con",
+        "sec",
+        "tetur",
+        "adi.pisc.ing",
+        "elit",
+        "42",
+      ]);
+    });
+  });
+
+  describe("types", () => {
+    test("simple const string are inferred", () => {
+      const input = "foo[bar.baz].qui";
+      const data = stringToPath(input);
+      assertType<["foo", "bar.baz", "qui"]>(data);
+    });
+
+    test("string constructed from const strings are inferred", () => {
+      const bar = "bar";
+      const baz = "baz";
+      const qui = "qui";
+      const input = `foo[${bar}.${baz}].${qui}.che`;
+      const data = stringToPath(input);
+      assertType<["foo", "bar.baz", "qui", "che"]>(data);
+    });
+
+    test("dynamic strings cannot be inferred", () => {
+      // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+      const bar: string = "bar";
+      const input = `foo.${bar}[baz]`;
+      const data = stringToPath(input);
+      assertType<Array<string>>(data);
+    });
+  });
 });

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -1,68 +1,65 @@
 import { stringToPath } from "./stringToPath";
 
-describe("stringToPath", () => {
-  describe("implementation", () => {
-    test("should convert a string to a deeply nested path", () => {
-      const res = stringToPath("foo.bar[3].baz");
-      expect(res).toEqual(["foo", "bar", "3", "baz"]);
-    });
-
-    test("should handle nested dot paths", () => {
-      const res = stringToPath("foo[bar.baz].qui.che");
-      expect(res).toEqual(["foo", "bar.baz", "qui", "che"]);
-    });
-
-    test("should handle short path with only bracket access", () => {
-      const res = stringToPath("foo[bar]");
-      expect(res).toEqual(["foo", "bar"]);
-    });
-
-    test("should handle bracket access at the end", () => {
-      const res = stringToPath("foo.bar[3]");
-      expect(res).toEqual(["foo", "bar", "3"]);
-    });
-
-    test("should handle relatively long paths without performance issues", () => {
-      const res = stringToPath(
-        "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
-      );
-      expect(res).toEqual([
-        "lorem",
-        "ipsum",
-        "dolor.sit",
-        "amet",
-        "con",
-        "sec",
-        "tetur",
-        "adi.pisc.ing",
-        "elit",
-        "42",
-      ]);
-    });
+describe("runtime", () => {
+  test("should convert a string to a deeply nested path", () => {
+    const res = stringToPath("foo.bar[3].baz");
+    expect(res).toEqual(["foo", "bar", "3", "baz"]);
   });
 
-  describe("types", () => {
-    test("simple const string are inferred", () => {
-      const input = "foo[bar.baz].qui";
-      const data = stringToPath(input);
-      assertType<["foo", "bar.baz", "qui"]>(data);
-    });
+  test("should handle nested dot paths", () => {
+    const res = stringToPath("foo[bar.baz].qui.che");
+    expect(res).toEqual(["foo", "bar.baz", "qui", "che"]);
+  });
 
-    test("string constructed from const strings are inferred", () => {
-      const bar = "bar";
-      const baz = "baz";
-      const qui = "qui";
-      const input = `foo[${bar}.${baz}].${qui}.che`;
-      const data = stringToPath(input);
-      assertType<["foo", "bar.baz", "qui", "che"]>(data);
-    });
+  test("should handle short path with only bracket access", () => {
+    const res = stringToPath("foo[bar]");
+    expect(res).toEqual(["foo", "bar"]);
+  });
 
-    test("dynamic strings cannot be inferred", () => {
-      // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-      const bar: string = "bar";
-      const input = `foo.${bar}[baz]`;
-      const data = stringToPath(input);
-      assertType<Array<string>>(data);
-    });
+  test("should handle bracket access at the end", () => {
+    const res = stringToPath("foo.bar[3]");
+    expect(res).toEqual(["foo", "bar", "3"]);
+  });
+
+  test("should handle relatively long paths without performance issues", () => {
+    const res = stringToPath(
+      "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
+    );
+    expect(res).toEqual([
+      "lorem",
+      "ipsum",
+      "dolor.sit",
+      "amet",
+      "con",
+      "sec",
+      "tetur",
+      "adi.pisc.ing",
+      "elit",
+      "42",
+    ]);
+  });
+});
+
+describe("types", () => {
+  test("simple const string are inferred", () => {
+    const input = "foo[bar.baz].qui";
+    const data = stringToPath(input);
+    expectTypeOf(data).toEqualTypeOf<["foo", "bar.baz", "qui"]>();
+  });
+
+  test("string constructed from const strings are inferred", () => {
+    const bar = "bar";
+    const baz = "baz";
+    const qui = "qui";
+    const input = `foo[${bar}.${baz}].${qui}.che`;
+    const data = stringToPath(input);
+    expectTypeOf(data).toEqualTypeOf<["foo", "bar.baz", "qui", "che"]>();
+  });
+
+  test("dynamic strings cannot be inferred", () => {
+    const bar = "bar" as string;
+    const input = `foo.${bar}[baz]`;
+    const data = stringToPath(input);
+    expectTypeOf(data).toEqualTypeOf<Array<string>>();
   });
 });

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -9,3 +9,9 @@ test("should handle nested dot paths", () => {
   const res = stringToPath("a.b[a.b].c");
   expect<["a", "b", "a.b", "c"]>(res).toEqual(["a", "b", "a.b", "c"]);
 });
+
+test("test with more than one-letter keys", () => {
+  const res = stringToPath("foo.bar[3].baz");
+  assertType<["foo", "bar", "3", "baz"]>(res);
+  expect(res).toEqual(["foo", "bar", "3", "baz"]);
+});

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -1,17 +1,57 @@
 import { stringToPath } from "./stringToPath";
 
 test("should convert a string to a deeply nested path", () => {
-  const res = stringToPath("a.b[0].c");
-  expect<["a", "b", "0", "c"]>(res).toEqual(["a", "b", "0", "c"]);
+  const res = stringToPath("foo.bar[3].baz");
+  expect<["foo", "bar", "3", "baz"]>(res).toEqual(["foo", "bar", "3", "baz"]);
 });
 
 test("should handle nested dot paths", () => {
-  const res = stringToPath("a.b[a.b].c");
-  expect<["a", "b", "a.b", "c"]>(res).toEqual(["a", "b", "a.b", "c"]);
+  const res = stringToPath("foo[bar.baz].qui.che");
+  expect<["foo", "bar.baz", "qui", "che"]>(res).toEqual([
+    "foo",
+    "bar.baz",
+    "qui",
+    "che",
+  ]);
 });
 
-test("test with more than one-letter keys", () => {
-  const res = stringToPath("foo.bar[3].baz");
-  assertType<["foo", "bar", "3", "baz"]>(res);
-  expect(res).toEqual(["foo", "bar", "3", "baz"]);
+test("should handle short path with only bracket access", () => {
+  const res = stringToPath("foo[bar]");
+  expect<["foo", "bar"]>(res).toEqual(["foo", "bar"]);
+});
+
+test("should handle bracket access at the end", () => {
+  const res = stringToPath("foo.bar[3]");
+  expect<["foo", "bar", "3"]>(res).toEqual(["foo", "bar", "3"]);
+});
+
+test("should handle relatively long paths without performance issues", () => {
+  const res = stringToPath(
+    "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
+  );
+  expect<
+    [
+      "lorem",
+      "ipsum",
+      "dolor.sit",
+      "amet",
+      "con",
+      "sec",
+      "tetur",
+      "adi.pisc.ing",
+      "elit",
+      "42",
+    ]
+  >(res).toEqual([
+    "lorem",
+    "ipsum",
+    "dolor.sit",
+    "amet",
+    "con",
+    "sec",
+    "tetur",
+    "adi.pisc.ing",
+    "elit",
+    "42",
+  ]);
 });

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -12,6 +12,7 @@ type StringToPath<T extends string> = string extends T
 
 /**
  * Converts a path string to an array of string keys (including array index access keys).
+ * For type-safe paths, make sure to pass string literals instead of general strings.
  *
  * @param path - A string path.
  * @signature R.stringToPathArray(path)

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -1,5 +1,5 @@
 type StringToPath<T extends string> = string extends T
-  ? Array<string>
+  ? never
   : T extends ""
     ? []
     : T extends `${infer Head}[${infer Nest}].${infer Tail}`
@@ -12,7 +12,9 @@ type StringToPath<T extends string> = string extends T
 
 /**
  * Converts a path string to an array of string keys (including array index access keys).
- * For type-safe paths, make sure to pass string literals instead of general strings.
+ * !IMPORTANT!: Attempting to pass a simple `string` type will result in the result being inferred
+ * as `never`. This is intentional to help with type-safety as this function is primarily intended
+ * to help with other "object path access" functions like `pathOr` or `setPath`.
  *
  * @param path - A string path.
  * @signature R.stringToPathArray(path)

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -1,9 +1,19 @@
+type StringToPath<T extends string> = T extends ""
+  ? []
+  : T extends `${infer Head}[${infer Nest}].${infer Tail}`
+    ? [...StringToPath<Head>, Nest, ...StringToPath<Tail>]
+    : T extends `${infer Head}[${infer Nest}]`
+      ? [...StringToPath<Head>, Nest]
+      : T extends `${infer Head}.${infer Tail}`
+        ? [...StringToPath<Head>, ...StringToPath<Tail>]
+        : [T];
+
 /**
- * Converts a path string to an array of keys.
+ * Converts a path string to an array of string keys (including array index access keys).
  *
  * @param path - A string path.
  * @signature R.stringToPathArray(path)
- * @example R.stringToPathArray('a.b[0].c') // => ['a', 'b', 0, 'c']
+ * @example R.stringToPathArray('a.b[0].c') // => ['a', 'b', '0', 'c']
  * @dataFirst
  * @category String
  */
@@ -28,13 +38,3 @@ function _stringToPath(path: string): Array<string> {
   }
   return [path];
 }
-
-export type StringToPath<T extends string> = T extends ""
-  ? []
-  : T extends `[${infer Head}].${infer Tail}`
-    ? [Head, ...StringToPath<Tail>]
-    : T extends `.${infer Head}${infer Tail}`
-      ? [Head, ...StringToPath<Tail>]
-      : T extends `${infer Head}${infer Tail}`
-        ? [Head, ...StringToPath<Tail>]
-        : [T];

--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -1,12 +1,14 @@
-type StringToPath<T extends string> = T extends ""
-  ? []
-  : T extends `${infer Head}[${infer Nest}].${infer Tail}`
-    ? [...StringToPath<Head>, Nest, ...StringToPath<Tail>]
-    : T extends `${infer Head}[${infer Nest}]`
-      ? [...StringToPath<Head>, Nest]
-      : T extends `${infer Head}.${infer Tail}`
-        ? [...StringToPath<Head>, ...StringToPath<Tail>]
-        : [T];
+type StringToPath<T extends string> = string extends T
+  ? Array<string>
+  : T extends ""
+    ? []
+    : T extends `${infer Head}[${infer Nest}].${infer Tail}`
+      ? [...StringToPath<Head>, Nest, ...StringToPath<Tail>]
+      : T extends `${infer Head}[${infer Nest}]`
+        ? [...StringToPath<Head>, Nest]
+        : T extends `${infer Head}.${infer Tail}`
+          ? [...StringToPath<Head>, ...StringToPath<Tail>]
+          : [T];
 
 /**
  * Converts a path string to an array of string keys (including array index access keys).


### PR DESCRIPTION
Tests only covered paths with single-character keys. While the implementation works correctly even for longer keys, types were actually inferred wrong:

```ts
const path = R.stringToPath("foo.bar");
          // ^?  would be ["f", "o", "o", "b", "a", "r"]
```
Reworked the `StringToPath` type and added tests covering more broad edge-cases.

I am not entirely clear why the "handles dot paths inside bracket access" is necessary, or even why it makes sense, since e.g. `"foo[bar.baz]"` is not a valid object path. 

I'm not sure if `pathOr` resolves an array access (or how), but even ignoring this was created to support `pathOr`, shouldn't we only allow integers between `[` and `]`, and potentially parse them out as numbers too? 🤔 

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
