### PR TITLE
docs(card): fix card header overflow

### DIFF
--- a/docs/src/components/function-card.astro
+++ b/docs/src/components/function-card.astro
@@ -19,7 +19,7 @@ const { func } = Astro.props;
 
 <Card id={func.name} className="scroll-mt-20">
   <CardHeader>
-    <div class="flex items-center gap-2">
+    <div class="sm:flex sm:items-center sm:gap-2">
       <CardTitle className="text-2xl">{func.name}</CardTitle>
 
       <Badge className="ml-auto bg-primary text-primary-foreground">


### PR DESCRIPTION
<details><summary>Added media query for card header to fix content overflow</summary>
While reading docs on my iPhone I've noticed that the menu at the top of the page is shorter than the page itself.
This happens due to overflow of `<CardHeader />`. When there is 3 tags and the github badge then whole row goes wider then the screen.

So I added media query for screens that is wider than `sm` breakpoint.

<img width="702" alt="Screenshot of the bug" src="https://github.com/remeda/remeda/assets/25722706/6e8d0952-acd6-45ea-9ccd-d77c10f611a7">
<img width="684" alt="Screenshot with the fix applied" src="https://github.com/remeda/remeda/assets/25722706/0bacf382-ba88-4b05-9843-e5ef642b042c">

</details>
