### PR TITLE
feat(hasSubObject): improve typing

### DIFF
--- a/src/hasSubObject.test.ts
+++ b/src/hasSubObject.test.ts
@@ -62,34 +62,96 @@ describe("typing", () => {
     it("must have matching keys and values", () => {
       expectTypeOf(hasSubObject({ a: 2 }, { a: 1 })).toEqualTypeOf<boolean>();
 
-      // @ts-expect-error [ts2353] - missing a key
+      // ok
+      hasSubObject({ a: 1, b: 2 }, { b: 2 });
+
+      // @ts-expect-error [ts2322] - non-matching key
       hasSubObject({ b: 2 }, { a: 1 });
+
+      // @ts-expect-error [ts2322] - non-matching key
+      hasSubObject({ b: 2 }, { b: 2, a: 1 });
 
       // @ts-expect-error [ts2322] - different value type
       hasSubObject({ a: "a" }, { a: 1 });
 
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: "a" }, { a: { b: 2 } });
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: 2 } }, { a: "a" });
+
       // ok - wider value type
-      hasSubObject({ a: "a" } as { a: number | string }, { a: 1 });
+      hasSubObject({ a: "a" as number | string }, { a: 1 });
 
-      // @ts-expect-error [ts2345] - narrower value type
-      hasSubObject({ a: "a" }, { a: 1 } as { a: number | string });
+      // ok - wider value type
+      hasSubObject({ a: "a" }, { a: 1 as number | string });
 
-      // ok - unknown data type
+      // ok - wider value type
+      hasSubObject({ a: "a" as number | string }, { a: 1 as boolean | number });
+
+      // @ts-expect-error [ts2345] - only allow valid objects to be passed
       hasSubObject({ a: 2 } as unknown, { a: 1 });
 
       // ok - const value
-      hasSubObject({ a: 2 }, { a: 1 } as const);
+      hasSubObject({ a: 2, b: 2 }, { a: 1 } as const);
     });
 
     it("allows nested objects", () => {
-      // ok - nested object has extra keys
-      hasSubObject({ a: { b: 4 } }, { a: { b: 1, c: 2 } });
-
-      // @ts-expect-error [ts2741] - nested object has missing keys
+      // @ts-expect-error [ts2322] - nested sub-object has missing keys
       hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1 } });
 
-      // @ts-expect-error [ts2322] - nested object has wrong value types
+      // @ts-expect-error [ts2379] - nested sub-object has missing keys
+      hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1 } } as {
+        a?: { b: number };
+      });
+
+      // @ts-expect-error [ts2322] - nested sub-object has extra keys
+      hasSubObject({ a: { b: 1 } }, { a: { b: 1, c: 2 } });
+
+      hasSubObject({ a: { b: 1 } } as { a?: { b: number } }, {
+        // @ts-expect-error ts[2322] - nested sub-object has extra keys
+        a: { b: 1, c: 2 },
+      });
+
+      // @ts-expect-error [ts2322] - nested sub-object has wrong value types
       hasSubObject({ a: { b: 4, c: "c" } }, { a: { b: 1, c: 2 } });
