### PR TITLE
fix: key and value typing of unions of object types.

### DIFF
--- a/src/forEachObj.test.ts
+++ b/src/forEachObj.test.ts
@@ -70,4 +70,22 @@ describe("typing", () => {
       expectTypeOf(value).toEqualTypeOf<boolean | string>();
     });
   });
+
+  test("union of records", () => {
+    forEachObj(
+      {} as Record<number, string> | Record<string, number>,
+      (value, key) => {
+        expectTypeOf(key).toEqualTypeOf<string>();
+        expectTypeOf(value).toEqualTypeOf<number | string>();
+      },
+    );
+
+    pipe(
+      {} as Record<number, string> | Record<string, number>,
+      forEachObj((value, key) => {
+        expectTypeOf(key).toEqualTypeOf<string>();
+        expectTypeOf(value).toEqualTypeOf<number | string>();
+      }),
+    );
+  });
 });

--- a/src/forEachObj.test.ts
+++ b/src/forEachObj.test.ts
@@ -72,16 +72,15 @@ describe("typing", () => {
   });
 
   test("union of records", () => {
-    forEachObj(
-      {} as Record<number, string> | Record<string, number>,
-      (value, key) => {
-        expectTypeOf(key).toEqualTypeOf<string>();
-        expectTypeOf(value).toEqualTypeOf<number | string>();
-      },
-    );
+    const data = {} as Record<number, string> | Record<string, number>;
+
+    forEachObj(data, (value, key) => {
+      expectTypeOf(key).toEqualTypeOf<string>();
+      expectTypeOf(value).toEqualTypeOf<number | string>();
+    });
 
     pipe(
-      {} as Record<number, string> | Record<string, number>,
+      data,
       forEachObj((value, key) => {
         expectTypeOf(key).toEqualTypeOf<string>();
         expectTypeOf(value).toEqualTypeOf<number | string>();

--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -1,4 +1,10 @@
-import { type Branded, type IfBoundedRecord } from "./types";
+import { type EmptyObject } from "type-fest";
+import {
+  type Branded,
+  type IfBoundedRecord,
+  type EnumerableStringKeyedValueOf,
+  type EnumerableStringKeyOf,
+} from "./types";
 
 declare const SymbolFoo: unique symbol;
 declare const SymbolBar: unique symbol;
@@ -154,5 +160,149 @@ describe("IfBoundedRecord", () => {
         Record<`${string}_${number}_${string}_${number}_${string}`, unknown>
       >
     >().toEqualTypeOf<false>();
+  });
+});
+
+describe("EnumerableStringKeyOf", () => {
+  test("string keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<string, unknown>>
+    >().toEqualTypeOf<string>();
+  });
+
+  test("number keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<number, unknown>>
+    >().toEqualTypeOf<`${number}`>();
+  });
+
+  test("union of records", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<
+        Record<`prefix_${string}`, unknown> | Record<number, unknown>
+      >
+    >().toEqualTypeOf<`${number}` | `prefix_${string}`>();
+  });
+
+  test("union keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<number | `prefix_${string}`, unknown>>
+    >().toEqualTypeOf<`${number}` | `prefix_${string}`>();
+  });
+
+  test("symbol keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<string | symbol, unknown>>
+    >().toEqualTypeOf<string>();
+
+    expectTypeOf<
+      EnumerableStringKeyOf<{ [SymbolFoo]: number; a: unknown }>
+    >().toEqualTypeOf<"a">();
+
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<string | typeof SymbolFoo, unknown>>
+    >().toEqualTypeOf<string>();
+  });
+
+  test("optional keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<{ a: unknown; b?: unknown }>
+    >().toEqualTypeOf<"a" | "b">();
+  });
+
+  test("branded types", () => {
+    expectTypeOf<
+      EnumerableStringKeyOf<Record<Branded<string, symbol>, unknown>>
+    >().toEqualTypeOf<`${Branded<string, symbol>}`>();
+  });
+});
+
+describe("EnumerableStringKeyedValueOf", () => {
+  test("string values", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<Record<PropertyKey, string>>
+    >().toEqualTypeOf<string>();
+  });
+
+  test("number values", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<Record<PropertyKey, number>>
+    >().toEqualTypeOf<number>();
+  });
+
+  test("union of records", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<
+        Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">
+      >
+    >().toEqualTypeOf<"cat" | "dog">();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<
+        Record<PropertyKey, number> | Record<PropertyKey, string>
+      >
+    >().toEqualTypeOf<number | string>();
+  });
+
+  test("union values", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<Record<PropertyKey, number | string>>
+    >().toEqualTypeOf<number | string>();
+  });
+
+  test("literal values", () => {
+    expectTypeOf<EnumerableStringKeyedValueOf<{ a: 1 }>>().toEqualTypeOf<1>();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{ a: "1" | "2" | 1 }>
+    >().toEqualTypeOf<"1" | "2" | 1>();
+  });
+
+  test("optional values", () => {
+    expectTypeOf<EnumerableStringKeyedValueOf<{ a: 1; b?: 4 }>>().toEqualTypeOf<
+      1 | 4
+    >();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{ a: string; b?: number }>
+    >().toEqualTypeOf<number | string>();
+  });
+
+  test("nullish and undefined values", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{
+        a: string | undefined;
+        b: string | null;
+      }>
+    >().toEqualTypeOf<string | null | undefined>();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{
+        a?: number | null;
+        b?: number | null | undefined;
+      }>
+    >().toEqualTypeOf<number | null | undefined>();
+  });
+
+  test("symbol keys", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{ [SymbolFoo]: string }>
+    >().toEqualTypeOf<never>();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<{ [SymbolFoo]: string; b: "1" }>
+    >().toEqualTypeOf<"1">();
+
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<
+        Record<PropertyKey | typeof SymbolFoo, string>
+      >
+    >().toEqualTypeOf<string>();
+  });
+
+  test("empty object", () => {
+    expectTypeOf<
+      EnumerableStringKeyedValueOf<EmptyObject>
+    >().toEqualTypeOf<never>();
   });
 });

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -8,6 +8,7 @@ import {
   type KeysOfUnion,
   type Simplify,
   type Split,
+  type EmptyObject,
 } from "type-fest";
 
 declare const __brand: unique symbol;
