### PR TITLE
fix(pickBy,omitBy): Don't partialize simple records

### DIFF
--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -187,6 +187,27 @@ describe("typing", () => {
       optionalNullish?: string;
     }>();
   });
+
+  // @see https://github.com/remeda/remeda/issues/696
+  describe("Records with non-narrowing predicates (Issue #696)", () => {
+    test("string keys", () => {
+      const data = {} as Record<string, string>;
+      const result = omitBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf(data);
+    });
+
+    test("number keys", () => {
+      const data = {} as Record<number, string>;
+      const result = omitBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf<Record<`${number}`, string>>();
+    });
+
+    test("combined numbers and strings", () => {
+      const data = {} as Record<number | string, string>;
+      const result = omitBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf<Record<string, string>>();
+    });
+  });
 });
 
 const isUndefined = <T>(value: T | undefined): value is undefined =>

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -2,6 +2,8 @@ import { type IfNever, type Simplify } from "type-fest";
 import {
   type EnumerableStringKeyOf,
   type EnumerableStringKeyedValueOf,
+  type IfSimpleRecord,
+  type ReconstructedRecord,
 } from "./internal/types";
 import { purry } from "./purry";
 
@@ -18,9 +20,13 @@ type PickSymbolKeys<T extends object> = {
 // filtered out. This means that we effectively make all (enumerable) keys
 // optional.
 type PartialEnumerableKeys<T extends object> = Simplify<
-  PickSymbolKeys<T> & {
-    -readonly [P in keyof T as P extends symbol ? never : P]?: Required<T>[P];
-  }
+  IfSimpleRecord<
+    T,
+    ReconstructedRecord<T>,
+    PickSymbolKeys<T> & {
+      -readonly [P in keyof T as P extends symbol ? never : P]?: Required<T>[P];
+    }
+  >
 >;
 
 // When the predicate is a type-guard we have more information to work with when

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -162,4 +162,25 @@ describe("typing", () => {
       optionalNullish?: string;
     }>();
   });
+
+  // @see https://github.com/remeda/remeda/issues/696
+  describe("Records with non-narrowing predicates (Issue #696)", () => {
+    test("string keys", () => {
+      const data = {} as Record<string, string>;
+      const result = pickBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf(data);
+    });
+
+    test("number keys", () => {
+      const data = {} as Record<number, string>;
+      const result = pickBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf<Record<`${number}`, string>>();
+    });
+
+    test("combined numbers and strings", () => {
+      const data = {} as Record<number | string, string>;
+      const result = pickBy(data, constant(true));
+      expectTypeOf(result).toEqualTypeOf<Record<string, string>>();
+    });
+  });
 });

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -2,6 +2,8 @@ import { type IfNever, type Simplify } from "type-fest";
 import {
   type EnumerableStringKeyOf,
   type EnumerableStringKeyedValueOf,
+  type IfSimpleRecord,
+  type ReconstructedRecord,
 } from "./internal/types";
 import { purry } from "./purry";
 
@@ -13,9 +15,15 @@ type EnumerableKey<T> = `${T extends number | string ? T : never}`;
 // When the predicate isn't a type-guard we don't know which properties would be
 // part of the output and which wouldn't so we can only safely downgrade the
 // whole object to a Partial of the input.
-type EnumeratedPartial<T> = Simplify<{
-  -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
-}>;
+type EnumeratedPartial<T> = Simplify<
+  IfSimpleRecord<
+    T,
+    ReconstructedRecord<T>,
+    {
+      -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
+    }
+  >
+>;
 
 // When the predicate is a type-guard we have more information to work with when
 // constructing the type of the output object. We can safely remove any property


### PR DESCRIPTION
Closes: #696

When making a Record/indexed-object partial `undefined` is added to the value type. This is incorrect when using exactOptionalProperties because `undefined` is not a valid value and would never show up, making the result type too wide.

By checking specifically for string and number keys (and their combination) we can rebuild the output object differently for those cases.