+
+      // @ts-expect-error [ts2322] - deep-nested sub-object has wrong value types
+      hasSubObject({ a: { b: { c: 2 } } }, { a: { b: { c: "2" } } });
+
+      // ok
+      hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1, c: 2 } });
+
+      // ok - deep-nested sub-object
+      hasSubObject({ a: { b: { c: 2 } } }, { a: { b: { c: 2 } } });
+
+      // ok
+      hasSubObject({ a: { b: 1 } }, {
+        a: { b: 1 },
+      } as { a?: { b?: number } });
+
+      // ok
+      hasSubObject({ a: { b: 1 } } as { a?: { b?: number } }, {
+        a: { b: 1 },
+      });
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: "a" } }, { a: { b: { c: 2 } } });
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: { c: 2 } } }, { a: { b: "a" } });
+
+      // ok - nested object wider value type
+      hasSubObject({ a: { b: 1 as number | string } }, { a: { b: 1 } });
+
+      // ok - nested sub-object wider value type
+      hasSubObject({ a: { b: 1 } }, { a: { b: 1 as number | string } });
+
+      // ok - nested object and sub-object wider value type
+      hasSubObject(
+        { a: { b: 1 as boolean | number } },
+        { a: { b: 1 as number | string } },
+      );
     });
 
     it("narrows with empty object", () => {
@@ -126,9 +188,93 @@ describe("typing", () => {
       const obj = {} as { a?: string; b?: number };
 
       if (hasSubObject(obj, { a: "a" } as const)) {
-        expectTypeOf(obj).toMatchTypeOf<{ readonly a: "a"; b?: number }>();
+        expectTypeOf(obj).toMatchTypeOf<{ a: "a"; b?: number }>();
       } else {
         expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      }
+    });
+
+    it("narrows with sub-object union type field", () => {
+      const obj: { a?: string; b?: number; c?: boolean } = {};
+
+      if (hasSubObject(obj, { c: true as boolean | number })) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c: boolean;
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: boolean;
+        }>();
+      }
+    });
+
+    it("narrows union types", () => {
+      const obj: { a?: string; b?: number; c?: number | string } = {};
+
+      if (hasSubObject(obj, { c: true } as { c?: boolean | number })) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: number;
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: number | string;
+        }>();
+      }
+    });
+
+    it("narrows nested fields with sub-object union types", () => {
+      const obj = {
+        a: { foo: "test", bar: true },
+        b: { foo: "test", bar: true },
+      };
+
+      if (
+        hasSubObject(obj, {
+          a: { foo: 12 as number | string, bar: true },
+          b: { foo: "test", bar: true as boolean | number },
+        })
+      ) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: string; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: string; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      }
+    });
+
+    it("narrows nested fields with union types", () => {
+      const obj = {
+        a: { foo: "test" as number | string, bar: true },
+        b: { foo: "test", bar: true as boolean | number },
+      };
+
+      if (
+        hasSubObject(obj, {
+          a: { foo: 12, bar: true },
+          b: { foo: "test", bar: true },
+        })
+      ) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: number; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: number | string; bar: boolean };
+          b: { foo: string; bar: boolean | number };
+        }>();
       }
     });
   });
@@ -139,34 +285,273 @@ describe("typing", () => {
         pipe({ a: 2 }, hasSubObject({ a: 1 })),
       ).toEqualTypeOf<boolean>();
 
-      // @ts-expect-error [ts2353] - missing a key
+      // @ts-expect-error [ts2353] - non-matching key
+      hasSubObject({ a: 1 })({ b: 2 });
+      // @ts-expect-error [ts2345] - non-matching key
       pipe({ b: 2 }, hasSubObject({ a: 1 }));
 
+      // @ts-expect-error [ts2353] - non-matching key
+      hasSubObject({ b: 2, a: 1 })({ b: 2 });
+      // @ts-expect-error [ts2345] - non-matching key
+      pipe({ b: 2 }, hasSubObject({ b: 2, a: 1 }));
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: 1 })({ a: "a" });
       // @ts-expect-error [ts2345] - different value type
       pipe({ a: "a" }, hasSubObject({ a: 1 }));
 
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: 2 } })({ a: "a" });
+      // @ts-expect-error [ts2345] - different value type
+      pipe({ a: "a" }, hasSubObject({ a: { b: 2 } }));
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: "a" })({ a: { b: 2 } });
+      // @ts-expect-error [ts2345] - different value type
+      pipe({ a: { b: 2 } }, hasSubObject({ a: "a" }));
+
       // ok - wider value type
-      pipe({ a: "a" } as { a: number | string }, hasSubObject({ a: 1 }));
+      hasSubObject({ a: 1 })({ a: "a" as number | string });
+      pipe({ a: "a" as number | string }, hasSubObject({ a: 1 }));
 
-      // @ts-expect-error [ts2345] - narrower value type
-      pipe({ a: "a" }, hasSubObject({ a: 1 } as { a: number | string }));
+      // ok - wider value type
+      hasSubObject({ a: 1 as number | string })({ a: "a" });
+      pipe({ a: "a" }, hasSubObject({ a: 1 as number | string }));
 
-      // ok - unknown data type
+      // ok - wider value type
+      hasSubObject({ a: 1 as boolean | number })({
+        a: "a" as number | string,
+      });
+      pipe(
+        { a: "a" as number | string },
+        hasSubObject({ a: 1 as boolean | number }),
+      );
+
+      // @ts-expect-error [ts2345] - only allow valid objects to be passed
+      hasSubObject({ a: 1 })({ a: 2 } as unknown);
+      // @ts-expect-error [ts2345] - only allow valid objects to be passed
       pipe({ a: 2 } as unknown, hasSubObject({ a: 1 }));
 
       // ok - const value
