### PR TITLE
fix(set): prevent setting `undefined` on optional props

### DIFF
--- a/src/addProp.test.ts
+++ b/src/addProp.test.ts
@@ -1,16 +1,54 @@
 import { addProp } from "./addProp";
 import { pipe } from "./pipe";
 
-describe("data first", () => {
-  test("addProp", () => {
-    const actual = addProp({ a: 1 }, "b", 2);
-    expect(actual).toEqual({ a: 1, b: 2 });
+describe("runtime", () => {
+  describe("data first", () => {
+    test("simple", () => {
+      const actual = addProp({ a: 1 }, "b", 2);
+      expect(actual).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  describe("data last", () => {
+    test("simple", () => {
+      const actual = pipe({ a: 1 }, addProp("b", 2));
+      expect(actual).toEqual({ a: 1, b: 2 });
+    });
   });
 });
 
-describe("data last", () => {
-  test("addProp", () => {
-    const actual = pipe({ a: 1 }, addProp("b", 2));
-    expect(actual).toEqual({ a: 1, b: 2 });
+describe("typing", () => {
+  it("allows redefining prop types", () => {
+    const result = addProp({} as { a: string }, "a", 1);
+    expectTypeOf(result).toEqualTypeOf<{ a: number }>();
+  });
+
+  it("makes optional fields required", () => {
+    const result = addProp({} as { a?: string }, "a", "hello");
+    expectTypeOf(result).toEqualTypeOf<{ a: string }>();
+  });
+
+  it("allows setting an unknown prop", () => {
+    const result = addProp({ a: "foo" }, "b", "bar");
+    expectTypeOf(result).toEqualTypeOf<{ a: string; b: string }>();
+  });
+
+  it("sets literal unions as optional", () => {
+    const result = addProp({} as { a: string }, "b" as "b" | "c", 123);
+    expectTypeOf(result).toEqualTypeOf<{ a: string; b?: number; c?: number }>();
+  });
+
+  it("keeps the prop optional when the key isn't literal", () => {
+    const result = addProp(
+      {} as { a?: string; b?: number },
+      "a" as "a" | "b",
+      "foo" as const,
+    );
+    expectTypeOf(result).toEqualTypeOf<{ a?: string; b?: number | "foo" }>();
+  });
+
+  it("works on simple objects", () => {
+    const result = addProp({} as Record<string, string>, "a", "foo" as const);
+    expectTypeOf(result).toEqualTypeOf<{ [x: string]: string; a: "foo" }>();
   });
 });

--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -1,3 +1,4 @@
+import type { UpsertProp } from "./internal/types";
 import { purry } from "./purry";
 
 /**
@@ -19,11 +20,11 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Object
  */
-export function addProp<
-  T extends Record<PropertyKey, unknown>,
-  K extends PropertyKey,
-  V,
->(obj: T, prop: K, value: V): T & { [x in K]: V };
+export function addProp<T, K extends PropertyKey, V>(
+  obj: T,
+  prop: K,
+  value: V,
+): UpsertProp<T, K, V>;
 
 /**
  * Add a new property to an object.
@@ -43,22 +44,19 @@ export function addProp<
  * @dataLast
  * @category Object
  */
-export function addProp<
-  T extends Record<PropertyKey, unknown>,
-  K extends PropertyKey,
-  V,
->(prop: K, value: V): (obj: T) => T & { [x in K]: V };
+export function addProp<T, K extends PropertyKey, V>(
+  prop: K,
+  value: V,
+): (obj: T) => UpsertProp<T, K, V>;
 
 export function addProp(...args: ReadonlyArray<unknown>): unknown {
   return purry(addPropImplementation, args);
 }
 
-const addPropImplementation = <
-  T extends Record<PropertyKey, unknown>,
-  K extends PropertyKey,
-  V,
->(
+const addPropImplementation = <T, K extends PropertyKey, V>(
   obj: T,
   prop: K,
   value: V,
-): T & { [x in K]: V } => ({ ...obj, [prop]: value });
+): UpsertProp<T, K, V> =>
+  // @ts-expect-error [ts2322] - Hard to type...
+  ({ ...obj, [prop]: value });

--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -4,7 +4,7 @@ import { purry } from "./purry";
  * Add a new property to an object.
  *
  * The function doesn't do any checks on the input object. If the property
- * already exists it will be overridden, and the type of the new value is not
+ * already exists it will be overwritten, and the type of the new value is not
  * checked against the previous type.
  *
  * Use `set` to override values explicitly with better protections.
@@ -29,7 +29,7 @@ export function addProp<
  * Add a new property to an object.
  *
  * The function doesn't do any checks on the input object. If the property
- * already exists it will be overridden, and the type of the new value is not
+ * already exists it will be overwritten, and the type of the new value is not
  * checked against the previous type.
  *
  * Use `set` to override values explicitly with better protections.

--- a/src/addProp.ts
+++ b/src/addProp.ts
@@ -3,6 +3,12 @@ import { purry } from "./purry";
 /**
  * Add a new property to an object.
  *
+ * The function doesn't do any checks on the input object. If the property
+ * already exists it will be overridden, and the type of the new value is not
+ * checked against the previous type.
+ *
+ * Use `set` to override values explicitly with better protections.
+ *
  * @param obj - The target object.
  * @param prop - The property name.
  * @param value - The property value.
@@ -21,6 +27,12 @@ export function addProp<
 
 /**
  * Add a new property to an object.
+ *
+ * The function doesn't do any checks on the input object. If the property
+ * already exists it will be overridden, and the type of the new value is not
+ * checked against the previous type.
+ *
+ * Use `set` to override values explicitly with better protections.
  *
  * @param prop - The property name.
  * @param value - The property value.

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,4 @@
-import type { IsAny, IsNever } from "type-fest";
+import type { IsAny, IsLiteral, IsNever } from "type-fest";
 
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
@@ -107,6 +107,11 @@ export type ExactRecord<Key extends PropertyKey, Value> = IfSimpleRecord<
 export type ReorderedArray<T extends IterableContainer> = {
   -readonly [P in keyof T]: T[number];
 };
+
+// This type attempts to detect when a type is a single literal value (e.g.
+// "cat"), and not anything else (e.g. "cat" | "dog", string, etc...)
+export type IsSingleLiteral<K> =
+  IsLiteral<K> extends true ? (IsUnion<K> extends true ? false : true) : false;
 
 // TODO [2024-10-01]: This type is copied from type-fest because it isn't
 // exported. It's part of the "internal" types. We should check back in a while

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,4 @@
-import type { IsAny, IsLiteral, IsNever } from "type-fest";
+import type { IsAny, IsLiteral, IsNever, Simplify } from "type-fest";
 
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
@@ -108,9 +108,31 @@ export type ReorderedArray<T extends IterableContainer> = {
   -readonly [P in keyof T]: T[number];
 };
 
+export type UpsertProp<T, K extends PropertyKey, V> = Simplify<
+  // Copy any uninvolved props from the object, they are unaffected by the type.
+  Omit<T, K> &
+    // Rebuild the object for the rest:
+    (IsSingleLiteral<K> extends true
+      ? // If it's a single literal we need to remove the optionality and set
+        // the value as we know this prop would be exactly this value in the
+        // output.
+        { -readonly [P in K]-?: V }
+      : // The key is either a broad type (`string`) or union of literals
+        // ('cat' | 'dog') so we can't say anything for sure, we need to narrow
+        // the types of all relevant props, this has 2 parts, for props already
+        // in the object this means the value _might_ change, or it might not.
+        {
+          -readonly [P in keyof T as P extends K ? P : never]: T[P] | V;
+        } & {
+          // And for new props they might have been added to the object, or they
+          // might not have been, so we need to set them as optional.
+          -readonly [P in K as P extends keyof T ? never : P]?: V;
+        })
+>;
+
 // This type attempts to detect when a type is a single literal value (e.g.
 // "cat"), and not anything else (e.g. "cat" | "dog", string, etc...)
-export type IsSingleLiteral<K> =
+type IsSingleLiteral<K> =
   IsLiteral<K> extends true ? (IsUnion<K> extends true ? false : true) : false;
 
 // TODO [2024-10-01]: This type is copied from type-fest because it isn't

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -38,7 +38,7 @@ describe("typing", () => {
     });
   });
 
-  it("redefines the prop type", () => {
+  it("narrows the prop type", () => {
     const result = set({} as { a?: string }, "a", "hello" as const);
     expectTypeOf(result).toEqualTypeOf<{ a: "hello" }>();
   });

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -1,14 +1,59 @@
 import { pipe } from "./pipe";
 import { set } from "./set";
 
-describe("data first", () => {
-  test("set", () => {
-    expect(set({ a: 1 }, "a", 2)).toEqual({ a: 2 });
+describe("runtime", () => {
+  describe("data first", () => {
+    test("simple", () => {
+      expect(set({ a: 1 }, "a", 2)).toEqual({ a: 2 });
+    });
+  });
+
+  describe("data last", () => {
+    test("simple", () => {
+      expect(pipe({ a: 1 }, set("a", 2))).toEqual({ a: 2 });
+    });
   });
 });
 
-describe("data last", () => {
-  test("set", () => {
-    expect(pipe({ a: 1 }, set("a", 2))).toEqual({ a: 2 });
+describe("typing", () => {
+  describe("parameter enforcing", () => {
+    it("prevents setting the wrong type", () => {
+      // @ts-expect-error [ts2345] - 'number' is not assignable to 'string'.
+      set({} as { a: string }, "a", 1);
+    });
+
+    it("doesn't expand narrow types", () => {
+      // @ts-expect-error [ts2345] - 'mouse' is not assignable to 'cat' | 'dog'.
+      set({} as { a: "cat" | "dog" }, "a", "mouse");
+    });
+
+    it("prevents setting `undefined` on optional fields", () => {
+      // @ts-expect-error [ts2345] - 'a' cannot be `undefined`.
+      set({} as { a?: string }, "a", undefined);
+    });
+
+    it("prevents setting an unknown prop", () => {
+      // @ts-expect-error [ts2345] - 'b' does not exist on type '{ a: string; }'.
+      set({ a: "foo" }, "b", "bar");
+    });
+  });
+
+  it("redefines the prop type", () => {
+    const result = set({} as { a?: string }, "a", "hello" as const);
+    expectTypeOf(result).toEqualTypeOf<{ a: "hello" }>();
+  });
+
+  it("keeps the prop optional when the key isn't literal", () => {
+    const result = set(
+      {} as { a?: string; b?: number },
+      "a" as "a" | "b",
+      "foo" as const,
+    );
+    expectTypeOf(result).toEqualTypeOf<{ a?: string; b?: number | "foo" }>();
+  });
+
+  it("works on simple objects", () => {
+    const result = set({} as Record<string, string>, "a", "foo" as const);
+    expectTypeOf(result).toEqualTypeOf<{ [x: string]: string; a: "foo" }>();
   });
 });

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,17 +1,5 @@
-import type { Simplify } from "type-fest";
-import type { IsSingleLiteral } from "./internal/types";
+import type { UpsertProp } from "./internal/types";
 import { purry } from "./purry";
-
-type SetPropValue<T, K extends keyof T, V extends Required<T>[K]> = Simplify<
-  Omit<T, K> &
-    (IsSingleLiteral<K> extends true
-      ? // If it's a single literal we need to remove the optionality because it
-        // is ensured that the prop would always we set.
-        { -readonly [P in K]-?: V }
-      : // But for any other situation the prop might not be the one that was
-        // set, so we need to maintain both it's type, and it's optionality.
-        { -readonly [P in K]: T[P] | V })
->;
 
 /**
  * Sets the `value` at `prop` of `object`.
@@ -33,7 +21,7 @@ export function set<T, K extends keyof T, V extends Required<T>[K]>(
   obj: T,
   prop: K,
   value: V,
-): SetPropValue<T, K, V>;
+): UpsertProp<T, K, V>;
 
 /**
  * Sets the `value` at `prop` of `object`.
@@ -53,7 +41,7 @@ export function set<T, K extends keyof T, V extends Required<T>[K]>(
 export function set<T, K extends keyof T, V extends Required<T>[K]>(
   prop: K,
   value: V,
-): (obj: T) => SetPropValue<T, K, V>;
+): (obj: T) => UpsertProp<T, K, V>;
 
 export function set(...args: ReadonlyArray<unknown>): unknown {
   return purry(setImplementation, args);
@@ -63,4 +51,6 @@ const setImplementation = <T, K extends keyof T, V extends Required<T>[K]>(
   obj: T,
   prop: K,
   value: V,
-): SetPropValue<T, K, V> => ({ ...obj, [prop]: value });
+): UpsertProp<T, K, V> =>
+  // @ts-expect-error [ts2322] - Hard to type
+  ({ ...obj, [prop]: value });

--- a/src/set.ts
+++ b/src/set.ts
@@ -16,6 +16,9 @@ type SetPropValue<T, K extends keyof T, V extends Required<T>[K]> = Simplify<
 /**
  * Sets the `value` at `prop` of `object`.
  *
+ * To add a new property to an object, or to override it's type use `addProp`
+ * instead.
+ *
  * @param obj - The target method.
  * @param prop - The property name.
  * @param value - The value to set.
@@ -34,6 +37,9 @@ export function set<T, K extends keyof T, V extends Required<T>[K]>(
 
 /**
  * Sets the `value` at `prop` of `object`.
+ *
+ * To add a new property to an object, or to override it's type use `addProp`
+ * instead.
  *
  * @param prop - The property name.
  * @param value - The value to set.

--- a/src/set.ts
+++ b/src/set.ts
@@ -4,8 +4,8 @@ import { purry } from "./purry";
 /**
  * Sets the `value` at `prop` of `object`.
  *
- * To add a new property to an object, or to override it's type use `addProp`
- * instead.
+ * To add a new property to an object, or to override its type, use `addProp`
+ * instead, and to set a property within a nested object use `setPath`.
  *
  * @param obj - The target method.
  * @param prop - The property name.

--- a/src/setPath.ts
+++ b/src/setPath.ts
@@ -25,6 +25,8 @@ type ValueAtPath<T, TPath extends Path<T>> = TPath extends readonly [
 /**
  * Sets the value at `path` of `object`.
  *
+ * For simple cases where the path is only one level deep, prefer `set` instead.
+ *
  * @param data - The target method.
  * @param path - The array of properties.
  * @param value - The value to set.


### PR DESCRIPTION
The current type would allow setting an optional prop with `undefined` even when it isn't a valid value for the prop.

I also expanded the typing to make the output more useful by making optional props required and have a fixed value (when possible).