@@ -96,15 +97,25 @@ type IsBoundedString<T> = T extends string
  *
  * @see EnumerableStringKeyedValueOf
  */
-export type EnumerableStringKeyOf<T> = `${Exclude<keyof T, symbol>}`;
+export type EnumerableStringKeyOf<T> =
+  T extends Record<infer K, unknown> ? `${Exclude<K, symbol>}` : never;
+
+/**
+ * Extracts the value type from an object type T.
+ */
+export type InferredRecordValue<T> = T extends EmptyObject
+  ? T[keyof T]
+  : T extends Record<PropertyKey, infer V>
+    ? V
+    : never;
 
 /**
  * A union of all values of properties in T which are not keyed by a symbol,
  * following the definition of `Object.values` and `Object.entries`.
  */
-export type EnumerableStringKeyedValueOf<T> = {
+export type EnumerableStringKeyedValueOf<T> = InferredRecordValue<{
   [K in keyof T]-?: K extends symbol ? never : T[K];
-}[keyof T];
+}>;
 
 /**
  * This is the type you'd get from doing:

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -103,9 +103,17 @@ export type EnumerableStringKeyOf<T> =
     : never;
 
 /**
+ * A union of all values of properties in T which are not keyed by a symbol,
+ * following the definition of `Object.values` and `Object.entries`.
+ */
+export type EnumerableStringKeyedValueOf<T> = ValuesOf<{
+  [K in keyof T]-?: K extends symbol ? never : T[K];
+}>;
+
+/**
  * Extracts the value type from an object type T.
  */
-export type ValuesOf<T> =
+type ValuesOf<T> =
   // EmptyObject is used to infer value type as never instead of unknown
   // for an empty object
   T extends EmptyObject
@@ -113,14 +121,6 @@ export type ValuesOf<T> =
     : T extends Record<PropertyKey, infer V>
       ? V
       : never;