-      pipe({ a: 2 }, hasSubObject({ a: 1 } as const));
+      hasSubObject({ a: 1 } as const)({ a: 2, b: 2 });
+      pipe({ a: 2, b: 2 }, hasSubObject({ a: 1 } as const));
     });
 
     it("allows nested objects", () => {
-      // ok - nested object has extra keys
-      pipe({ a: { b: 4 } }, hasSubObject({ a: { b: 1, c: 2 } }));
-
-      // @ts-expect-error [ts2345] - nested object has missing keys
+      // @ts-expect-error [ts2322] - nested sub-object has missing keys
+      hasSubObject({ a: { b: 1 } })({ a: { b: 1, c: 2 } });
+      // @ts-expect-error [ts2345] - nested sub-object has missing keys
       pipe({ a: { b: 1, c: 2 } }, hasSubObject({ a: { b: 1 } }));
 
-      // @ts-expect-error [ts2345] - nested object has wrong value types
+      hasSubObject({ a: { b: 1 } } as { a?: { b: number } })({
+        // @ts-expect-error [ts2322] - nested sub-object has missing keys
+        a: { b: 1, c: 2 },
+      });
+      pipe(
+        { a: { b: 1, c: 2 } },
+        // @ts-expect-error [ts2345] - nested sub-object has missing keys
+        hasSubObject({ a: { b: 1 } } as { a?: { b: number } }),
+      );
+
+      // @ts-expect-error [ts2322] - nested sub-object has extra keys
+      hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 1 } });
+      // @ts-expect-error [ts2345] - nested sub-object has extra keys
+      pipe({ a: { b: 1 } }, hasSubObject({ a: { b: 1, c: 2 } }));
+
+      // @ts-expect-error [ts2379] - nested sub-object has extra keys
+      hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 1 } } as {
+        a?: { b: number };
+      });
+      pipe(
+        { a: { b: 1 } } as { a?: { b: number } },
+        // @ts-expect-error [ts2345] - nested sub-object has extra keys
+        hasSubObject({ a: { b: 1, c: 2 } }),
+      );
+
+      // @ts-expect-error [ts2322] - nested sub-object has wrong value types
+      hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 4, c: "c" } });
+      // @ts-expect-error [ts2345] - nested sub-object has wrong value types
       pipe({ a: { b: 4, c: "c" } }, hasSubObject({ a: { b: 1, c: 2 } }));
