### PR TITLE
chore(codecov): Add secret to action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,3 +26,5 @@ jobs:
 
       - name: 🗺️ Upload coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Following the guide from codecov:

https://docs.codecov.com/docs/adding-the-codecov-token#github-actions