### PR TITLE
docs(darkMode): Stop light mode flickering on load

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,6 +2,7 @@
 dist/
 build/
 src/data/data.json
+public/dist/
 
 # generated types
 .astro/
@@ -11,13 +12,6 @@ node_modules/
 
 # logs
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-
-# environment variables
-.env
-.env.production
 
 # macOS-specific files
 .DS_Store

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -25,7 +25,7 @@
         "clsx": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "remeda": "^2.0.0",
+        "remeda": "^2.0.3",
         "tailwind-merge": "^2.3.0"
       },
       "devDependencies": {
@@ -10714,9 +10714,10 @@
       }
     },
     "node_modules/remeda": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.0.0.tgz",
-      "integrity": "sha512-KBvW1gjFitqspnhSV+SLAy3g13Kj/NLb/3lLZyIIFC+D+qOYT7UnSQfNBc3+uh9KDBjFfu6lvcuV52TQhubuJg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.0.3.tgz",
+      "integrity": "sha512-3OtBvbFnhPJPNDxrP4dQ+Y7ghIErMeTy7KQ2vkC6XzrQHbFdlD0tT6mYaJ2S96lUu3umNnhkqni2lhVOdL9UOQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^4.18.2"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,11 +6,12 @@
   "author": "Łukasz Sentkiewicz",
   "type": "module",
   "scripts": {
-    "build": "astro check && astro build",
+    "build": "astro check && npm run build:scripts && astro build",
     "build:all": "npm run clean && npm run typedoc && npm run build",
     "build:debug": "npm run build && open-cli node_modules/.cache/bundleVisualizer.html",
-    "check": "npx tsc && astro check",
-    "clean": "rm -rf dist && rm -f src/data/data.json",
+    "build:scripts": "vite build --config vite.scripts.config.ts",
+    "check": "tsc && astro check",
+    "clean": "rm -rf dist && rm -f src/data/data.json && rm -rf public/dist",
     "dev": "astro dev",
     "preview": "astro preview",
     "typedoc": "typedoc --json src/data/data.json"
@@ -32,7 +33,7 @@
     "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "remeda": "^2.0.0",
+    "remeda": "^2.0.3",
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {

--- a/docs/src/layouts/base.astro
+++ b/docs/src/layouts/base.astro
@@ -14,10 +14,7 @@ import "@/styles/globals.css";
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>Remeda</title>
-    <script>
-      import { initTheme } from "@/lib/theme";
-      initTheme();
-    </script>
+    <script src="/dist/scripts/init-theme.js" is:inline></script>
   </head>
   <body class="flex w-full flex-col items-stretch">
     <Header />

--- a/docs/src/layouts/base.astro
+++ b/docs/src/layouts/base.astro
@@ -14,7 +14,7 @@ import "@/styles/globals.css";
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>Remeda</title>
-    <script src="/dist/scripts/init-theme.js" is:inline></script>
+    <script is:inline src="/dist/scripts/init-theme.js"></script>
   </head>
   <body class="flex w-full flex-col items-stretch">
     <Header />

--- a/docs/src/scripts/README.md
+++ b/docs/src/scripts/README.md
@@ -1,17 +1,17 @@
 # Warning!
 
 The scripts in this folder are not bundled into our main project! Instead, they
-are build in a pre-processing step **before** astro builds the project. They are
+are built in a pre-processing step **before** astro builds the project. They are
 then used in our project as static imports so they can run **before** the page
 is loaded.
 
 The scripts are built via vite (see `vite.scripts.config.ts`) into the
-`public/scripts` folder.
+`public/dist/scripts` folder.
 
 ### Example
 
 ```html
-<script is:inline src="/scripts/<__SCRIPT_NAME__>.js"></script>
+<script is:inline src="/dist/scripts/<__SCRIPT_NAME__>.js"></script>
 ```
 
-**The need for this mechanism is very rare!**
+**This mechanism is rarely needed!**

--- a/docs/src/scripts/README.md
+++ b/docs/src/scripts/README.md
@@ -1,0 +1,17 @@
+# Warning!
+
+The scripts in this folder are not bundled into our main project! Instead, they
+are build in a pre-processing step **before** astro builds the project. They are
+then used in our project as static imports so they can run **before** the page
+is loaded.
+
+The scripts are built via vite (see `vite.scripts.config.ts`) into the
+`public/scripts` folder.
+
+### Example
+
+```html
+<script is:inline src="/scripts/<__SCRIPT_NAME__>.js"></script>
+```
+
+**The need for this mechanism is very rare!**

--- a/docs/src/scripts/init-theme.ts
+++ b/docs/src/scripts/init-theme.ts
@@ -1,0 +1,2 @@
+import { initTheme } from "../lib/theme";
+initTheme();

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "astro/tsconfigs/strictest",
-  "include": ["src/**/*", ".eslintrc.cjs", "*.config.js"],
+  "include": ["src/**/*", ".eslintrc.cjs", "*.config.js", "*.config.ts"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/docs/vite.scripts.config.ts
+++ b/docs/vite.scripts.config.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { filter, pipe, pullObject } from "remeda";
+import { defineConfig, resolveConfig } from "vite";
+import astroConfig from "./astro.config.mjs";
+
+const SOURCE_DIRECTORY = "src/scripts";
+const OUTPUT_DIR = "dist/scripts";
+
+// This is not the main vite config for the astro project! It uses vite because
+// it already comes bundled with astro to build our scripts folder so they can
+// be imported and run **before page load** in our project. You would rarely
+// need this.
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: await getSourceFiles(SOURCE_DIRECTORY),
+
+      output: {
+        dir: await getPublicDirectory(OUTPUT_DIR),
+        entryFileNames: "[name].js",
+      },
+    },
+  },
+
+  // Disable the publicDir for the scripts because we aren't really building a
+  // server here and the name clash makes vite unhappy (very unhappy!).
+  publicDir: false,
+});
+
+async function getSourceFiles(directory: string): Promise<string> {
+  const sourceDir = path.resolve(import.meta.dirname, directory);
+  // @ts-expect-error [ts2322] - TODO: Our typing for pullObject (and fromKeys!) make the results Partial even for simple records!
+  return pipe(
+    await fs.readdir(sourceDir),
+    filter((fileName) => fileName.endsWith(".ts")),
+    pullObject(
+      (fileName) => path.basename(fileName, ".ts"),
+      (fileName) => path.resolve(sourceDir, fileName),
+    ),
+  );
+}
+
+/**
+ * This function ensures that even if the public directory is changed in the
+ * astro config we will still output the scripts to the correct location.
+ */
+async function getPublicDirectory(subDir: string): Promise<string> {
+  const { publicDir } = await resolveConfig(
+    astroConfig.vite ?? {},
+    "build" /* command */,
+  );
+  return path.resolve(publicDir, subDir);
+}

--- a/docs/vite.scripts.config.ts
+++ b/docs/vite.scripts.config.ts
@@ -28,7 +28,9 @@ export default defineConfig({
   publicDir: false,
 });
 
-async function getSourceFiles(directory: string): Promise<string> {
+async function getSourceFiles(
+  directory: string,
+): Promise<Record<string, string>> {
   const sourceDir = path.resolve(import.meta.dirname, directory);
   // @ts-expect-error [ts2322] - TODO: Our typing for pullObject (and fromKeys!) make the results Partial even for simple records!
   return pipe(


### PR DESCRIPTION
Our initTheme function was running after the page already rendered, causing it to flicker with lightMode no matter what mode you were on.

This is a holisitc approach to providing us a way to load scripts synchronosly wihle the page loads.