+
+      // @ts-expect-error [ts2322] - deep-nested sub-object has wrong value types
+      hasSubObject({ a: { b: { c: "2" } } })({ a: { b: { c: 2 } } });
+      // @ts-expect-error [ts2345] - deep-nested sub-object has wrong value types
+      pipe({ a: { b: { c: 2 } } }, hasSubObject({ a: { b: { c: "2" } } }));
+
+      // ok
+      hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 1, c: 2 } });
+      pipe({ a: { b: 1, c: 2 } }, hasSubObject({ a: { b: 1, c: 2 } }));
+
+      // ok - deep-nested sub-object
+      hasSubObject({ a: { b: { c: 2 } } })({ a: { b: { c: 2 } } });
+      pipe({ a: { b: { c: 2 } } }, hasSubObject({ a: { b: { c: 2 } } }));
+
+      // ok
+      hasSubObject({ a: { b: 1 } } as { a?: { b?: number } })({ a: { b: 1 } });
+      pipe(
+        { a: { b: 1 } },
+        hasSubObject({ a: { b: 1 } } as { a?: { b?: number } }),
+      );
+
+      // ok
+      hasSubObject({ a: { b: 1 } })({ a: { b: 1 } } as { a?: { b?: number } });
+      pipe(
+        { a: { b: 1 } } as { a?: { b?: number } },
+        hasSubObject({ a: { b: 1 } }),
+      );
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: { c: 2 } } })({ a: { b: "a" } });
+      // @ts-expect-error [ts2345] - different value type
+      pipe({ a: { b: "a" } }, hasSubObject({ a: { b: { c: 2 } } }));
+
+      // @ts-expect-error [ts2322] - different value type
+      hasSubObject({ a: { b: "a" } })({ a: { b: { c: 2 } } });
+      // @ts-expect-error [ts2345] - different value type
+      pipe({ a: { b: { c: 2 } } }, hasSubObject({ a: { b: "a" } }));
+
+      // ok - nested object wider value type
+      hasSubObject({ a: { b: 1 } })({ a: { b: 1 as number | string } });
+      pipe({ a: { b: 1 as number | string } }, hasSubObject({ a: { b: 1 } }));
+
+      // ok - nested sub-object wider value type
+      hasSubObject({ a: { b: 1 as number | string } })({ a: { b: 1 } });
+      pipe({ a: { b: 1 } }, hasSubObject({ a: { b: 1 as number | string } }));
+
+      // ok - nested object and sub-object wider value type
+      hasSubObject({
+        a: { b: 1 as number | string },
+      })({
+        a: { b: 1 as boolean | number },
+      });
+      pipe(
+        { a: { b: 1 as boolean | number } },
+        hasSubObject({ a: { b: 1 as number | string } }),
+      );
+    });
+
+    it("narrows with empty object", () => {
+      const obj = {} as { a?: string; b?: number };
+
+      if (hasSubObject({})(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      }
+    });
+
+    it("narrows with same object", () => {
+      const obj = {} as { a?: string; b?: number };
+
+      if (hasSubObject(obj)(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      }
+    });
+
+    it("narrows optional field to required", () => {
+      const obj = {} as { a?: string; b?: number };
+
+      if (hasSubObject({ a: "a" })(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{ a: string; b?: number }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      }
+    });
+
+    it("narrows field to constant type", () => {
+      const obj = {} as { a?: string; b?: number };
+
+      if (hasSubObject({ a: "a" } as const)(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{ a: "a"; b?: number }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{ a?: string; b?: number }>();
+      }
+    });
+
+    it("narrows with sub-object union type field", () => {
+      const obj: { a?: string; b?: number; c?: boolean } = {};
+
+      if (hasSubObject({ c: true as boolean | number })(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c: boolean;
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: boolean;
+        }>();
+      }
+    });
+
+    it("narrows union types", () => {
+      const obj: { a?: string; b?: number; c?: number | string } = {};
+
+      if (hasSubObject({ c: true } as { c?: boolean | number })(obj)) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: number;
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a?: string;
+          b?: number;
+          c?: number | string;
+        }>();
+      }
+    });
+
+    it("narrows nested fields with sub-object union types", () => {
+      const obj = {
+        a: { foo: "test", bar: true },
+        b: { foo: "test", bar: true },
+      };
+
+      if (
+        hasSubObject({
+          a: { foo: 12 as number | string, bar: true },
+          b: { foo: "test", bar: true as boolean | number },
+        })(obj)
+      ) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: string; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: string; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      }
+    });
+
+    it("narrows nested fields with union types", () => {
+      const obj = {
+        a: { foo: "test" as number | string, bar: true },
+        b: { foo: "test", bar: true as boolean | number },
+      };
+
+      if (
+        hasSubObject({
+          a: { foo: 12, bar: true },
+          b: { foo: "test", bar: true },
+        })(obj)
+      ) {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: number; bar: boolean };
+          b: { foo: string; bar: boolean };
+        }>();
+      } else {
+        expectTypeOf(obj).toMatchTypeOf<{
+          a: { foo: number | string; bar: boolean };
+          b: { foo: string; bar: boolean | number };
+        }>();
+      }
     });
   });
 });

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -76,7 +76,7 @@ type HasSubObjectSubObject<
  * @category Guard
  */
 export function hasSubObject<
-  T extends Record<string, unknown>,
+  T extends Record<PropertyKey, unknown>,
   S extends HasSubObjectSubObject<S, T>,
 >(data: T, subObject: S): data is HasSubObjectGuard<T, S>;
 
@@ -95,7 +95,7 @@ export function hasSubObject<
  * @dataLast
  * @category Guard
  */
