### PR TITLE
fix(`take`): Improve `take` typings for tuples

### DIFF
--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -4,6 +4,14 @@ describe("data_first", () => {
   it("take", () => {
     expect(take([1, 2, 3, 4, 3, 2, 1] as const, 3)).toEqual([1, 2, 3]);
   });
+
+  it("returns the whole array if N is greater than length", () => {
+    expect(take([1, 2, 3] as const, 10)).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array if N is negative", () => {
+    expect(take([1, 2, 3] as const, -1)).toEqual([]);
+  });
 });
 
 describe("data_last", () => {
@@ -14,8 +22,19 @@ describe("data_last", () => {
 
 describe("typings", () => {
   it("infers tuple types properly", () => {
-    const result = take([1, 2, "foo", "bar"] as const, 3);
+    const valid = take([1, 2, "foo", "bar"] as const, 3);
+    expectTypeOf(valid).toEqualTypeOf<[1, 2, "foo"]>();
 
-    expectTypeOf(result).toEqualTypeOf<[1, 2, "foo"]>();
+    const negative = take([1, 2, 3] as const, -1);
+    expectTypeOf(negative).toEqualTypeOf<[]>();
+
+    const greater = take([1, 2, 3] as const, 10);
+    expectTypeOf(greater).toEqualTypeOf<[1, 2, 3]>();
+
+    const unknown = take([1, 2, 3], 2);
+    expectTypeOf(unknown).toEqualTypeOf<Array<number>>();
+
+    const dataLast = take(3)([1, 2, 3, 4, 5] as const);
+    expectTypeOf(dataLast).toEqualTypeOf<[1, 2, 3]>();
   });
 });

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -1,3 +1,4 @@
+import { pipe } from "./pipe";
 import { take } from "./take";
 
 describe("data_first", () => {
@@ -33,8 +34,12 @@ describe("typings", () => {
 
     const unknown = take([1, 2, 3], 2);
     expectTypeOf(unknown).toEqualTypeOf<Array<number>>();
+  });
 
-    const dataLast = take(3)([1, 2, 3, 4, 5] as const);
-    expectTypeOf(dataLast).toEqualTypeOf<[1, 2, 3]>();
+  it("infers types in pipe", () => {
+    const input = [1, 2, 3, 4] as const;
+    const result = pipe(input, take(2));
+
+    expectTypeOf(result).toEqualTypeOf<[1, 2]>();
   });
 });

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -11,3 +11,11 @@ describe("data_last", () => {
     expect(take(3)([1, 2, 3, 4, 3, 2, 1] as const)).toEqual([1, 2, 3]);
   });
 });
+
+describe("typings", () => {
+  it("infers tuple types properly", () => {
+    const result = take([1, 2, "foo", "bar"] as const, 3);
+
+    expectTypeOf(result).toEqualTypeOf<[1, 2, "foo"]>();
+  });
+});

--- a/src/take.ts
+++ b/src/take.ts
@@ -2,6 +2,21 @@ import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
+type TakeAcc<
+  T extends Array<unknown>,
+  N extends number,
+  Acc extends Array<unknown> = T,
+> = `${N}` extends `-${number}`
+  ? []
+  : Acc["length"] extends N
+    ? Acc
+    : // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Acc extends [...infer Head, infer _Tail]
+      ? TakeAcc<T, N, Head>
+      : T;
+
+type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
+
 /**
  * Returns the first `n` elements of `array`.
  *
@@ -15,7 +30,10 @@ import { purry } from "./purry";
  * @pipeable
  * @category Array
  */
-export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
+export function take<T extends Array<unknown>, N extends number>(
+  array: T,
+  n: N,
+): Take<T, N>;
 
 /**
  * Returns the first `n` elements of `array`.
@@ -29,13 +47,18 @@ export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
  * @pipeable
  * @category Array
  */
-export function take<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
+export function take<N extends number>(
+  n: N,
+): <T extends Array<unknown>>(array: T) => Take<T, N>;
 
 export function take(): unknown {
   return purry(_take, arguments, take.lazy);
 }
 
-function _take<T>(array: ReadonlyArray<T>, n: number): Array<T> {
+function _take<T extends Array<unknown>, N extends number>(
+  array: T,
+  n: N,
+): unknown {
   return _reduceLazy(array, take.lazy(n));
 }
 

--- a/src/take.ts
+++ b/src/take.ts
@@ -2,20 +2,24 @@ import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
 type TakeAcc<
-  T extends Array<unknown>,
+  T extends ReadonlyArray<unknown>,
   N extends number,
-  Acc extends Array<unknown> = T,
+  Acc extends ReadonlyArray<unknown> = T,
 > = `${N}` extends `-${number}`
   ? []
   : Acc["length"] extends N
     ? Acc
     : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      Acc extends [...infer Head, infer _Tail]
+      Acc extends readonly [...infer Head, infer _Tail]
       ? TakeAcc<T, N, Head>
-      : T;
+      : Mutable<T>;
 
-type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
+type Take<T extends ReadonlyArray<unknown>, N extends number> = TakeAcc<T, N>;
 
 /**
  * Returns the first `n` elements of `array`.
@@ -30,7 +34,7 @@ type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
  * @pipeable
  * @category Array
  */
-export function take<T extends Array<unknown>, N extends number>(
+export function take<T extends ReadonlyArray<unknown>, N extends number>(
   array: T,
   n: N,
 ): Take<T, N>;
@@ -47,15 +51,15 @@ export function take<T extends Array<unknown>, N extends number>(
  * @pipeable
  * @category Array
  */
-export function take<N extends number>(
+export function take<T extends ReadonlyArray<unknown>, N extends number>(
   n: N,
-): <T extends Array<unknown>>(array: T) => Take<T, N>;
+): (array: T) => Take<T, N>;
 
 export function take(): unknown {
   return purry(_take, arguments, take.lazy);
 }
 
-function _take<T extends Array<unknown>, N extends number>(
+function _take<T extends ReadonlyArray<unknown>, N extends number>(
   array: T,
   n: N,
 ): unknown {


### PR DESCRIPTION
Continuing in the spirit of https://github.com/remeda/remeda/pull/623, here are proper types for readonly tuples for `last`.

I _did try_ copying over `ArraySlice` from `type-fest` but
- it added _a lot_ of dependent types and
- it immediately crashed on infinite type instantiation anyway

I think this type should be safe for all cases of the existing implementation and much more performant.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