-
-/**
- * A union of all values of properties in T which are not keyed by a symbol,
- * following the definition of `Object.values` and `Object.entries`.
- */
-export type EnumerableStringKeyedValueOf<T> = ValuesOf<{
-  [K in keyof T]-?: K extends symbol ? never : T[K];
-}>;
 
 /**
  * This is the type you'd get from doing:

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -98,7 +98,9 @@ type IsBoundedString<T> = T extends string
  * @see EnumerableStringKeyedValueOf
  */
 export type EnumerableStringKeyOf<T> =
-  T extends Record<infer K, unknown> ? `${Exclude<K, symbol>}` : never;
+  Required<T> extends Record<infer K, unknown>
+    ? `${Exclude<K, symbol>}`
+    : never;
 
 /**
  * Extracts the value type from an object type T.

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -103,7 +103,7 @@ export type EnumerableStringKeyOf<T> =
 /**
  * Extracts the value type from an object type T.
  */
-export type InferredRecordValue<T> = T extends EmptyObject
+export type ValuesOf<T> = T extends EmptyObject
   ? T[keyof T]
   : T extends Record<PropertyKey, infer V>
     ? V
@@ -113,7 +113,7 @@ export type InferredRecordValue<T> = T extends EmptyObject
  * A union of all values of properties in T which are not keyed by a symbol,
  * following the definition of `Object.values` and `Object.entries`.
  */
