### PR TITLE
docs: Fix mobile view

### DIFF
--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -19,9 +19,11 @@ const navbarEntries = await getNavbarEntries(
 ---
 
 <header
-  class="sticky top-0 z-50 flex h-16 flex-none items-center gap-2 bg-background/95 px-4 shadow backdrop-blur supports-[backdrop-filter]:bg-background/60 sm:px-8"
+  class="sticky top-0 z-50 flex h-16 flex-none items-center bg-background/95 px-3 shadow backdrop-blur supports-[backdrop-filter]:bg-background/60 sm:px-8"
 >
-  <nav class="flex flex-1 items-center gap-4 text-xs sm:gap-8 sm:text-base">
+  <nav
+    class="flex flex-1 items-center gap-3 overflow-hidden text-xs sm:gap-8 sm:text-base"
+  >
     <a href="/" class="font-bold">Remeda</a>
     <NavLink href="/docs" additionalHrefs={["/v1"]}>Documentation</NavLink>
     <NavLink href="/mapping">Lodash/Ramda</NavLink>

--- a/docs/src/components/nav-link.astro
+++ b/docs/src/components/nav-link.astro
@@ -15,7 +15,7 @@ const isActive = [href, ...additionalHrefs].some((path) => path === trimmed);
 <a
   href={href}
   class:list={[
-    "transition-colors hover:text-foreground/80",
+    "truncate transition-colors hover:text-foreground/80",
     isActive ? "font-semibold text-primary" : "text-foreground/60",
   ]}
 >

--- a/docs/src/layouts/docs-page.astro
+++ b/docs/src/layouts/docs-page.astro
@@ -48,7 +48,7 @@ const { pathname } = Astro.url;
         <VersionSelector pathname={pathname} client:load /></Navbar
       >
     </aside>
-    <main class="flex-1 space-y-8">
+    <main class="flex-1 space-y-8 overflow-hidden">
       {
         renderedCollection.map(({ slug, rendered: { Content } }) => (
           <Prose id={slug} class="scroll-mt-24">

--- a/docs/src/layouts/wiki.astro
+++ b/docs/src/layouts/wiki.astro
@@ -4,7 +4,7 @@ import BaseLayout from "./base.astro";
 ---
 
 <BaseLayout>
-  <main class="p-6">
+  <main class="overflow-hidden p-6">
     <Prose class="container max-w-4xl">
       <slot />
     </Prose>


### PR DESCRIPTION
When viewed on mobile the docs page extends beyond the "frame", skewing the layout.

Merging into `master` until we can get the deployment fixed.