-export function hasSubObject<S extends Record<string, unknown>>(
+export function hasSubObject<S extends Record<PropertyKey, unknown>>(
   subObject: S,
 ): <T extends HasSubObjectData<T, S>>(
   data: T,
@@ -106,8 +106,8 @@ export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
 }
 
 function hasSubObjectImplementation<
-  T extends Record<string, unknown>,
-  S extends Record<string, unknown>,
+  T extends Record<PropertyKey, unknown>,
+  S extends Record<PropertyKey, unknown>,
 >(data: T, subObject: S): data is HasSubObjectGuard<T, S> {
   for (const [key, value] of Object.entries(subObject)) {
     if (!Object.hasOwn(data, key)) {

--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -9,6 +9,56 @@ type HasSubObjectGuard<T, S> = Simplify<
   Branded<S & T, typeof HAS_SUB_OBJECT_BRAND>
 >;
 
+type HasSubObjectObjectValue<A, B> = Partial<{
+  [Key in keyof A & keyof B]: A[Key] & B[Key] extends never
+    ? B[Key]
+    : A[Key] | B[Key] extends object
+      ? HasSubObjectObjectValue<A[Key], B[Key]>
+      : A[Key] & B[Key] extends object
+        ? B[Key]
+        : A[Key];
+}> & {
+  [Key in
+    | Exclude<keyof A, keyof B>
+    | Exclude<keyof B, keyof A>]: Key extends keyof B ? B[Key] : never;
+};
+
+type HasSubObjectData<
+  Data,
+  SubObject,
+  RData = Required<Data>,
+  RSubObject = Required<SubObject>,
+> = Partial<{
+  [Key in keyof RData & keyof RSubObject]: RData[Key] &
+    RSubObject[Key] extends never
+    ? RSubObject[Key]
+    : RData[Key] | RSubObject[Key] extends object
+      ? HasSubObjectObjectValue<RData[Key], RSubObject[Key]>
+      : RData[Key] & RSubObject[Key] extends object
+        ? RSubObject[Key]
+        : RData[Key];
+}> & {
+  [Key in Exclude<keyof SubObject, keyof Data>]: SubObject[Key];
+};
+
+type HasSubObjectSubObject<
+  SubObject,
+  Data,
+  RSubObject = Required<SubObject>,
+  RData = Required<Data>,
+> = Partial<{
+  [Key in keyof RData & keyof RSubObject]: RData[Key] &
+    RSubObject[Key] extends never
+    ? RData[Key]
+    : RData[Key] | RSubObject[Key] extends object
+      ? HasSubObjectObjectValue<RSubObject[Key], RData[Key]>
+      : RData[Key] & RSubObject[Key] extends object
+        ? RData[Key]
+        : RSubObject[Key];
+}> & {
+  [Key in Exclude<keyof SubObject, keyof Data>]: never;
+};
+
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
  * property and value in `subObject`, there's the same property in `object`
@@ -25,10 +75,10 @@ type HasSubObjectGuard<T, S> = Simplify<
  * @dataFirst
  * @category Guard
  */
-export function hasSubObject<T, S extends Partial<T>>(
-  data: T,
-  subObject: S,
-): data is HasSubObjectGuard<T, S>;
+export function hasSubObject<
+  T extends Record<string, unknown>,
+  S extends HasSubObjectSubObject<S, T>,
+>(data: T, subObject: S): data is HasSubObjectGuard<T, S>;
 
 /**
  * Checks if `subObject` is a sub-object of `object`, which means for every
@@ -45,32 +95,29 @@ export function hasSubObject<T, S extends Partial<T>>(
  * @dataLast
  * @category Guard
  */
-export function hasSubObject<T, S extends Partial<T>>(
+export function hasSubObject<S extends Record<string, unknown>>(
   subObject: S,
-): (data: T) => data is HasSubObjectGuard<T, S>;
+): <T extends HasSubObjectData<T, S>>(
+  data: T,
+) => data is HasSubObjectGuard<T, S>;
 
 export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
   return purry(hasSubObjectImplementation, args);
 }
 
-function hasSubObjectImplementation<T extends object, S extends Partial<T>>(
-  data: T,
-  subObject: S,
-): data is HasSubObjectGuard<T, S> {
+function hasSubObjectImplementation<
+  T extends Record<string, unknown>,
+  S extends Record<string, unknown>,
+>(data: T, subObject: S): data is HasSubObjectGuard<T, S> {
   for (const [key, value] of Object.entries(subObject)) {
     if (!Object.hasOwn(data, key)) {
       return false;
     }
 
-    if (
-      !isDeepEqual(
-        value,
-        // @ts-expect-error [ts7053] - We already checked that `data` has `key
-        data[key],
-      )
-    ) {
+    if (!isDeepEqual(value, data[key])) {
       return false;
     }
   }
+
   return true;
 }


### PR DESCRIPTION
> This PR depends on https://github.com/remeda/remeda/pull/683. See 35afa2fee17aa0fe16af3d467c18b22fabe23a44 for changes.

**Depends on:** https://github.com/remeda/remeda/pull/683

- make type narrowing smarter
- handle cases with overlapping union types (e.g. `{ a: string | number}, { a: number | boolean }`)
- improve typing for nested objects

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
