### PR TITLE
fix(pipe): early exit on hasMany

### DIFF
--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -1,4 +1,6 @@
 import { filter } from "./filter";
+import { flat } from "./flat";
+import { flatMap } from "./flatMap";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
@@ -114,5 +116,40 @@ describe("lazy", () => {
     expect(count).toHaveBeenCalledTimes(4);
     expect(count2).toHaveBeenCalledTimes(2);
     expect(result).toEqual([100, 200]);
+  });
+
+  it("lazy take + flat", () => {
+    const result = pipe(
+      [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      take(1),
+      flat(),
+    );
+    expect(result).toEqual([1, 2]);
+  });
+
+  it("lazy take + flatMap", () => {
+    const result = pipe(
+      [
+        [
+          [1, 2],
+          [2, 3],
+        ],
+        [
+          [4, 5],
+          [5, 6],
+        ],
+        [
+          [7, 8],
+          [8, 9],
+        ],
+      ],
+      take(2),
+      flatMap((x) => x[1]),
+    );
+    expect(result).toEqual([2, 3, 5, 6]);
   });
 });

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -1,6 +1,5 @@
 import { filter } from "./filter";
 import { flat } from "./flat";
-import { flatMap } from "./flatMap";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
@@ -118,7 +117,7 @@ describe("lazy", () => {
     expect(result).toEqual([100, 200]);
   });
 
-  it("lazy take + flat", () => {
+  it("lazy early exit with hasMany", () => {
     const result = pipe(
       [
         [1, 2],
@@ -129,27 +128,5 @@ describe("lazy", () => {
       flat(),
     );
     expect(result).toEqual([1, 2]);
-  });
-
-  it("lazy take + flatMap", () => {
-    const result = pipe(
-      [
-        [
-          [1, 2],
-          [2, 3],
-        ],
-        [
-          [4, 5],
-          [5, 6],
-        ],
-        [
-          [7, 8],
-          [8, 9],
-        ],
-      ],
-      take(2),
-      flatMap((x) => x[1]),
-    );
-    expect(result).toEqual([2, 3, 5, 6]);
   });
 });

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -332,7 +332,7 @@ function processItem(
             return true;
           }
         }
-        return false;
+        return isDone;
       }
       currentItem = lazyResult.next;
     }
@@ -348,10 +348,7 @@ function processItem(
   if (lazyResult.hasNext) {
     accumulator.push(currentItem);
   }
-  if (isDone) {
-    return true;
-  }
-  return false;
+  return isDone;
 }
 
 function prepareLazyOperation(op: LazyOp): PreparedLazyOperation {


### PR DESCRIPTION
Currently when using `pipe`, `take` does nothing if it is followed by `flat` or `flatMap`. Here is a small example:

```ts
import * as R from 'remeda';

console.log(
  R.pipe(
    [
      [1, 2],
      [3, 4],
      [5, 6],
    ],
    R.take(1),
    R.flat()
  )
);
```

This code should output to the console `[1, 2]`, but actually outputs `[1, 2, 3, 4, 5, 6]`
This is because using `take` causes `isDone` to change to `true`, but `flat` (or any other function with `hasMany` in its iterator) has an early return of `false`, that ignores the value of `isDone` (so, instead of taking only first pair in the example code, `pipe` will take all pairs)

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/pages/mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
