### PR TITLE
fix(conditional): Use Object.assign to inject the defaultCase prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "main": "dist/index.cjs",

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -7,6 +7,8 @@ type Case<In, Out, Thru extends In = In> = readonly [
   then: (data: Thru) => Out,
 ];
 
+export const conditional = Object.assign(conditionalImpl, { defaultCase });
+
 /**
  * Executes a transformer function based on the first matching predicate,
  * functioning like a series of `if...else if...` statements. It sequentially
@@ -51,7 +53,7 @@ type Case<In, Out, Thru extends In = In> = readonly [
  * @dataLast
  * @category Function
  */
-export function conditional<
+function conditionalImpl<
   T,
   Return0,
   Return1 = never,
@@ -141,7 +143,7 @@ export function conditional<
  * @dataFirst
  * @category Function
  */
-export function conditional<
+function conditionalImpl<
   T,
   Return0,
   Return1 = never,
@@ -187,7 +189,7 @@ export function conditional<
   | Return8
   | Return9;
 
-export function conditional(...args: ReadonlyArray<unknown>): unknown {
+function conditionalImpl(...args: ReadonlyArray<unknown>): unknown {
   return purryOn(isCase, conditionalImplementation, args);
 }
 
@@ -219,37 +221,34 @@ function isCase(maybeCase: unknown): maybeCase is Case<unknown, unknown> {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace conditional {
-  /**
-   * A simplified case that accepts all data. Put this as the last case to
-   * prevent an exception from being thrown when none of the previous cases
-   * match.
-   * If this is not the last case it will short-circuit anything after it.
-   *
-   * @param then - You only need to provide the transformer, the predicate is
-   * implicit. @default () => undefined, which is how Lodash and Ramda handle
-   * the final fallback case.
-   * @example
-   *   const nameOrId = 3 as string | number;
-   *   R.conditional(
-   *     nameOrId,
-   *     [R.isString, (name) => `Hello ${name}`],
-   *     [R.isNumber, (id) => `Hello ID: ${id}`],
-   *     R.conditional.defaultCase(
-   *       (something) => `Hello something (${JSON.stringify(something)})`,
-   *     ),
-   *   ); //=> 'Hello ID: 3'
-   */
-  export function defaultCase(): Case<unknown, undefined>;
-  export function defaultCase<In, Then extends (param: In) => unknown>(
-    then: Then,
-  ): Case<In, ReturnType<Then>>;
-  export function defaultCase(
-    then: (data: unknown) => unknown = trivialDefaultCase,
-  ): Case<unknown, unknown> {
-    return [acceptAnything, then];
-  }
+/**
+ * A simplified case that accepts all data. Put this as the last case to
+ * prevent an exception from being thrown when none of the previous cases
+ * match.
+ * If this is not the last case it will short-circuit anything after it.
+ *
+ * @param then - You only need to provide the transformer, the predicate is
+ * implicit. @default () => undefined, which is how Lodash and Ramda handle
+ * the final fallback case.
+ * @example
+ *   const nameOrId = 3 as string | number;
+ *   R.conditional(
+ *     nameOrId,
+ *     [R.isString, (name) => `Hello ${name}`],
+ *     [R.isNumber, (id) => `Hello ID: ${id}`],
+ *     R.conditional.defaultCase(
+ *       (something) => `Hello something (${JSON.stringify(something)})`,
+ *     ),
+ *   ); //=> 'Hello ID: 3'
+ */
+function defaultCase(): Case<unknown, undefined>;
+function defaultCase<In, Then extends (param: In) => unknown>(
+  then: Then,
+): Case<In, ReturnType<Then>>;
+function defaultCase(
+  then: (data: unknown) => unknown = trivialDefaultCase,
+): Case<unknown, unknown> {
+  return [acceptAnything, then];
 }
 
 // We memoize this so it isn't recreated on every invocation of `defaultCase`.

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -7,7 +7,10 @@ type Case<In, Out, Thru extends In = In> = readonly [
   then: (data: Thru) => Out,
 ];
 
-export const conditional = Object.assign(conditionalImpl, { defaultCase });
+// We package the defaultCase helper into the function itself so that we
+// encapsulate everything into a single export.
+const conditionalPlus = Object.assign(conditional, { defaultCase });
+export { conditionalPlus as conditional };
 
 /**
  * Executes a transformer function based on the first matching predicate,
@@ -53,7 +56,7 @@ export const conditional = Object.assign(conditionalImpl, { defaultCase });
  * @dataLast
  * @category Function
  */
-function conditionalImpl<
+function conditional<
   T,
   Return0,
   Return1 = never,
@@ -143,7 +146,7 @@ function conditionalImpl<
  * @dataFirst
  * @category Function
  */
-function conditionalImpl<
+function conditional<
   T,
   Return0,
   Return1 = never,
@@ -189,7 +192,7 @@ function conditionalImpl<
   | Return8
   | Return9;
 
-function conditionalImpl(...args: ReadonlyArray<unknown>): unknown {
+function conditional(...args: ReadonlyArray<unknown>): unknown {
   return purryOn(isCase, conditionalImplementation, args);
 }
 


### PR DESCRIPTION
Fixes: #720

Copying what I wrote in issue #720:

I managed to reproduce the issue. It bisects to #596, but that makes me think that maybe that PR (that simply fixed a attw linit warning) just surfaced the fact that our ESM build for this function was always broken. I have a hunch that tsup (or esbuild) is not doing a good job with `namespace` by using an IIFE to inject the property instead of `Object.assign`, which is what I would expect would happen.
