### PR TITLE
build(v2): Switch CI to use main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
-      - beta
+      - main
   pull_request:
 
 jobs:
@@ -127,7 +126,7 @@ jobs:
       - typecheck-source
       - typecheck-outputs
       - test
-    if: github.repository == 'remeda/remeda' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta')
+    if: github.repository == 'remeda/remeda' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,7 +2,8 @@ name: Codecov
 
 on:
   push:
-    branches: [master, beta]
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The first "data-first" and "data-last" utility library designed especially for TypeScript.
 
-![GitHub CI](https://img.shields.io/github/actions/workflow/status/remeda/remeda/ci.yml?branch=beta&label=github-ci)
-[![Codecov](https://img.shields.io/codecov/c/github/remeda/remeda/beta)](https://codecov.io/gh/remeda/remeda)
+![GitHub CI](https://img.shields.io/github/actions/workflow/status/remeda/remeda/ci.yml?branch=main&label=github-ci)
+[![Codecov](https://img.shields.io/codecov/c/github/remeda/remeda/main)](https://codecov.io/gh/remeda/remeda)
 [![NPM](https://img.shields.io/npm/v/remeda)](https://www.npmjs.org/package/remeda)
 ![Dependencies](https://img.shields.io/librariesio/release/npm/remeda)
 
@@ -15,12 +15,12 @@ Migrating from Lodash or Ramda? Check the function mapping on [remedajs.com/mapp
 
 ## Features
 
-* First-class TypeScript support, with types that are as specific as possible. 
-* Supports data-first (`R.filter(array, fn)`) and data-last (`R.filter(fn)(array)`) approaches.
-* Lazy evaluation support with `pipe` and `piped`.
-* Runtime and types are both extensively tested, with full code coverage.
-* Tree-shakable, supports CJS and ESM.
-* Fully documented with JSDoc, supports in-editor function documentation.
+- First-class TypeScript support, with types that are as specific as possible.
+- Supports data-first (`R.filter(array, fn)`) and data-last (`R.filter(fn)(array)`) approaches.
+- Lazy evaluation support with `pipe` and `piped`.
+- Runtime and types are both extensively tested, with full code coverage.
+- Tree-shakable, supports CJS and ESM.
+- Fully documented with JSDoc, supports in-editor function documentation.
 
 ## Getting started
 

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -10,5 +10,5 @@
   },
 
   "excludeNotDocumented": true,
-  "sourceLinkTemplate": "https://github.com/remeda/remeda/blob/master/{path}"
+  "sourceLinkTemplate": "https://github.com/remeda/remeda/blob/main/{path}"
 }


### PR DESCRIPTION
main has been checked out from the 'beta' branch so now represents the HEAD for v2 and remeda in general.

This PR makes the CI treat main as a valid branch for releases. by making it breaking it would de-facto release v2.

BREAKING CHANGE: Releases Remeda v2.