### PR TITLE
fix(isDeepEqual): wrong dataLast types

### DIFF
--- a/src/isDeepEqual.test.ts
+++ b/src/isDeepEqual.test.ts
@@ -1,3 +1,4 @@
+import { differenceWith } from "./differenceWith";
 import { isDeepEqual } from "./isDeepEqual";
 
 function func1(): void {
@@ -373,5 +374,15 @@ describe("typing", () => {
     } else {
       expectTypeOf(data1).toEqualTypeOf<{ a: number }>();
     }
+  });
+
+  it("headless usage can infer types", () => {
+    // Tests the issue reported in: https://github.com/remeda/remeda/issues/641
+    const result = differenceWith(
+      ["a", "b", "c"],
+      ["a", "c", "d"],
+      isDeepEqual,
+    );
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
   });
 });

--- a/src/isDeepEqual.ts
+++ b/src/isDeepEqual.ts
@@ -55,10 +55,10 @@ export function isDeepEqual<T, S extends T = T>(data: T, other: S): boolean;
  * @dataLast
  * @category Guard
  */
-export function isDeepEqual<T, S extends T>(other: S): (data: T) => data is S;
-export function isDeepEqual<T, S extends T = T>(
+export function isDeepEqual<T, S extends T>(
   other: T extends Exclude<T, S> ? S : never,
-): (data: T) => boolean;
+): (data: T) => data is S;
+export function isDeepEqual<S>(other: S): <T extends S = S>(data: T) => boolean;
 
 export function isDeepEqual(): unknown {
   return purry(isDeepEqualImplementation, arguments);


### PR DESCRIPTION
There was a bug with the typing in the dataLast version that slipped through our testing. It prevented headless usage as an equality checker for functions like differenceWith.