### PR TITLE
fix(hasSubObject): incorrect type narrowing in negate condition

### DIFF
--- a/src/hasSubObject.test.ts
+++ b/src/hasSubObject.test.ts
@@ -1,19 +1,19 @@
-import { type HasSubObjectBrand, hasSubObject } from "./hasSubObject";
+import { hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 
 describe("data first", () => {
-  test("works with empty sub-object", () => {
+  it("works with empty sub-object", () => {
     expect(hasSubObject({ a: 1, b: "b", c: 3 }, {})).toBe(true);
     expect(hasSubObject({}, {})).toBe(true);
   });
 
-  test("works with primitives", () => {
+  it("works with primitives", () => {
     expect(hasSubObject({ a: 1, b: "b", c: 3 }, { a: 1, b: "b" })).toBe(true);
     expect(hasSubObject({ a: 1, b: "c", c: 3 }, { a: 1, b: "b" })).toBe(false);
     expect(hasSubObject({ a: 2, b: "b", c: 3 }, { a: 1, b: "b" })).toBe(false);
   });
 
-  test("works with deep objects", () => {
+  it("works with deep objects", () => {
     expect(hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1, c: 2 } })).toBe(
       true,
     );
@@ -22,19 +22,19 @@ describe("data first", () => {
     );
   });
 
-  test("checks for matching key", () => {
+  it("checks for matching key", () => {
     const data = {} as { a?: undefined };
     expect(hasSubObject(data, { a: undefined })).toBe(false);
   });
 });
 
 describe("data last", () => {
-  test("empty sub-object", () => {
+  it("works with empty sub-object", () => {
     expect(pipe({ a: 1, b: 2, c: 3 }, hasSubObject({}))).toBe(true);
     expect(pipe({}, hasSubObject({}))).toBe(true);
   });
 
-  test("works with primitives", () => {
+  it("works with primitives", () => {
     expect(pipe({ a: 1, b: "b", c: 3 }, hasSubObject({ a: 1, b: "b" }))).toBe(
       true,
     );
@@ -46,7 +46,7 @@ describe("data last", () => {
     );
   });
 
-  test("works with deep objects", () => {
+  it("works with deep objects", () => {
     expect(
       pipe({ a: { b: 1, c: 2 } }, hasSubObject({ a: { b: 1, c: 2 } })),
     ).toBe(true);
@@ -59,7 +59,7 @@ describe("data last", () => {
 
 describe("typing", () => {
   describe("data-first", () => {
-    test("must have matching keys and values", () => {
+    it("must have matching keys and values", () => {
       expectTypeOf(hasSubObject({ a: 2 }, { a: 1 })).toEqualTypeOf<boolean>();
 
       // @ts-expect-error [ts2353] - missing a key
@@ -81,7 +81,7 @@ describe("typing", () => {
       hasSubObject({ a: 2 }, { a: 1 } as const);
     });
 
-    test("allows nested objects", () => {
+    it("allows nested objects", () => {
       // ok - nested object has extra keys
       hasSubObject({ a: { b: 4 } }, { a: { b: 1, c: 2 } });
 
@@ -92,45 +92,49 @@ describe("typing", () => {
       hasSubObject({ a: { b: 4, c: "c" } }, { a: { b: 1, c: 2 } });
     });
 
-    test("narrows type", () => {
+    it("narrows with empty object", () => {
       const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, {})) {
-        expectTypeOf(obj).toEqualTypeOf<
-          HasSubObjectBrand & { a?: string; b?: number }
-        >();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       } else {
-        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       }
+    });
+
+    it("narrows with same object", () => {
+      const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, obj)) {
-        expectTypeOf(obj).toEqualTypeOf<
-          HasSubObjectBrand & { a?: string; b?: number }
-        >();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       } else {
-        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       }
+    });
+
+    it("narrows optional field to required", () => {
+      const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, { a: "a" })) {
-        expectTypeOf(obj).toEqualTypeOf<
-          HasSubObjectBrand & { a: string; b?: number }
-        >();
+        expectTypeOf(obj).toMatchTypeOf<{ a: string; b?: number }>();
       } else {
-        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       }
+    });
+
+    it("narrows field to constant type", () => {
+      const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, { a: "a" } as const)) {
-        expectTypeOf(obj).toEqualTypeOf<
-          HasSubObjectBrand & { readonly a: "a"; b?: number }
-        >();
+        expectTypeOf(obj).toMatchTypeOf<{ readonly a: "a"; b?: number }>();
       } else {
-        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
       }
     });
   });
 
   describe("data-last", () => {
-    test("must have matching keys and values", () => {
+    it("must have matching keys and values", () => {
       expectTypeOf(
         pipe({ a: 2 }, hasSubObject({ a: 1 })),
       ).toEqualTypeOf<boolean>();
@@ -154,7 +158,7 @@ describe("typing", () => {
       pipe({ a: 2 }, hasSubObject({ a: 1 } as const));
     });
 
-    test("allows nested objects", () => {
+    it("allows nested objects", () => {
       // ok - nested object has extra keys
       pipe({ a: { b: 4 } }, hasSubObject({ a: { b: 1, c: 2 } }));
 

--- a/src/hasSubObject.test.ts
+++ b/src/hasSubObject.test.ts
@@ -1,4 +1,4 @@
-import { hasSubObject } from "./hasSubObject";
+import { type HasSubObjectBrand, hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 
 describe("data first", () => {
@@ -96,15 +96,35 @@ describe("typing", () => {
       const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, {})) {
+        expectTypeOf(obj).toEqualTypeOf<
+          HasSubObjectBrand & { a?: string; b?: number }
+        >();
+      } else {
+        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
+      }
+
+      if (hasSubObject(obj, obj)) {
+        expectTypeOf(obj).toEqualTypeOf<
+          HasSubObjectBrand & { a?: string; b?: number }
+        >();
+      } else {
         expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
       }
 
       if (hasSubObject(obj, { a: "a" })) {
-        expectTypeOf(obj).toEqualTypeOf<{ a: string; b?: number }>();
+        expectTypeOf(obj).toEqualTypeOf<
+          HasSubObjectBrand & { a: string; b?: number }
+        >();
+      } else {
+        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
       }
 
       if (hasSubObject(obj, { a: "a" } as const)) {
-        expectTypeOf(obj).toEqualTypeOf<{ a: "a"; b?: number }>();
+        expectTypeOf(obj).toEqualTypeOf<
+          HasSubObjectBrand & { readonly a: "a"; b?: number }
+        >();
+      } else {
+        expectTypeOf(obj).toEqualTypeOf<{ a?: string; b?: number }>();
       }
     });
   });

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -1,6 +1,8 @@
-import type { Simplify } from "type-fest";
+import type { Merge } from "type-fest";
 import { isDeepEqual } from "./isDeepEqual";
 import { purry } from "./purry";
+
+export type HasSubObjectBrand = { __remeda: "hasSubObject" };
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
@@ -19,10 +21,9 @@ import { purry } from "./purry";
  * @category Guard
  */
 export function hasSubObject<T, S extends Partial<T>>(
-  data: T,
+  data: Merge<T, S> | T,
   subObject: S,
-): // TODO: want to use data is Merge<T, S> here, but it's a typescript error. fix after we allow @ts-expect-error in the build process
-data is Simplify<S & T>;
+): data is HasSubObjectBrand & Merge<T, S>;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
@@ -41,16 +42,16 @@ data is Simplify<S & T>;
  */
 export function hasSubObject<T, S extends Partial<T>>(
   subObject: S,
-): (data: T) => data is Simplify<S & T>;
+): (data: Merge<T, S> | T) => data is HasSubObjectBrand & Merge<T, S>;
 
 export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
   return purry(hasSubObjectImplementation, args);
 }
 
 function hasSubObjectImplementation<T extends object, S extends Partial<T>>(
-  data: T,
+  data: Merge<T, S> | T,
   subObject: S,
-): data is Simplify<S & T> {
+): data is HasSubObjectBrand & Merge<T, S> {
   for (const [key, value] of Object.entries(subObject)) {
     if (!Object.hasOwn(data, key)) {
       return false;

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -1,8 +1,9 @@
 import type { Merge } from "type-fest";
+import type { Brand } from "./internal/types";
 import { isDeepEqual } from "./isDeepEqual";
 import { purry } from "./purry";
 
-export type HasSubObjectBrand = { __remeda: "hasSubObject" };
+export type HasSubObjectBrand = Brand<"hasSubObject">;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -1,11 +1,14 @@
 import type { Merge } from "type-fest";
-import type { Brand } from "./internal/types";
+import type { Branded } from "./internal/types";
 import { isDeepEqual } from "./isDeepEqual";
 import { purry } from "./purry";
 
-declare const hasSubObjectBrandId: unique symbol;
+declare const HAS_SUB_OBJECT_BRAND: unique symbol;
 
-export type HasSubObjectBrand = Brand<typeof hasSubObjectBrandId>;
+type HasSubObjectGuard<T, S> = Branded<
+  Merge<T, S>,
+  typeof HAS_SUB_OBJECT_BRAND
+>;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
@@ -26,7 +29,7 @@ export type HasSubObjectBrand = Brand<typeof hasSubObjectBrandId>;
 export function hasSubObject<T, S extends Partial<T>>(
   data: Merge<T, S> | T,
   subObject: S,
-): data is HasSubObjectBrand & Merge<T, S>;
+): data is HasSubObjectGuard<T, S>;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
@@ -45,7 +48,7 @@ export function hasSubObject<T, S extends Partial<T>>(
  */
 export function hasSubObject<T, S extends Partial<T>>(
   subObject: S,
-): (data: Merge<T, S> | T) => data is HasSubObjectBrand & Merge<T, S>;
+): (data: Merge<T, S> | T) => data is HasSubObjectGuard<T, S>;
 
 export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
   return purry(hasSubObjectImplementation, args);
@@ -54,7 +57,7 @@ export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
 function hasSubObjectImplementation<T extends object, S extends Partial<T>>(
   data: Merge<T, S> | T,
   subObject: S,
-): data is HasSubObjectBrand & Merge<T, S> {
+): data is HasSubObjectGuard<T, S> {
   for (const [key, value] of Object.entries(subObject)) {
     if (!Object.hasOwn(data, key)) {
       return false;

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -3,7 +3,9 @@ import type { Brand } from "./internal/types";
 import { isDeepEqual } from "./isDeepEqual";
 import { purry } from "./purry";
 
-export type HasSubObjectBrand = Brand<"hasSubObject">;
+declare const hasSubObjectBrandId: unique symbol;
+
+export type HasSubObjectBrand = Brand<typeof hasSubObjectBrandId>;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -2,7 +2,7 @@ import type { IsAny, IsNever } from "type-fest";
 
 declare const __brand: unique symbol;
 
-export type Brand<T> = { [__brand]: T };
+export type Branded<T, Brand extends symbol> = T & { [__brand]: Brand };
 
 export type NonEmptyArray<T> = [T, ...Array<T>];
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,9 @@
 import type { IsAny, IsNever } from "type-fest";
 
+declare const __brand: unique symbol;
+
+export type Brand<T> = { [__brand]: T };
+
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
 export type Mapped<T extends IterableContainer, K> = {


### PR DESCRIPTION
Fixes: #678

The only way I come up to fix the issue with the negate condition in case when the guard resolves to the same type as `data` is by using something that will make the guard always different from `data`. One solution can be by using a brand type. Brand type is an internal type that doesn't affect anything but can help us identify the type result better. The users of the library can safely ignore that brand type.

This is the first occurrence of a brand type so let me know if I need to change its format/naming, etc.

Next, in a separate PR, I'm going to try to improve the overall typing of `hasSubObject` to make the narrowing more smarter. I already did some progress but stuck on making it work well with `pipe` function.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>