-export type EnumerableStringKeyedValueOf<T> = InferredRecordValue<{
+export type EnumerableStringKeyedValueOf<T> = ValuesOf<{
   [K in keyof T]-?: K extends symbol ? never : T[K];
 }>;
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -103,11 +103,14 @@ export type EnumerableStringKeyOf<T> =
 /**
  * Extracts the value type from an object type T.
  */
-export type ValuesOf<T> = T extends EmptyObject
-  ? T[keyof T]
-  : T extends Record<PropertyKey, infer V>
-    ? V
-    : never;
+export type ValuesOf<T> =
+  // EmptyObject is used to infer value type as never instead of unknown
+  // for an empty object
+  T extends EmptyObject
+    ? T[keyof T]
+    : T extends Record<PropertyKey, infer V>
+      ? V
+      : never;
 
 /**
  * A union of all values of properties in T which are not keyed by a symbol,

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -113,19 +113,14 @@ describe("typing", () => {
     });
 
     test("unions of records", () => {
-      const dataFirst = keys(
-        {} as Record<number, string> | Record<string, string>,
-      );
+      const data = {} as Record<number, unknown> | Record<string, unknown>;
 
+      const dataFirst = keys(data);
       expectTypeOf(dataFirst).toEqualTypeOf<
         Array<`${number}`> | Array<string>
       >();
 
-      const dataLast = pipe(
-        {} as Record<number, string> | Record<string, string>,
-        keys(),
-      );
-
+      const dataLast = pipe(data, keys());
       expectTypeOf(dataLast).toEqualTypeOf<
         Array<`${number}`> | Array<string>
       >();

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -1,4 +1,5 @@
 import { keys } from "./keys";
+import { pipe } from "./pipe";
 
 describe("runtime", () => {
   describe("dataFirst", () => {
@@ -109,6 +110,25 @@ describe("typing", () => {
     test("empty record (const)", () => {
       const result = keys({} as const);
       expectTypeOf(result).toEqualTypeOf<[]>();
+    });
+
+    test("unions of records", () => {
+      const dataFirst = keys(
+        {} as Record<number, string> | Record<string, string>,
+      );
+
+      expectTypeOf(dataFirst).toEqualTypeOf<
+        Array<`${number}`> | Array<string>
+      >();
+
+      const dataLast = pipe(
+        {} as Record<number, string> | Record<string, string>,
+        keys(),
+      );
+
+      expectTypeOf(dataLast).toEqualTypeOf<
+        Array<`${number}`> | Array<string>
+      >();
     });
 
     test("simple (required) object", () => {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -50,9 +50,7 @@ type IndicesAfterSpread<
       : Iterations["length"];
 
 type ObjectKeys<T> =
-  T extends Record<PropertyKey, never>
-    ? []
-    : Array<EnumerableStringKeyOf<Required<T>>>;
+  T extends Record<PropertyKey, never> ? [] : Array<EnumerableStringKeyOf<T>>;
 
 /**
  * Returns a new array containing the keys of the array or object.

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -50,7 +50,9 @@ type IndicesAfterSpread<
       : Iterations["length"];
 
 type ObjectKeys<T> =
-  T extends Record<PropertyKey, never> ? [] : Array<EnumerableStringKeyOf<T>>;
+  T extends Record<PropertyKey, never>
+    ? []
+    : Array<EnumerableStringKeyOf<Required<T>>>;
 
 /**
  * Returns a new array containing the keys of the array or object.

--- a/src/mapKeys.test.ts
+++ b/src/mapKeys.test.ts
@@ -107,12 +107,12 @@ describe("typing", () => {
   });
 
   test("union of records", () => {
-    const data = {} as Record<number, string> | Record<string, string>;
+    const data = {} as Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">;
 
     const dataFirst = mapKeys(data, constant("hello" as string));
-    expectTypeOf(dataFirst).toEqualTypeOf<Record<string, string>>();
+    expectTypeOf(dataFirst).toEqualTypeOf<Record<string, "cat" | "dog">>();
 
     const dataLast = pipe(data, mapKeys(constant("hello" as string)));
-    expectTypeOf(dataLast).toEqualTypeOf<Record<string, string>>();
+    expectTypeOf(dataLast).toEqualTypeOf<Record<string, "cat" | "dog">>();
   });
 });

--- a/src/mapKeys.test.ts
+++ b/src/mapKeys.test.ts
@@ -107,18 +107,12 @@ describe("typing", () => {
   });
 
   test("union of records", () => {
-    const dataFirst = mapKeys(
-      {} as Record<number, string> | Record<string, string>,
-      constant("hello" as string),
-    );
+    const data = {} as Record<number, string> | Record<string, string>;
 
+    const dataFirst = mapKeys(data, constant("hello" as string));
     expectTypeOf(dataFirst).toEqualTypeOf<Record<string, string>>();
 
-    const dataLast = pipe(
-      {} as Record<number, string> | Record<string, string>,
-      mapKeys(constant("hello" as string)),
-    );
-
+    const dataLast = pipe(data, mapKeys(constant("hello" as string)));
     expectTypeOf(dataLast).toEqualTypeOf<Record<string, string>>();
   });
 });

--- a/src/mapKeys.test.ts
+++ b/src/mapKeys.test.ts
@@ -105,4 +105,20 @@ describe("typing", () => {
     const result = mapKeys({ a: "b" }, constant(123));
     expectTypeOf(result).toEqualTypeOf<Partial<Record<123, string>>>();
   });
+
+  test("union of records", () => {
+    const dataFirst = mapKeys(
+      {} as Record<number, string> | Record<string, string>,
+      constant("hello" as string),
+    );
+
+    expectTypeOf(dataFirst).toEqualTypeOf<Record<string, string>>();
+
+    const dataLast = pipe(
+      {} as Record<number, string> | Record<string, string>,
+      mapKeys(constant("hello" as string)),
+    );
+
+    expectTypeOf(dataLast).toEqualTypeOf<Record<string, string>>();
+  });
 });

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -10,6 +10,18 @@ import type {
 } from "./internal/types";
 import { purry } from "./purry";
 
+type KeyMapperKey<T> =
+  T extends Record<infer K, unknown>
+    ? EnumerableStringKeyOf<{ [P in K]: unknown }>
+    : never;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InferredRecordValue<T> = T extends Record<any, infer V> ? V : never;
+
+type KeyMapperValue<T> = InferredRecordValue<{
+  [K in keyof T]: EnumerableStringKeyedValueOf<T>;
+}>;
+
 /**
  * Maps keys of `object` and keeps the same values.
  *
@@ -24,12 +36,8 @@ import { purry } from "./purry";
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: (
-    key: EnumerableStringKeyOf<T>,
-    value: EnumerableStringKeyedValueOf<T>,
-    data: T,
-  ) => S,
-): ExactRecord<S, T[keyof T]>;
+  keyMapper: (key: KeyMapperKey<T>, value: KeyMapperValue<T>, data: T) => S,
+): ExactRecord<S, KeyMapperValue<T>>;
 
 /**
  * Maps keys of `object` and keeps the same values.
@@ -43,12 +51,8 @@ export function mapKeys<T extends {}, S extends PropertyKey>(
  * @category Object
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
-  keyMapper: (
-    key: EnumerableStringKeyOf<T>,
-    value: EnumerableStringKeyedValueOf<T>,
-    data: T,
-  ) => S,
-): (data: T) => ExactRecord<S, T[keyof T]>;
+  keyMapper: (key: KeyMapperKey<T>, value: KeyMapperValue<T>, data: T) => S,
+): (data: T) => ExactRecord<S, KeyMapperValue<T>>;
 
 export function mapKeys(...args: ReadonlyArray<unknown>): unknown {
   return purry(mapKeysImplementation, args);

--- a/src/mapKeys.ts
+++ b/src/mapKeys.ts
@@ -10,18 +10,6 @@ import type {
 } from "./internal/types";
 import { purry } from "./purry";
 
-type KeyMapperKey<T> =
-  T extends Record<infer K, unknown>
-    ? EnumerableStringKeyOf<{ [P in K]: unknown }>
-    : never;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type InferredRecordValue<T> = T extends Record<any, infer V> ? V : never;
-
-type KeyMapperValue<T> = InferredRecordValue<{
-  [K in keyof T]: EnumerableStringKeyedValueOf<T>;
-}>;
-
 /**
  * Maps keys of `object` and keeps the same values.
  *
@@ -36,8 +24,12 @@ type KeyMapperValue<T> = InferredRecordValue<{
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
   data: T,
-  keyMapper: (key: KeyMapperKey<T>, value: KeyMapperValue<T>, data: T) => S,
-): ExactRecord<S, KeyMapperValue<T>>;
+  keyMapper: (
+    key: EnumerableStringKeyOf<T>,
+    value: EnumerableStringKeyedValueOf<T>,
+    data: T,
+  ) => S,
+): ExactRecord<S, EnumerableStringKeyedValueOf<T>>;
 
 /**
  * Maps keys of `object` and keeps the same values.
@@ -51,8 +43,12 @@ export function mapKeys<T extends {}, S extends PropertyKey>(
  * @category Object
  */
 export function mapKeys<T extends {}, S extends PropertyKey>(
-  keyMapper: (key: KeyMapperKey<T>, value: KeyMapperValue<T>, data: T) => S,
-): (data: T) => ExactRecord<S, KeyMapperValue<T>>;
+  keyMapper: (
+    key: EnumerableStringKeyOf<T>,
+    value: EnumerableStringKeyedValueOf<T>,
+    data: T,
+  ) => S,
+): (data: T) => ExactRecord<S, EnumerableStringKeyedValueOf<T>>;
 
 export function mapKeys(...args: ReadonlyArray<unknown>): unknown {
   return purry(mapKeysImplementation, args);

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -163,20 +163,14 @@ describe("typing", () => {
   });
 
   test("unions of records", () => {
-    const dataFirst = mapValues(
-      {} as Record<number, string> | Record<string, string>,
-      constant("hello" as string),
-    );
+    const data = {} as Record<number, unknown> | Record<string, unknown>;
 
+    const dataFirst = mapValues(data, constant("hello" as string));
     expectTypeOf(dataFirst).toEqualTypeOf<
       Record<`${number}`, string> | Record<string, string>
     >();
 
-    const dataLast = pipe(
-      {} as Record<number, string> | Record<string, string>,
-      mapValues(constant("hello" as string)),
-    );
-
+    const dataLast = pipe(data, mapValues(constant("hello" as string)));
     expectTypeOf(dataLast).toEqualTypeOf<
       Record<`${number}`, string> | Record<string, string>
     >();

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -116,7 +116,7 @@ describe("typing", () => {
 
       mapValues(userValues, (value, key) => {
         expectTypeOf(value).toEqualTypeOf<number>();
-        expectTypeOf(key).toEqualTypeOf<`${UserID}`>();
+        expectTypeOf(key).toMatchTypeOf<`${UserID}`>();
       });
     });
   });
@@ -159,5 +159,25 @@ describe("typing", () => {
       c: boolean;
       d: boolean;
     }>();
+  });
+
+  test("unions of records", () => {
+    const dataFirst = mapValues(
+      {} as Record<number, string> | Record<string, string>,
+      constant("hello" as string),
+    );
+
+    expectTypeOf(dataFirst).toEqualTypeOf<
+      Record<`${number}`, string> | Record<string, string>
+    >();
+
+    const dataLast = pipe(
+      {} as Record<number, string> | Record<string, string>,
+      mapValues(constant("hello" as string)),
+    );
+
+    expectTypeOf(dataLast).toEqualTypeOf<
+      Record<`${number}`, string> | Record<string, string>
+    >();
   });
 });

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -116,6 +116,7 @@ describe("typing", () => {
 
       mapValues(userValues, (value, key) => {
         expectTypeOf(value).toEqualTypeOf<number>();
+        // TODO: If possible, use `toEqualTypeOf`
         expectTypeOf(key).toMatchTypeOf<`${UserID}`>();
       });
     });

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -1,4 +1,5 @@
 import { constant } from "./constant";
