### PR TITLE
docs(layout): add R globally

### DIFF
--- a/docs/src/layouts/layout.astro
+++ b/docs/src/layouts/layout.astro
@@ -16,11 +16,14 @@ import "@/styles/globals.css";
     <meta name="generator" content={Astro.generator} />
     <title>Remeda</title>
     <ThemeScript />
+    <script>
+      import * as R from "remeda";
+      window.R = R;
+    </script>
   </head>
 
   <body>
     <Header />
-
     <div class="container">
       <slot />
     </div>

--- a/docs/src/layouts/layout.astro
+++ b/docs/src/layouts/layout.astro
@@ -24,6 +24,7 @@ import "@/styles/globals.css";
 
   <body>
     <Header />
+
     <div class="container">
       <slot />
     </div>

--- a/docs/src/window.d.ts
+++ b/docs/src/window.d.ts
@@ -2,6 +2,6 @@ import * as R from "remeda";
 
 declare global {
   interface Window {
-    R: readonly typeof R;
+    R: typeof R;
   }
 }

--- a/docs/src/window.d.ts
+++ b/docs/src/window.d.ts
@@ -1,0 +1,7 @@
+import * as R from "remeda";
+
+declare global {
+  interface Window {
+    R: readonly typeof R;
+  }
+}


### PR DESCRIPTION
Add r globally to docs

Fixes #661
- doesn’t work with <script type="module> but works fine with <script>

<img width="1502" alt="Capture d’écran 2024-05-05 à 16 06 55" src="https://github.com/remeda/remeda/assets/91478082/90a5cf1f-85a3-4bb0-96ec-e50369f56629">



---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
