### PR TITLE
docs: Update .map example in docs home page

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -57,7 +57,7 @@ expected.
 ```ts
 const DATA = [1, 2, 3] as const;
 
-const builtin = DATA.map(DATA, (x) => x.toString());
+const builtin = DATA.map((x) => x.toString());
 //    ^? string[]
 
 const withRemeda = R.map(DATA, (x) => x.toString());


### PR DESCRIPTION
Fixes Array .map example in docs home page to use valid js

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/pages/mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
