### PR TITLE
feat(every): Add `every`

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -27,8 +27,7 @@ documentation when migrating._
 | [`dropLast`](https://remedajs.com/docs/#dropLast)                   | [`dropRight`](https://lodash.com/docs/4.17.15#dropRight)                 | [`dropLast`](https://ramdajs.com/docs/#dropLast)                   |
 | [`dropLastWhile`](https://remedajs.com/docs/#dropLastWhile)         | [`dropRightWhile`](https://lodash.com/docs/4.17.15#dropRightWhile)       | [`dropLastWhile`](https://ramdajs.com/docs/#dropLastWhile)         |
 | [`dropWhile`](https://remedajs.com/docs/#dropWhile)                 | [`dropWhile`](https://lodash.com/docs/4.17.15#dropWhile)                 | [`dropWhile`](https://ramdajs.com/docs/#dropWhile)                 |
-| [`entries`](https://remedajs.com/docs/#entries)                     |
-| [`toPairs`](https://lodash.com/docs/4.17.15#toPairs)                | [`toPairs`](https://ramdajs.com/docs/#toPairs)                           |
+| [`entries`](https://remedajs.com/docs/#entries)                     | [`toPairs`](https://lodash.com/docs/4.17.15#toPairs)                     | [`toPairs`](https://ramdajs.com/docs/#toPairs)                     |
 | [`every`](https://remedajs.com/docs/#every)                         | [`every`](https://lodash.com/docs/4.17.15#every)                         |
 | [`evolve`](https://remedajs.com/docs/#evolve)                       |                                                                          | [`evolve`](https://ramdajs.com/docs/#evolve)                       |
 | [`filter`](https://remedajs.com/docs/#filter)                       | [`filter`](https://lodash.com/docs/4.17.15#filter)                       | [`filter`](https://ramdajs.com/docs/#filter)                       |

--- a/mapping.md
+++ b/mapping.md
@@ -111,6 +111,7 @@ documentation when migrating._
 | [`unique`](https://remedajs.com/docs/#unique)                       | [`uniq`](https://lodash.com/docs/4.17.15#uniq)                           | [`uniq`](https://ramdajs.com/docs/#uniq)                           |
 | [`uniqueBy`](https://remedajs.com/docs/#uniqueBy)                   | [`uniqBy`](https://lodash.com/docs/4.17.15#uniqBy)                       | [`uniqBy`](https://ramdajs.com/docs/#uniqBy)                       |
 | [`uniqueWith`](https://remedajs.com/docs/#uniqueWith)               | [`uniqWith`](https://lodash.com/docs/4.17.15#uniqWith)                   | [`uniqWith`](https://ramdajs.com/docs/#uniqWith)                   |
+| [`every`](https://remedajs.com/docs/#every)                         | [`every`](https://lodash.com/docs/4.17.15#every)                         |                                                                    |
 
 ## Helpful one-liners
 

--- a/mapping.md
+++ b/mapping.md
@@ -27,7 +27,9 @@ documentation when migrating._
 | [`dropLast`](https://remedajs.com/docs/#dropLast)                   | [`dropRight`](https://lodash.com/docs/4.17.15#dropRight)                 | [`dropLast`](https://ramdajs.com/docs/#dropLast)                   |
 | [`dropLastWhile`](https://remedajs.com/docs/#dropLastWhile)         | [`dropRightWhile`](https://lodash.com/docs/4.17.15#dropRightWhile)       | [`dropLastWhile`](https://ramdajs.com/docs/#dropLastWhile)         |
 | [`dropWhile`](https://remedajs.com/docs/#dropWhile)                 | [`dropWhile`](https://lodash.com/docs/4.17.15#dropWhile)                 | [`dropWhile`](https://ramdajs.com/docs/#dropWhile)                 |
-| [`entries`](https://remedajs.com/docs/#entries)                     | [`toPairs`](https://lodash.com/docs/4.17.15#toPairs)                     | [`toPairs`](https://ramdajs.com/docs/#toPairs)                     |
+| [`entries`](https://remedajs.com/docs/#entries)                     |
+| [`toPairs`](https://lodash.com/docs/4.17.15#toPairs)                | [`toPairs`](https://ramdajs.com/docs/#toPairs)                           |
+| [`every`](https://remedajs.com/docs/#every)                         | [`every`](https://lodash.com/docs/4.17.15#every)                         |
 | [`evolve`](https://remedajs.com/docs/#evolve)                       |                                                                          | [`evolve`](https://ramdajs.com/docs/#evolve)                       |
 | [`filter`](https://remedajs.com/docs/#filter)                       | [`filter`](https://lodash.com/docs/4.17.15#filter)                       | [`filter`](https://ramdajs.com/docs/#filter)                       |
 | [`find`](https://remedajs.com/docs/#find)                           | [`find`](https://lodash.com/docs/4.17.15#find)                           | [`find`](https://ramdajs.com/docs/#find)                           |
@@ -111,7 +113,6 @@ documentation when migrating._
 | [`unique`](https://remedajs.com/docs/#unique)                       | [`uniq`](https://lodash.com/docs/4.17.15#uniq)                           | [`uniq`](https://ramdajs.com/docs/#uniq)                           |
 | [`uniqueBy`](https://remedajs.com/docs/#uniqueBy)                   | [`uniqBy`](https://lodash.com/docs/4.17.15#uniqBy)                       | [`uniqBy`](https://ramdajs.com/docs/#uniqBy)                       |
 | [`uniqueWith`](https://remedajs.com/docs/#uniqueWith)               | [`uniqWith`](https://lodash.com/docs/4.17.15#uniqWith)                   | [`uniqWith`](https://ramdajs.com/docs/#uniqWith)                   |
-| [`every`](https://remedajs.com/docs/#every)                         | [`every`](https://lodash.com/docs/4.17.15#every)                         |                                                                    |
 
 ## Helpful one-liners
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -12,6 +12,20 @@ export type PredIndexedOptional<T, K> = (
   array?: ReadonlyArray<T>,
 ) => K;
 
+export type TypePred<T, S extends T> = (input: T) => input is S;
+
+export type TypePredIndexed<T, S extends T> = (
+  input: T,
+  index: number,
+  array: ReadonlyArray<T>,
+) => input is S;
+
+export type TypePredIndexedOptional<T, S extends T> = (
+  input: T,
+  index?: number,
+  array?: ReadonlyArray<T>,
+) => input is S;
+
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
 export type Mapped<T extends IterableContainer, K> = {

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -12,20 +12,6 @@ export type PredIndexedOptional<T, K> = (
   array?: ReadonlyArray<T>,
 ) => K;
 
-export type TypePred<T, S extends T> = (input: T) => input is S;
-
-export type TypePredIndexed<T, S extends T> = (
-  input: T,
-  index: number,
-  array: ReadonlyArray<T>,
-) => input is S;
-
-export type TypePredIndexedOptional<T, S extends T> = (
-  input: T,
-  index?: number,
-  array?: ReadonlyArray<T>,
-) => input is S;
-
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
 export type Mapped<T extends IterableContainer, K> = {

--- a/src/every.test.ts
+++ b/src/every.test.ts
@@ -1,111 +1,93 @@
-import { conditional } from "./conditional";
-import { constant } from "./constant";
 import { every } from "./every";
+import { filter } from "./filter";
 import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";
 
-describe("every", () => {
-  describe("data-first", () => {
-    test("returns correct values on simple arrays", () => {
-      const trueInput = [1, 2, 3];
-      const trueData = every(trueInput, (val) => val < 5);
-      expect(trueData).toBe(true);
+describe("data-first", () => {
+  test("returns correct values on simple arrays", () => {
+    const trueInput = [1, 2, 3];
+    const trueData = every(trueInput, (val) => val < 5);
+    expect(trueData).toBe(true);
 
-      const falseInput = ["foo", "bar", "buzz"];
-      const falseData = every(falseInput, (val) => val.length > 3);
-      expect(falseData).toBe(false);
-    });
-
-    // empty set check
-    test("returns true on empty arrays regardless of predicate", () => {
-      const input = [] as const;
-      const data = every(input, () => false);
-      expect(data).toBe(true);
-    });
-
-    test("narrows types when a type predicate is passed", () => {
-      const input: Array<number | string> = [1, 2];
-      const data = every(input, isNumber);
-      expect(data).toBe(true);
-      if (every(input, isNumber)) {
-        assertType<Array<number>>(input);
-      }
-    });
+    const falseInput = ["foo", "bar", "buzz"];
+    const falseData = every(falseInput, (val) => val.length > 3);
+    expect(falseData).toBe(false);
   });
 
-  describe("data-last", () => {
-    test("returns correct values on simple arrays", () => {
-      const trueInput = [1, 2, 3];
-      const trueData = every((val: number) => val < 5)(trueInput);
-      expect(trueData).toBe(true);
-
-      const falseInput = ["foo", "bar", "buzz"];
-      const falseData = every((val: string) => val.length > 3)(falseInput);
-      expect(falseData).toBe(false);
-    });
-
-    // empty set check
-    test("returns true on empty arrays regardless of predicate", () => {
-      const input = [] as const;
-      const data = every(() => false)(input);
-      expect(data).toBe(true);
-    });
-
-    test("narrows types when a type predicate is passed", () => {
-      const input: Array<number | string> = [1, 2];
-      const data = every(isNumber)(input);
-      expect(data).toBe(true);
-      if (every(isNumber)(input)) {
-        assertType<Array<number>>(input);
-      }
-    });
+  // empty set check
+  test("returns true on empty arrays regardless of predicate", () => {
+    const input = [] as const;
+    const data = every(input, () => false);
+    expect(data).toBe(true);
   });
 
-  describe("indexed", () => {
-    test("works correctly", () => {
-      const input = [1, 2, 3];
-      const data = every.indexed(input, (_, index) => index > 5);
-      expect(data).toBe(false);
-    });
+  test("narrows types when a type predicate is passed", () => {
+    const input: Array<number | string> = [1, 2];
+    const data = every(input, isNumber);
+    expect(data).toBe(true);
+    if (every(input, isNumber)) {
+      expectTypeOf(input).toEqualTypeOf<Array<number>>();
+    }
+  });
+});
+
+describe("data-last", () => {
+  test("returns correct values on simple arrays", () => {
+    const trueInput = [1, 2, 3];
+    const trueData = every((val: number) => val < 5)(trueInput);
+    expect(trueData).toBe(true);
+
+    const falseInput = ["foo", "bar", "buzz"];
+    const falseData = every((val: string) => val.length > 3)(falseInput);
+    expect(falseData).toBe(false);
   });
 
-  describe("in pipe", () => {
-    test("infers types", () => {
-      const input: Array<number | string> = [1, 2, 3];
-      const data = pipe(
-        input,
-        every((_val) => {
-          assertType<number | string>(_val);
-          return true;
-        }),
-      );
-      expect(data).toBe(true);
-    });
+  // empty set check
+  test("returns true on empty arrays regardless of predicate", () => {
+    const input = [] as const;
+    const data = every(() => false)(input);
+    expect(data).toBe(true);
+  });
 
-    const customIsNumber = (val: unknown): val is number =>
-      typeof val === "number";
+  test("narrows types when a type predicate is passed", () => {
+    const input: Array<number | string> = [1, 2];
+    const data = every(isNumber)(input);
+    expect(data).toBe(true);
+    if (every(isNumber)(input)) {
+      expectTypeOf(input).toEqualTypeOf<Array<number>>();
+    }
+  });
+});
 
-    test("narrows types", () => {
-      const input: Array<number | string> = [1, 2, "foo"];
+describe("indexed", () => {
+  test("works correctly", () => {
+    const input = [1, 2, 3];
+    const data = every.indexed(input, (_, index) => index > 5);
+    expect(data).toBe(false);
+  });
+});
 
-      const checkType = every(customIsNumber);
-      //    ^? returns `data is number[]`
-      const data = pipe(
-        input,
-        conditional(
-          [
-            every(customIsNumber),
-            (val) => {
-              // but the narrowing here fails
-              // it works if I directly use `checkType` instead of `every(customIsNumber)`
-              assertType<Array<number>>(val);
-              return true;
-            },
-          ],
-          conditional.defaultCase(constant(false)),
-        ),
-      );
-      expect(data).toBe(false);
+describe("in pipe", () => {
+  test("infers types", () => {
+    const input: Array<number | string> = [1, 2, 3];
+    const data = pipe(
+      input,
+      every((val) => {
+        expectTypeOf(val).toEqualTypeOf<number | string>();
+        return true;
+      }),
+    );
+    expect(data).toBe(true);
+  });
+
+  test("narrows types when used with filter", () => {
+    const input = [
+      [1, 2],
+      [1, "a"],
+      ["foo", "bar"],
+    ] as Array<Array<number | string>>;
+    pipe(input, filter(every(isNumber)), (val) => {
+      expectTypeOf(val).toEqualTypeOf<Array<Array<number>>>();
     });
   });
 });

--- a/src/every.test.ts
+++ b/src/every.test.ts
@@ -1,5 +1,4 @@
 import { every } from "./every";
-import { filter } from "./filter";
 import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";
 
@@ -78,16 +77,5 @@ describe("in pipe", () => {
       }),
     );
     expect(data).toBe(true);
-  });
-
-  test("narrows types when used with filter", () => {
-    const input = [
-      [1, 2],
-      [1, "a"],
-      ["foo", "bar"],
-    ] as Array<Array<number | string>>;
-    pipe(input, filter(every(isNumber)), (val) => {
-      expectTypeOf(val).toEqualTypeOf<Array<Array<number>>>();
-    });
   });
 });

--- a/src/every.test.ts
+++ b/src/every.test.ts
@@ -1,0 +1,111 @@
+import { conditional } from "./conditional";
+import { constant } from "./constant";
+import { every } from "./every";
+import { isNumber } from "./isNumber";
+import { pipe } from "./pipe";
+
+describe("every", () => {
+  describe("data-first", () => {
+    test("returns correct values on simple arrays", () => {
+      const trueInput = [1, 2, 3];
+      const trueData = every(trueInput, (val) => val < 5);
+      expect(trueData).toBe(true);
+
+      const falseInput = ["foo", "bar", "buzz"];
+      const falseData = every(falseInput, (val) => val.length > 3);
+      expect(falseData).toBe(false);
+    });
+
+    // empty set check
+    test("returns true on empty arrays regardless of predicate", () => {
+      const input = [] as const;
+      const data = every(input, () => false);
+      expect(data).toBe(true);
+    });
+
+    test("narrows types when a type predicate is passed", () => {
+      const input: Array<number | string> = [1, 2];
+      const data = every(input, isNumber);
+      expect(data).toBe(true);
+      if (every(input, isNumber)) {
+        assertType<Array<number>>(input);
+      }
+    });
+  });
+
+  describe("data-last", () => {
+    test("returns correct values on simple arrays", () => {
+      const trueInput = [1, 2, 3];
+      const trueData = every((val: number) => val < 5)(trueInput);
+      expect(trueData).toBe(true);
+
+      const falseInput = ["foo", "bar", "buzz"];
+      const falseData = every((val: string) => val.length > 3)(falseInput);
+      expect(falseData).toBe(false);
+    });
+
+    // empty set check
+    test("returns true on empty arrays regardless of predicate", () => {
+      const input = [] as const;
+      const data = every(() => false)(input);
+      expect(data).toBe(true);
+    });
+
+    test("narrows types when a type predicate is passed", () => {
+      const input: Array<number | string> = [1, 2];
+      const data = every(isNumber)(input);
+      expect(data).toBe(true);
+      if (every(isNumber)(input)) {
+        assertType<Array<number>>(input);
+      }
+    });
+  });
+
+  describe("indexed", () => {
+    test("works correctly", () => {
+      const input = [1, 2, 3];
+      const data = every.indexed(input, (_, index) => index > 5);
+      expect(data).toBe(false);
+    });
+  });
+
+  describe("in pipe", () => {
+    test("infers types", () => {
+      const input: Array<number | string> = [1, 2, 3];
+      const data = pipe(
+        input,
+        every((_val) => {
+          assertType<number | string>(_val);
+          return true;
+        }),
+      );
+      expect(data).toBe(true);
+    });
+
+    const customIsNumber = (val: unknown): val is number =>
+      typeof val === "number";
+
+    test("narrows types", () => {
+      const input: Array<number | string> = [1, 2, "foo"];
+
+      const checkType = every(customIsNumber);
+      //    ^? returns `data is number[]`
+      const data = pipe(
+        input,
+        conditional(
+          [
+            every(customIsNumber),
+            (val) => {
+              // but the narrowing here fails
+              // it works if I directly use `checkType` instead of `every(customIsNumber)`
+              assertType<Array<number>>(val);
+              return true;
+            },
+          ],
+          conditional.defaultCase(constant(false)),
+        ),
+      );
+      expect(data).toBe(false);
+    });
+  });
+});

--- a/src/every.test.ts
+++ b/src/every.test.ts
@@ -2,73 +2,99 @@ import { every } from "./every";
 import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";
 
-describe("data-first", () => {
-  test("returns correct values on simple arrays", () => {
-    const trueInput = [1, 2, 3];
-    const trueData = every(trueInput, (val) => val < 5);
-    expect(trueData).toBe(true);
+describe("runtime", () => {
+  describe("data-first", () => {
+    test("returns correct values on simple arrays", () => {
+      const trueInput = [1, 2, 3];
+      const trueData = every(trueInput, (val) => val < 5);
+      expect(trueData).toBe(true);
 
-    const falseInput = ["foo", "bar", "buzz"];
-    const falseData = every(falseInput, (val) => val.length > 3);
-    expect(falseData).toBe(false);
+      const falseInput = ["foo", "bar", "buzz"];
+      const falseData = every(falseInput, (val) => val.length > 3);
+      expect(falseData).toBe(false);
+    });
+
+    // empty set check
+    test("returns true on empty arrays regardless of predicate", () => {
+      const input = [] as const;
+      const data = every(input, () => false);
+      expect(data).toBe(true);
+    });
+
+    test("works with indexed predicate", () => {
+      const input = [1, 2, 3];
+      const data = every(input, (_, index) => index < 5);
+      expect(data).toBe(true);
+    });
   });
 
-  // empty set check
-  test("returns true on empty arrays regardless of predicate", () => {
-    const input = [] as const;
-    const data = every(input, () => false);
-    expect(data).toBe(true);
-  });
+  describe("data-last", () => {
+    test("returns correct values on simple arrays", () => {
+      const trueData = pipe(
+        [1, 2, 3],
+        every((val: number) => val < 5),
+      );
+      expect(trueData).toBe(true);
 
+      const falseData = pipe(
+        ["foo", "bar", "buzz"],
+        every((val: string) => val.length > 3),
+      );
+      expect(falseData).toBe(false);
+    });
+
+    // empty set check
+    test("returns true on empty arrays regardless of predicate", () => {
+      const data = pipe(
+        [] as const,
+        every(() => false),
+      );
+      expect(data).toBe(true);
+    });
+
+    test("works with indexed predicate", () => {
+      const input = [1, 2, 3];
+      const data = pipe(
+        input,
+        every((_, index) => index < 5),
+      );
+      expect(data).toBe(true);
+    });
+  });
+});
+
+describe("typing", () => {
   test("narrows types when a type predicate is passed", () => {
     const input: Array<number | string> = [1, 2];
-    const data = every(input, isNumber);
-    expect(data).toBe(true);
     if (every(input, isNumber)) {
       expectTypeOf(input).toEqualTypeOf<Array<number>>();
     }
   });
-});
 
-describe("data-last", () => {
-  test("returns correct values on simple arrays", () => {
-    const trueInput = [1, 2, 3];
-    const trueData = every((val: number) => val < 5)(trueInput);
-    expect(trueData).toBe(true);
-
-    const falseInput = ["foo", "bar", "buzz"];
-    const falseData = every((val: string) => val.length > 3)(falseInput);
-    expect(falseData).toBe(false);
-  });
-
-  // empty set check
-  test("returns true on empty arrays regardless of predicate", () => {
-    const input = [] as const;
-    const data = every(() => false)(input);
-    expect(data).toBe(true);
-  });
-
-  test("narrows types when a type predicate is passed", () => {
-    const input: Array<number | string> = [1, 2];
-    const data = every(isNumber)(input);
-    expect(data).toBe(true);
-    if (every(isNumber)(input)) {
-      expectTypeOf(input).toEqualTypeOf<Array<number>>();
-    }
-  });
-});
-
-describe("indexed", () => {
-  test("works correctly", () => {
+  test("works with indexed predicate", () => {
     const input = [1, 2, 3];
-    const data = every.indexed(input, (_, index) => index > 5);
-    expect(data).toBe(false);
-  });
-});
+    const data = every(input, (val, index, arr) => {
+      expectTypeOf(val).toEqualTypeOf<number>();
+      expectTypeOf(index).toEqualTypeOf<number>();
+      expectTypeOf(arr).toEqualTypeOf<ReadonlyArray<number>>();
+      return index < 5;
+    });
 
-describe("in pipe", () => {
-  test("infers types", () => {
-    const input: Array<number | string> = [1, 2, 3];
+    const dataPipe = pipe(
+      input,
+      every((val, index, arr) => {
+        expectTypeOf(val).toEqualTypeOf<number>();
+        expectTypeOf(index).toEqualTypeOf<number>();
+        expectTypeOf(arr).toEqualTypeOf<ReadonlyArray<number>>();
+        return index < 5;
+      }),
+    );
+    expect(data).toBe(true);
+    expect(dataPipe).toBe(true);
+  });
+
+  test("infers types when used in pipe", () => {
+    const input = [1, 2, 3] as Array<number | string>;
     const data = pipe(
       input,
       every((val) => {

--- a/src/every.ts
+++ b/src/every.ts
@@ -1,10 +1,4 @@
-import type {
-  Pred,
-  PredIndexed,
-  PredIndexedOptional,
-  TypePred,
-  TypePredIndexed,
-} from "./_types";
+import type { PredIndexed, TypePredIndexed } from "./_types";
 import { purry } from "./purry";
 
 /**
@@ -24,11 +18,11 @@ import { purry } from "./purry";
  */
 export function every<T, S extends T>(
   data: ReadonlyArray<T>,
-  predicate: TypePred<T, S>,
+  predicate: TypePredIndexed<T, S>,
 ): data is Array<S>;
 export function every<T>(
   data: ReadonlyArray<T>,
-  predicate: Pred<T, boolean>,
+  predicate: PredIndexed<T, boolean>,
 ): boolean;
 
 /**
@@ -41,54 +35,23 @@ export function every<T>(
  * @example
  *    R.every(isNumber)([1, 2, 3]) // => true
  *    R.every(isString)(['a', 0, 'b']) // => false
- * @example
- *    // using `R.every` as a type predicate within `conditional`
- *    const allNumbers = R.every(R.isNumber);
- *    const result = R.pipe(
- *      R.conditional(
- *        [allNumbers, val => {...}]
- *                  // ^? number[]
- *        ...
- *      )
- *    )
  * @dataLast
  * @indexed
  * @category Array
  */
 export function every<T, S extends T>(
-  predicate: TypePred<T, S>,
+  predicate: TypePredIndexed<T, S>,
 ): (data: ReadonlyArray<T>) => data is Array<S>;
 export function every<T>(
-  predicate: (input: T) => boolean,
+  predicate: PredIndexed<T, boolean>,
 ): (data: ReadonlyArray<T>) => boolean;
 
 export function every(): unknown {
-  return purry(_every(false), arguments);
+  return purry(everyImplementation, arguments);
 }
 
-const _every =
-  (indexed: boolean) =>
-  <T>(data: ReadonlyArray<T>, predicate: PredIndexedOptional<T, boolean>) =>
-    indexed
-      ? data.every((element, index, array) => predicate(element, index, array))
-      : data.every((element) => predicate(element));
-
-export namespace every {
-  export function indexed<T, S extends T>(
-    data: ReadonlyArray<T>,
-    predicate: TypePredIndexed<T, S>,
-  ): data is Array<S>;
-  export function indexed<T>(
-    data: ReadonlyArray<T>,
-    predicate: PredIndexed<T, boolean>,
-  ): boolean;
-  export function indexed<T, S extends T>(
-    predicate: TypePredIndexed<T, S>,
-  ): (data: ReadonlyArray<T>) => data is Array<S>;
-  export function indexed<T>(
-    predicate: PredIndexed<T, boolean>,
-  ): (data: ReadonlyArray<T>) => boolean;
-  export function indexed(): unknown {
-    return purry(_every(true), arguments);
-  }
-}
+const everyImplementation = <T>(
+  data: ReadonlyArray<T>,
+  predicate: PredIndexed<T, boolean>,
+): boolean =>
+  data.every((element, index, array) => predicate(element, index, array));

--- a/src/every.ts
+++ b/src/every.ts
@@ -35,10 +35,6 @@ export function every<T>(
 /**
  * Checks if every element of `data` passed the predicate `predicate`.
  *
- * NOTE: If you want to use this inside `conditional` predicates and preserve proper type inference,
- * make sure to define the final type guard outside of the pipe. This is due to Typescript's limitation
- * in generic type inference. See examples below for details.
- *
  * @param predicate - A predicate function to run.
  * @returns A `boolean` indicating if every element in `data` passes the predicate `pred`.
  * @signature

--- a/src/every.ts
+++ b/src/every.ts
@@ -1,5 +1,11 @@
-import type { PredIndexed, TypePredIndexed } from "./_types";
+import type { PredIndexed } from "./_types";
 import { purry } from "./purry";
+
+type TypePredIndexed<T, S extends T> = (
+  input: T,
+  index: number,
+  array: ReadonlyArray<T>,
+) => input is S;
 
 /**
  * Checks if every element of `data` passed the predicate `predicate`.

--- a/src/every.ts
+++ b/src/every.ts
@@ -20,7 +20,6 @@ import { purry } from "./purry";
  *    R.every(['a', 0, 'b'], R.isString) // => false
  * @dataFirst
  * @indexed
- * @pipeable
  * @category Array
  */
 export function every<T, S extends T>(
@@ -54,7 +53,6 @@ export function every<T>(
  *    )
  * @dataLast
  * @indexed
- * @pipeable
  * @category Array
  */
 export function every<T, S extends T>(

--- a/src/every.ts
+++ b/src/every.ts
@@ -1,0 +1,71 @@
+// TODO: Fix ESlint issues
+/* eslint-disable jsdoc/require-example */
+/* eslint-disable jsdoc/require-description */
+import type {
+  Pred,
+  PredIndexed,
+  PredIndexedOptional,
+  TypePred,
+  TypePredIndexed,
+} from "./_types";
+import { purry } from "./purry";
+
+/**
+ * @param data - The Array to check.
+ * @param pred - A predicate function to run.
+ * @returns A `boolean` indicating if every element in `data` passes the predicate `pred`.
+ * @dataFirst
+ * @category Array
+ */
+export function every<T, S extends T>(
+  data: ReadonlyArray<T>,
+  pred: TypePred<T, S>,
+): data is Array<S>;
+export function every<T>(
+  data: ReadonlyArray<T>,
+  pred: Pred<T, boolean>,
+): boolean;
+
+/**
+ * @param pred - A predicate function to run.
+ * @dataLast
+ * @category Array
+ */
+export function every<T, S extends T>(
+  pred: TypePred<T, S>,
+): (data: ReadonlyArray<T>) => data is Array<S>;
+export function every<T>(
+  // pred: Pred<T, boolean>,
+  pred: (input: T) => boolean,
+): (data: ReadonlyArray<T>) => boolean;
+
+export function every(): unknown {
+  return purry(_every(false), arguments);
+}
+
+const _every =
+  (indexed: boolean) =>
+  <T>(data: ReadonlyArray<T>, pred: PredIndexedOptional<T, boolean>) =>
+    indexed
+      ? data.every((element, index, array) => pred(element, index, array))
+      : data.every((element) => pred(element));
+
+export namespace every {
+  export function indexed<T, S extends T>(
+    data: ReadonlyArray<T>,
+    pred: TypePredIndexed<T, S>,
+  ): data is Array<S>;
+  export function indexed<T>(
+    data: ReadonlyArray<T>,
+    pred: PredIndexed<T, boolean>,
+  ): boolean;
+  export function indexed<T, S extends T>(
+    pred: TypePredIndexed<T, S>,
+  ): (data: ReadonlyArray<T>) => data is Array<S>;
+  export function indexed<T>(
+    pred: PredIndexed<T, boolean>,
+  ): (data: ReadonlyArray<T>) => boolean;
+  export function indexed(): unknown {
+    return purry(_every(true), arguments);
+  }
+}

--- a/src/every.ts
+++ b/src/every.ts
@@ -1,6 +1,3 @@
-// TODO: Fix ESlint issues
-/* eslint-disable jsdoc/require-example */
-/* eslint-disable jsdoc/require-description */
 import type {
   Pred,
   PredIndexed,
@@ -11,32 +8,64 @@ import type {
 import { purry } from "./purry";
 
 /**
+ * Checks if every element of `data` passed the predicate `predicate`.
+ *
  * @param data - The Array to check.
- * @param pred - A predicate function to run.
+ * @param predicate - A predicate function to run.
  * @returns A `boolean` indicating if every element in `data` passes the predicate `pred`.
+ * @signature
+ *    R.every(arr, predicate)
+ * @example
+ *    R.every([1, 2, 3], R.isNumber) // => true
+ *    R.every(['a', 0, 'b'], R.isString) // => false
  * @dataFirst
+ * @indexed
+ * @pipeable
  * @category Array
  */
 export function every<T, S extends T>(
   data: ReadonlyArray<T>,
-  pred: TypePred<T, S>,
+  predicate: TypePred<T, S>,
 ): data is Array<S>;
 export function every<T>(
   data: ReadonlyArray<T>,
-  pred: Pred<T, boolean>,
+  predicate: Pred<T, boolean>,
 ): boolean;
 
 /**
- * @param pred - A predicate function to run.
+ * Checks if every element of `data` passed the predicate `predicate`.
+ *
+ * NOTE: If you want to use this inside `conditional` predicates and preserve proper type inference,
+ * make sure to define the final type guard outside of the pipe. This is due to Typescript's limitation
+ * in generic type inference. See examples below for details.
+ *
+ * @param predicate - A predicate function to run.
+ * @returns A `boolean` indicating if every element in `data` passes the predicate `pred`.
+ * @signature
+ *    R.every(predicate)(data)
+ * @example
+ *    R.every(isNumber)([1, 2, 3]) // => true
+ *    R.every(isString)(['a', 0, 'b']) // => false
+ * @example
+ *    // using `R.every` as a type predicate within `conditional`
+ *    const allNumbers = R.every(R.isNumber);
+ *    const result = R.pipe(
+ *      R.conditional(
+ *        [allNumbers, val => {...}]
+ *                  // ^? number[]
+ *        ...
+ *      )
+ *    )
  * @dataLast
+ * @indexed
+ * @pipeable
  * @category Array
  */
 export function every<T, S extends T>(
-  pred: TypePred<T, S>,
+  predicate: TypePred<T, S>,
 ): (data: ReadonlyArray<T>) => data is Array<S>;
 export function every<T>(
-  // pred: Pred<T, boolean>,
-  pred: (input: T) => boolean,
+  predicate: (input: T) => boolean,
 ): (data: ReadonlyArray<T>) => boolean;
 
 export function every(): unknown {
@@ -45,25 +74,25 @@ export function every(): unknown {
 
 const _every =
   (indexed: boolean) =>
-  <T>(data: ReadonlyArray<T>, pred: PredIndexedOptional<T, boolean>) =>
+  <T>(data: ReadonlyArray<T>, predicate: PredIndexedOptional<T, boolean>) =>
     indexed
-      ? data.every((element, index, array) => pred(element, index, array))
-      : data.every((element) => pred(element));
+      ? data.every((element, index, array) => predicate(element, index, array))
+      : data.every((element) => predicate(element));
 
 export namespace every {
   export function indexed<T, S extends T>(
     data: ReadonlyArray<T>,
-    pred: TypePredIndexed<T, S>,
+    predicate: TypePredIndexed<T, S>,
   ): data is Array<S>;
   export function indexed<T>(
     data: ReadonlyArray<T>,
-    pred: PredIndexed<T, boolean>,
+    predicate: PredIndexed<T, boolean>,
   ): boolean;
   export function indexed<T, S extends T>(
-    pred: TypePredIndexed<T, S>,
+    predicate: TypePredIndexed<T, S>,
   ): (data: ReadonlyArray<T>) => data is Array<S>;
   export function indexed<T>(
-    pred: PredIndexed<T, boolean>,
+    predicate: PredIndexed<T, boolean>,
   ): (data: ReadonlyArray<T>) => boolean;
   export function indexed(): unknown {
     return purry(_every(true), arguments);

--- a/src/every.ts
+++ b/src/every.ts
@@ -1,11 +1,4 @@
-import type { PredIndexed } from "./_types";
 import { purry } from "./purry";
-
-type TypePredIndexed<T, S extends T> = (
-  input: T,
-  index: number,
-  array: ReadonlyArray<T>,
-) => input is S;
 
 /**
  * Checks if every element of `data` passed the predicate `predicate`.
@@ -24,11 +17,11 @@ type TypePredIndexed<T, S extends T> = (
  */
 export function every<T, S extends T>(
   data: ReadonlyArray<T>,
-  predicate: TypePredIndexed<T, S>,
+  predicate: (input: T, index: number, array: ReadonlyArray<T>) => input is S,
 ): data is Array<S>;
 export function every<T>(
   data: ReadonlyArray<T>,
-  predicate: PredIndexed<T, boolean>,
+  predicate: (input: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): boolean;
 
 /**
@@ -46,10 +39,10 @@ export function every<T>(
  * @category Array
  */
 export function every<T, S extends T>(
-  predicate: TypePredIndexed<T, S>,
+  predicate: (input: T, index: number, array: ReadonlyArray<T>) => input is S,
 ): (data: ReadonlyArray<T>) => data is Array<S>;
 export function every<T>(
-  predicate: PredIndexed<T, boolean>,
+  predicate: (input: T, index: number, array: ReadonlyArray<T>) => boolean,
 ): (data: ReadonlyArray<T>) => boolean;
 
 export function every(): unknown {
@@ -58,6 +51,6 @@ export function every(): unknown {
 
 const everyImplementation = <T>(
   data: ReadonlyArray<T>,
-  predicate: PredIndexed<T, boolean>,
-): boolean =>
-  data.every((element, index, array) => predicate(element, index, array));
+  predicate: (input: T, index: number, array: ReadonlyArray<T>) => boolean,
+  // eslint-disable-next-line unicorn/no-array-callback-reference
+): boolean => data.every(predicate);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from "./dropLastWhile";
 export * from "./dropWhile";
 export * from "./entries";
 export * from "./equals";
+export * from "./every";
 export * from "./evolve";
 export * from "./filter";
 export * from "./find";


### PR DESCRIPTION
Following up on conversation in https://github.com/remeda/remeda/issues/624, I started with implementing `every`.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