+import { type Branded } from "./internal/types";
 import { mapValues } from "./mapValues";
 import { pipe } from "./pipe";
 
@@ -106,8 +107,7 @@ describe("typing", () => {
 
   describe("branded types", () => {
     test("should infer types correctly in the mapper", () => {
-      type Branded<K, T> = K & { _type: T };
-      type UserID = Branded<string, "UserId">;
+      type UserID = Branded<string, symbol>;
 
       const userValues: Record<UserID, number> = {
         ["U1" as UserID]: 1,
@@ -116,8 +116,7 @@ describe("typing", () => {
 
       mapValues(userValues, (value, key) => {
         expectTypeOf(value).toEqualTypeOf<number>();
-        // TODO: If possible, use `toEqualTypeOf`
-        expectTypeOf(key).toMatchTypeOf<`${UserID}`>();
+        expectTypeOf(key).toEqualTypeOf<`${UserID}`>();
       });
     });
   });

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -207,6 +207,20 @@ describe("typing", () => {
       const result = omitBy(data, constant(true));
       expectTypeOf(result).toEqualTypeOf<Record<string, string>>();
     });
+
+    test("union of records", () => {
+      const data = {} as Record<number, string> | Record<string, string>;
+
+      const dataFirst = omitBy(data, constant(true));
+      expectTypeOf(dataFirst).toEqualTypeOf<
+        Record<`${number}`, string> | Record<string, string>
+      >();
+
+      const dataLast = pipe(data, omitBy(constant(true)));
+      expectTypeOf(dataLast).toEqualTypeOf<
+        Record<`${number}`, string> | Record<string, string>
+      >();
+    });
   });
 });
 

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -19,19 +19,22 @@ type PickSymbolKeys<T extends object> = {
 // would be omitted from the output, so we need to assume any of them could be
 // filtered out. This means that we effectively make all (enumerable) keys
 // optional.
-type PartialEnumerableKeys<T extends object> = T extends unknown
-  ? Simplify<
-      IfBoundedRecord<
-        T,
-        PickSymbolKeys<T> & {
-          -readonly [P in keyof T as P extends symbol
-            ? never
-            : P]?: Required<T>[P];
-        },
-        ReconstructedRecord<T>
+type PartialEnumerableKeys<T extends object> =
+  // `extends unknown` is always going to be the case and is used to convert any
+  // union into a [distributive conditional type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
+  T extends unknown
+    ? Simplify<
+        IfBoundedRecord<
+          T,
+          PickSymbolKeys<T> & {
+            -readonly [P in keyof T as P extends symbol
+              ? never
+              : P]?: Required<T>[P];
+          },
+          ReconstructedRecord<T>
+        >
       >
-    >
-  : unknown;
+    : unknown;
 
 // When the predicate is a type-guard we have more information to work with when
 // constructing the type of the output object. We can safely remove any property

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -34,7 +34,7 @@ type PartialEnumerableKeys<T extends object> =
           ReconstructedRecord<T>
         >
       >
-    : unknown;
+    : never;
 
 // When the predicate is a type-guard we have more information to work with when
 // constructing the type of the output object. We can safely remove any property

--- a/src/omitBy.ts
+++ b/src/omitBy.ts
@@ -19,15 +19,19 @@ type PickSymbolKeys<T extends object> = {
 // would be omitted from the output, so we need to assume any of them could be
 // filtered out. This means that we effectively make all (enumerable) keys
 // optional.
-type PartialEnumerableKeys<T extends object> = Simplify<
-  IfBoundedRecord<
-    T,
-    PickSymbolKeys<T> & {
-      -readonly [P in keyof T as P extends symbol ? never : P]?: Required<T>[P];
-    },
-    ReconstructedRecord<T>
-  >
->;
+type PartialEnumerableKeys<T extends object> = T extends unknown
+  ? Simplify<
+      IfBoundedRecord<
+        T,
+        PickSymbolKeys<T> & {
+          -readonly [P in keyof T as P extends symbol
+            ? never
+            : P]?: Required<T>[P];
+        },
+        ReconstructedRecord<T>
+      >
+    >
+  : unknown;
 
 // When the predicate is a type-guard we have more information to work with when
 // constructing the type of the output object. We can safely remove any property

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -182,5 +182,18 @@ describe("typing", () => {
       const result = pickBy(data, constant(true));
       expectTypeOf(result).toEqualTypeOf<Record<string, string>>();
     });
+
+    test("union of records", () => {
+      const data = {} as Record<number, string> | Record<string, string>;
+      const dataFirst = pickBy(data, constant(true));
+      expectTypeOf(dataFirst).toEqualTypeOf<
+        Record<`${number}`, string> | Record<string, string>
+      >();
+
+      const dataLast = pipe(data, pickBy(constant(true)));
+      expectTypeOf(dataLast).toEqualTypeOf<
+        Record<`${number}`, string> | Record<string, string>
+      >();
+    });
   });
 });

