### PR TITLE
fix(hasSubObject): use `Simplify` type to show better type information

### DIFF
--- a/src/hasSubObject.ts
+++ b/src/hasSubObject.ts
@@ -1,13 +1,12 @@
-import type { Merge } from "type-fest";
+import type { Simplify } from "type-fest";
 import type { Branded } from "./internal/types";
 import { isDeepEqual } from "./isDeepEqual";
 import { purry } from "./purry";
 
 declare const HAS_SUB_OBJECT_BRAND: unique symbol;
 
-type HasSubObjectGuard<T, S> = Branded<
-  Merge<T, S>,
-  typeof HAS_SUB_OBJECT_BRAND
+type HasSubObjectGuard<T, S> = Simplify<
+  Branded<S & T, typeof HAS_SUB_OBJECT_BRAND>
 >;
 
 /**
@@ -27,7 +26,7 @@ type HasSubObjectGuard<T, S> = Branded<
  * @category Guard
  */
 export function hasSubObject<T, S extends Partial<T>>(
-  data: Merge<T, S> | T,
+  data: T,
   subObject: S,
 ): data is HasSubObjectGuard<T, S>;
 
@@ -48,14 +47,14 @@ export function hasSubObject<T, S extends Partial<T>>(
  */
 export function hasSubObject<T, S extends Partial<T>>(
   subObject: S,
-): (data: Merge<T, S> | T) => data is HasSubObjectGuard<T, S>;
+): (data: T) => data is HasSubObjectGuard<T, S>;
 
 export function hasSubObject(...args: ReadonlyArray<unknown>): unknown {
   return purry(hasSubObjectImplementation, args);
 }
 
 function hasSubObjectImplementation<T extends object, S extends Partial<T>>(
-  data: Merge<T, S> | T,
+  data: T,
   subObject: S,
 ): data is HasSubObjectGuard<T, S> {
   for (const [key, value] of Object.entries(subObject)) {


### PR DESCRIPTION
**Context:** https://github.com/remeda/remeda/pull/683#discussion_r1630022640


| Before | After
| - | - |
| ![image](https://github.com/remeda/remeda/assets/10157660/8ff6e445-12c0-4efc-a1a7-dcb54b757d46) | ![image](https://github.com/remeda/remeda/assets/10157660/056622d8-edd6-4f01-b25b-1fca33403e2c) |

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/pages/mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
