### PR TITLE
test(mapValues): add tests for using branded types as record keys

### DIFF
--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -104,6 +104,23 @@ describe("typing", () => {
     });
   });
 
+  describe("branded types", () => {
+    test("should infer types correctly in the mapper", () => {
+      type Branded<K, T> = K & { _type: T };
+      type UserID = Branded<string, "UserId">;
+
+      const userValues: Record<UserID, number> = {
+        ["U1" as UserID]: 1,
+        ["U2" as UserID]: 2,
+      };
+
+      mapValues(userValues, (value, key) => {
+        expectTypeOf(value).toEqualTypeOf<number>();
+        expectTypeOf(key).toEqualTypeOf<`${UserID}`>();
+      });
+    });
+  });
+
   test("symbols are filtered out", () => {
     const mySymbol = Symbol("mySymbol");
     const result = mapValues({ [mySymbol]: 1, a: "hello" }, constant(true));


### PR DESCRIPTION
Noticed that #684 is labeled as good first issue so I gave it a try. I enhanced `mapValues` tests by adding a case for branded types used as record keys.

I would be happy to make any further adjustments as needed.

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/pages/mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