--- a/src/pickBy.ts
+++ b/src/pickBy.ts
@@ -15,15 +15,17 @@ type EnumerableKey<T> = `${T extends number | string ? T : never}`;
 // When the predicate isn't a type-guard we don't know which properties would be
 // part of the output and which wouldn't so we can only safely downgrade the
 // whole object to a Partial of the input.
-type EnumeratedPartial<T> = Simplify<
-  IfBoundedRecord<
-    T,
-    {
-      -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
-    },
-    ReconstructedRecord<T>
-  >
->;
+type EnumeratedPartial<T> = T extends unknown
+  ? Simplify<
+      IfBoundedRecord<
+        T,
+        {
+          -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
+        },
+        ReconstructedRecord<T>
+      >
+    >
+  : never;
 
 // When the predicate is a type-guard we have more information to work with when
 // constructing the type of the output object. We can safely remove any property

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -54,9 +54,10 @@ describe("typing", () => {
   });
 
   it("should correctly type union of Records", () => {
-    const result = values<Record<number, string> | Record<string, string>>({
+    const result = values({
       a: "b",
-    });
+    } as Record<number, string> | Record<string, string>);
+
     expectTypeOf(result).toEqualTypeOf<Array<string>>();
   });
 

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -53,6 +53,13 @@ describe("typing", () => {
     expectTypeOf(result).toEqualTypeOf<Array<boolean>>();
   });
 
+  it("should correctly type union of Records", () => {
+    const result = values<Record<number, string> | Record<string, string>>({
+      a: "b",
+    });
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
   it("should correctly type typed objects", () => {
     const result = values<{ type: "cat" | "dog"; age: number }>({
       type: "cat",

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -55,10 +55,10 @@ describe("typing", () => {
 
   it("should correctly type union of Records", () => {
     const result = values({
-      a: "b",
-    } as Record<number, string> | Record<string, string>);
+      a: "cat",
+    } as Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">);
 
-    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+    expectTypeOf(result).toEqualTypeOf<Array<"cat"> | Array<"dog">>();
   });
 
   it("should correctly type typed objects", () => {


### PR DESCRIPTION
Closes #727.

I thought it was an inference issue so I tried to resolve it by modifying the types and using `infer`. Moreover, I tried to keep using the internal types `EnumerableStringKeyOf` and `EnumerableStringKeyedValueOf`. 

I would be happy to integrate any further adjustments as needed. 

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/pages/mapping.md`

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
