### PR TITLE
fix(v2): Improve `take` typings for tuples

### DIFF
--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -26,24 +26,137 @@ describe("data_last", () => {
 });
 
 describe("typings", () => {
-  it("infers tuple types properly", () => {
-    const valid = take([1, 2, "foo", "bar"] as const, 3);
-    expectTypeOf(valid).toEqualTypeOf<[1, 2, "foo"]>();
+  it("handles strict tuples", () => {
+    const strict = ["1", 2, true] as [string, number, boolean];
+    expectTypeOf(take(strict, 2)).toEqualTypeOf<[string, number]>();
 
-    const negative = take([1, 2, 3] as const, -1);
-    expectTypeOf(negative).toEqualTypeOf<[]>();
+    const strictReadonly = ["1", 2, true] as readonly [string, number, boolean];
+    expectTypeOf(take(strictReadonly, 2)).toEqualTypeOf<[string, number]>();
+  });
 
-    const greater = take([1, 2, 3] as const, 10);
-    expectTypeOf(greater).toEqualTypeOf<[1, 2, 3]>();
+  it("handles literal unions", () => {
+    const unions = ["cat", "mouse"] as ["cat" | "dog", "mouse" | "chicken"];
+    expectTypeOf(take(unions, 1)).toEqualTypeOf<["cat" | "dog"]>();
 
-    const unknown = take([1, 2, 3], 2);
-    expectTypeOf(unknown).toEqualTypeOf<Array<number>>();
+    const unionsReadonly = ["cat", "mouse"] as readonly [
+      "cat" | "dog",
+      "mouse" | "chicken",
+    ];
+    expectTypeOf(take(unionsReadonly, 1)).toEqualTypeOf<["cat" | "dog"]>();
+  });
+
+  it("handles rest tails", () => {
+    const restTail = ["1", 2, 3] as [string, ...Array<number>];
+    expectTypeOf(take(restTail, 1)).toEqualTypeOf<[string]>();
+    expectTypeOf(take(restTail, 2)).toEqualTypeOf<[string, ...Array<number>]>();
+
+    const restTailReadonly = ["1", 2, 3] as readonly [string, ...Array<number>];
+    expectTypeOf(take(restTailReadonly, 1)).toEqualTypeOf<[string]>();
+    expectTypeOf(take(restTailReadonly, 2)).toEqualTypeOf<
+      [string, ...Array<number>]
+    >();
+  });
+
+  it("handles rest heads", () => {
+    const restHead = [1, 2, 3, "foo"] as [...Array<number>, string];
+    expectTypeOf(take(restHead, 3)).toEqualTypeOf<[...Array<number>, string]>();
+
+    const restHeadReadonly = [1, 2, 3, "foo"] as readonly [
+      ...Array<number>,
+      string,
+    ];
+    expectTypeOf(take(restHeadReadonly, 3)).toEqualTypeOf<
+      [...Array<number>, string]
+    >();
+  });
+
+  it("handles a mix of unions and rest params", () => {
+    const mix = ["cat", 123, 123, 456] as ["cat" | "dog", ...Array<123 | 456>];
+    expectTypeOf(take(mix, 1)).toEqualTypeOf<["cat" | "dog"]>();
+    expectTypeOf(take(mix, 3)).toEqualTypeOf<
+      ["cat" | "dog", ...Array<123 | 456>]
+    >();
+
+    const mixReadonly = ["cat", 123, 123, 456] as readonly [
+      "cat" | "dog",
+      ...Array<123 | 456>,
+    ];
+    expectTypeOf(take(mixReadonly, 1)).toEqualTypeOf<["cat" | "dog"]>();
+    expectTypeOf(take(mixReadonly, 3)).toEqualTypeOf<
+      ["cat" | "dog", ...Array<123 | 456>]
+    >();
+  });
+
+  it("handles N greater than tuple length", () => {
+    const short = ["foo"] as [string];
+    expectTypeOf(take(short, 10)).toEqualTypeOf<[string]>();
+
+    const shortReadonly = ["foo"] as readonly [string];
+    expectTypeOf(take(shortReadonly, 10)).toEqualTypeOf<[string]>();
+  });
+
+  it("handles shorter heads", () => {
+    const shortHead = [1, "foo", true, false] as [
+      number,
+      string,
+      ...Array<boolean>,
+    ];
+    expectTypeOf(take(shortHead, 3)).toEqualTypeOf<
+      [number, string, ...Array<boolean>]
+    >();
+
+    const shortHeadReadonly = [1, "foo", true, false] as readonly [
+      number,
+      string,
+      ...Array<boolean>,
+    ];
+    expectTypeOf(take(shortHeadReadonly, 3)).toEqualTypeOf<
+      [number, string, ...Array<boolean>]
+    >();
+  });
+
+  it("handles longer heads", () => {
+    const longHead = [1, "foo", true, "foo", "bar"] as [
+      number,
+      string,
+      boolean,
+      ...Array<string>,
+    ];
+
+    expectTypeOf(take(longHead, 2)).toEqualTypeOf<[number, string]>();
+    expectTypeOf(take(longHead, 6)).toEqualTypeOf<
+      [number, string, boolean, ...Array<string>]
+    >();
+
+    const longHeadReadonly = [1, "foo", true, "foo", "bar"] as readonly [
+      number,
+      string,
+      boolean,
+      ...Array<string>,
+    ];
+
+    expectTypeOf(take(longHeadReadonly, 2)).toEqualTypeOf<[number, string]>();
+    expectTypeOf(take(longHeadReadonly, 6)).toEqualTypeOf<
+      [number, string, boolean, ...Array<string>]
+    >();
+
+    it("handles regular arrays", () => {
+      const input = [1, 2, 3];
+      expectTypeOf(take(input, 1)).toEqualTypeOf<Array<number>>();
+      expectTypeOf(take(input, -1)).toEqualTypeOf<[]>();
+      expectTypeOf(take(input, 10)).toEqualTypeOf<Array<number>>();
+    });
   });
 
   it("infers types in pipe", () => {
-    const input = [1, 2, 3, 4] as const;
+    const input = [1, 2, 3, 4] as [1, 2, 3, 4];
     const result = pipe(input, take(2));
 
     expectTypeOf(result).toEqualTypeOf<[1, 2]>();
+
+    const inputReadonly = [1, 2, 3, 4] as readonly [1, 2, 3, 4];
+    const resultReadonly = pipe(inputReadonly, take(2));
+
+    expectTypeOf(resultReadonly).toEqualTypeOf<[1, 2]>();
   });
 });

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -5,6 +5,14 @@ describe("data_first", () => {
   it("take", () => {
     expect(take([1, 2, 3, 4, 3, 2, 1], 3)).toEqual([1, 2, 3]);
   });
+
+  it("returns the whole array if N is greater than length", () => {
+    expect(take([1, 2, 3] as const, 10)).toEqual([1, 2, 3]);
+  });
+
+  it("returns an empty array if N is negative", () => {
+    expect(take([1, 2, 3] as const, -1)).toEqual([]);
+  });
 });
 
 describe("data_last", () => {
@@ -19,8 +27,19 @@ describe("data_last", () => {
 
 describe("typings", () => {
   it("infers tuple types properly", () => {
-    const result = take([1, 2, "foo", "bar"] as const, 3);
+    const valid = take([1, 2, "foo", "bar"] as const, 3);
+    expectTypeOf(valid).toEqualTypeOf<[1, 2, "foo"]>();
 
-    expectTypeOf(result).toEqualTypeOf<[1, 2, "foo"]>();
+    const negative = take([1, 2, 3] as const, -1);
+    expectTypeOf(negative).toEqualTypeOf<[]>();
+
+    const greater = take([1, 2, 3] as const, 10);
+    expectTypeOf(greater).toEqualTypeOf<[1, 2, 3]>();
+
+    const unknown = take([1, 2, 3], 2);
+    expectTypeOf(unknown).toEqualTypeOf<Array<number>>();
+
+    const dataLast = take(3)([1, 2, 3, 4, 5] as const);
+    expectTypeOf(dataLast).toEqualTypeOf<[1, 2, 3]>();
   });
 });

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -139,13 +139,13 @@ describe("typings", () => {
     expectTypeOf(take(longHeadReadonly, 6)).toEqualTypeOf<
       [number, string, boolean, ...Array<string>]
     >();
+  });
 
-    it("handles regular arrays", () => {
-      const input = [1, 2, 3];
-      expectTypeOf(take(input, 1)).toEqualTypeOf<Array<number>>();
-      expectTypeOf(take(input, -1)).toEqualTypeOf<[]>();
-      expectTypeOf(take(input, 10)).toEqualTypeOf<Array<number>>();
-    });
+  it("handles regular arrays", () => {
+    const input = [1, 2, 3];
+    expectTypeOf(take(input, 1)).toEqualTypeOf<Array<number>>();
+    expectTypeOf(take(input, -1)).toEqualTypeOf<[]>();
+    expectTypeOf(take(input, 10)).toEqualTypeOf<Array<number>>();
   });
 
   it("infers types in pipe", () => {

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -38,8 +38,12 @@ describe("typings", () => {
 
     const unknown = take([1, 2, 3], 2);
     expectTypeOf(unknown).toEqualTypeOf<Array<number>>();
+  });
 
-    const dataLast = take(3)([1, 2, 3, 4, 5] as const);
-    expectTypeOf(dataLast).toEqualTypeOf<[1, 2, 3]>();
+  it("infers types in pipe", () => {
+    const input = [1, 2, 3, 4] as const;
+    const result = pipe(input, take(2));
+
+    expectTypeOf(result).toEqualTypeOf<[1, 2]>();
   });
 });

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -16,3 +16,11 @@ describe("data_last", () => {
     expect(pipe([1, 2, 3, 4, 3, 2, 1], take(0))).toEqual([]);
   });
 });
+
+describe("typings", () => {
+  it("infers tuple types properly", () => {
+    const result = take([1, 2, "foo", "bar"] as const, 3);
+
+    expectTypeOf(result).toEqualTypeOf<[1, 2, "foo"]>();
+  });
+});

--- a/src/take.ts
+++ b/src/take.ts
@@ -2,6 +2,21 @@ import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
+type TakeAcc<
+  T extends Array<unknown>,
+  N extends number,
+  Acc extends Array<unknown> = T,
+> = `${N}` extends `-${number}`
+  ? []
+  : Acc["length"] extends N
+    ? Acc
+    : // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Acc extends [...infer Head, infer _Tail]
+      ? TakeAcc<T, N, Head>
+      : T;
+
+type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
+
 /**
  * Returns the first `n` elements of `array`.
  *
@@ -15,7 +30,10 @@ import { purry } from "./purry";
  * @pipeable
  * @category Array
  */
-export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
+export function take<T extends Array<unknown>, N extends number>(
+  array: T,
+  n: N,
+): Take<T, N>;
 
 /**
  * Returns the first `n` elements of `array`.
@@ -29,14 +47,18 @@ export function take<T>(array: ReadonlyArray<T>, n: number): Array<T>;
  * @pipeable
  * @category Array
  */
-export function take<T>(n: number): (array: ReadonlyArray<T>) => Array<T>;
+export function take<N extends number>(
+  n: N,
+): <T extends Array<unknown>>(array: T) => Take<T, N>;
 
 export function take(...args: ReadonlyArray<unknown>): unknown {
   return purry(takeImplementation, args, lazyImplementation);
 }
 
-const takeImplementation = <T>(array: ReadonlyArray<T>, n: number): Array<T> =>
-  _reduceLazy(array, lazyImplementation(n));
+const takeImplementation = <T extends Array<unknown>, N extends number>(
+  array: T,
+  n: N,
+): unknown => _reduceLazy(array, lazyImplementation(n));
 
 function lazyImplementation<T>(n: number): LazyEvaluator<T> {
   if (n <= 0) {

--- a/src/take.ts
+++ b/src/take.ts
@@ -1,4 +1,3 @@
-import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
@@ -57,7 +56,7 @@ export function take(...args: ReadonlyArray<unknown>): unknown {
 const takeImplementation = <T extends ReadonlyArray<unknown>, N extends number>(
   array: T,
   n: N,
-): unknown => _reduceLazy(array, lazyImplementation(n));
+): unknown => (n < 0 ? [] : array.slice(0, n));
 
 function lazyImplementation<T>(n: number): LazyEvaluator<T> {
   if (n <= 0) {

--- a/src/take.ts
+++ b/src/take.ts
@@ -2,20 +2,24 @@ import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
 type TakeAcc<
-  T extends Array<unknown>,
+  T extends ReadonlyArray<unknown>,
   N extends number,
-  Acc extends Array<unknown> = T,
+  Acc extends ReadonlyArray<unknown> = T,
 > = `${N}` extends `-${number}`
   ? []
   : Acc["length"] extends N
     ? Acc
     : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      Acc extends [...infer Head, infer _Tail]
+      Acc extends readonly [...infer Head, infer _Tail]
       ? TakeAcc<T, N, Head>
-      : T;
+      : Mutable<T>;
 
-type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
+type Take<T extends ReadonlyArray<unknown>, N extends number> = TakeAcc<T, N>;
 
 /**
  * Returns the first `n` elements of `array`.
@@ -30,7 +34,7 @@ type Take<T extends Array<unknown>, N extends number> = TakeAcc<T, N>;
  * @pipeable
  * @category Array
  */
-export function take<T extends Array<unknown>, N extends number>(
+export function take<T extends ReadonlyArray<unknown>, N extends number>(
   array: T,
   n: N,
 ): Take<T, N>;
@@ -47,15 +51,15 @@ export function take<T extends Array<unknown>, N extends number>(
  * @pipeable
  * @category Array
  */
-export function take<N extends number>(
+export function take<T extends ReadonlyArray<unknown>, N extends number>(
   n: N,
-): <T extends Array<unknown>>(array: T) => Take<T, N>;
+): (array: T) => Take<T, N>;
 
 export function take(...args: ReadonlyArray<unknown>): unknown {
   return purry(takeImplementation, args, lazyImplementation);
 }
 
-const takeImplementation = <T extends Array<unknown>, N extends number>(
+const takeImplementation = <T extends ReadonlyArray<unknown>, N extends number>(
   array: T,
   n: N,
 ): unknown => _reduceLazy(array, lazyImplementation(n));

--- a/src/take.ts
+++ b/src/take.ts
@@ -2,22 +2,17 @@ import { _reduceLazy } from "./_reduceLazy";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
-type Mutable<T> = {
-  -readonly [P in keyof T]: T[P];
-};
-
 type TakeAcc<
   T extends ReadonlyArray<unknown>,
   N extends number,
-  Acc extends ReadonlyArray<unknown> = T,
+  Acc extends ReadonlyArray<unknown> = [],
 > = `${N}` extends `-${number}`
   ? []
   : Acc["length"] extends N
     ? Acc
-    : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      Acc extends readonly [...infer Head, infer _Tail]
-      ? TakeAcc<T, N, Head>
-      : Mutable<T>;
+    : T extends readonly [infer Head, ...infer Tail]
+      ? TakeAcc<Tail, N, [...Acc, Head]>
+      : [...Acc, ...T];
 
 type Take<T extends ReadonlyArray<unknown>, N extends number> = TakeAcc<T, N>;
 


### PR DESCRIPTION
Based on https://github.com/remeda/remeda/pull/647#pullrequestreview-2013028424, porting that MR into v2 and improved typing tests.

Please do let me know if there is anything else needed to merging into `beta` - I noticed pre-commit hooks failing due to a bunch of TS errors that are unrelated to my changes, so I assume that is expected for now?

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
