### PR TITLE
docs(identity): Remove headless identity invocations from examples

### DIFF
--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -87,7 +87,7 @@ type DebounceOptions = {
  * @signature
  *   R.debounce(func, options);
  * @example
- *   const debouncer = debounce(identity, { timing: 'trailing', waitMs: 1000 });
+ *   const debouncer = debounce(identity(), { timing: 'trailing', waitMs: 1000 });
  *   const result1 = debouncer.call(1); // => undefined
  *   const result2 = debouncer.call(2); // => undefined
  *   // after 1 second

--- a/src/firstBy.ts
+++ b/src/firstBy.ts
@@ -26,7 +26,7 @@ type FirstBy<T extends IterableContainer> =
  * @signature
  *   R.firstBy(...rules)(data);
  * @example
- *   const max = R.pipe([1,2,3], R.firstBy([R.identity, "desc"])); // => 3;
+ *   const max = R.pipe([1,2,3], R.firstBy([R.identity(), "desc"])); // => 3;
  *   const min = R.pipe([1,2,3], R.firstBy(R.identity())); // => 1;
  *
  *   const data = [{ a: "a" }, { a: "aa" }, { a: "aaa" }] as const;
@@ -55,8 +55,8 @@ export function firstBy<T extends IterableContainer>(
  * @signature
  *   R.firstBy(data, ...rules);
  * @example
- *   const max = R.firstBy([1,2,3], [R.identity, "desc"]); // => 3;
- *   const min = R.firstBy([1,2,3], R.identity); // => 1;
+ *   const max = R.firstBy([1,2,3], [R.identity(), "desc"]); // => 3;
+ *   const min = R.firstBy([1,2,3], R.identity()); // => 1;
  *
  *   const data = [{ a: "a" }, { a: "aa" }, { a: "aaa" }] as const;
  *   const maxBy = R.firstBy(data, [(item) => item.a.length, "desc"]); // => { a: "aaa" };

--- a/src/nthBy.ts
+++ b/src/nthBy.ts
@@ -21,7 +21,7 @@ import type {
  * @signature
  *   R.nthBy(data, index, ...rules);
  * @example
- *   R.nthBy([2,1,4,5,3,], 2, identity); // => 3
+ *   R.nthBy([2,1,4,5,3,], 2, identity()); // => 3
  * @dataFirst
  * @category Array
  */
@@ -42,7 +42,7 @@ export function nthBy<T extends IterableContainer>(
  * @signature
  *   R.nthBy(index, ...rules)(data);
  * @example
- *   R.pipe([2,1,4,5,3,], R.nthBy(2, identity)); // => 3
+ *   R.pipe([2,1,4,5,3,], R.nthBy(2, identity())); // => 3
  * @dataLast
  * @category Array
  */

--- a/src/times.ts
+++ b/src/times.ts
@@ -10,7 +10,7 @@ import { purry } from "./purry";
  * @param count - A value between `0` and `n - 1`. Increments after each function call.
  * @param fn - The function to invoke. Passed one argument, the current value of `n`.
  * @returns An array containing the return values of all calls to `fn`.
- * @example times(5, identity); //=> [0, 1, 2, 3, 4]
+ * @example times(5, identity()); //=> [0, 1, 2, 3, 4]
  * @dataFirst
  */
 export function times<T>(count: number, fn: (n: number) => T): Array<T>;
@@ -24,7 +24,7 @@ export function times<T>(count: number, fn: (n: number) => T): Array<T>;
  *
  * @param fn - The function to invoke. Passed one argument, the current value of `n`.
  * @returns An array containing the return values of all calls to `fn`.
- * @example times(identity)(5); //=> [0, 1, 2, 3, 4]
+ * @example times(identity())(5); //=> [0, 1, 2, 3, 4]
  * @dataLast
  */
 export function times<T>(fn: (n: number) => T): (count: number) => Array<T>;


### PR DESCRIPTION
Headless invocation of identity has been removed. This PR makes sure that the docs are aligned with this change.

Fixes: #709 