### PR TITLE
feat(split): Add split

### DIFF
--- a/docs/src/content/mapping/lodash/__MISSING.md
+++ b/docs/src/content/mapping/lodash/__MISSING.md
@@ -144,7 +144,6 @@ TODO: Go over: https://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore/#
 - repeat
 - replace
 - snakeCase
-- split
 - startCase
 - startsWith
 - template

--- a/docs/src/content/mapping/lodash/split.md
+++ b/docs/src/content/mapping/lodash/split.md
@@ -1,0 +1,4 @@
+---
+category: String
+remeda: split
+---

--- a/docs/src/content/mapping/ramda/__MISSING.md
+++ b/docs/src/content/mapping/ramda/__MISSING.md
@@ -166,6 +166,16 @@
 - union
 - unionWith
 
+# String
+
+- match
+- replace
+- test
+- toLower
+- toString
+- toUpper
+- trim
+
 # Type
 
 - type

--- a/docs/src/content/mapping/ramda/split.md
+++ b/docs/src/content/mapping/ramda/split.md
@@ -1,0 +1,4 @@
+---
+category: String
+remeda: split
+---

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ export * from "./sortedIndexWith";
 export * from "./sortedLastIndex";
 export * from "./sortedLastIndexBy";
 export * from "./splice";
+export * from "./split";
 export * from "./splitAt";
 export * from "./splitWhen";
 export * from "./stringToPath";

--- a/src/split.test.ts
+++ b/src/split.test.ts
@@ -1,0 +1,201 @@
+import { split } from "./split";
+import { pipe } from "./pipe";
+
+describe("runtime", () => {
+  test("empty string, empty separator", () => {
+    expect(split("", "")).toEqual([]);
+  });
+
+  test("empty string, non-empty separator", () => {
+    expect(split("", ",")).toEqual([""]);
+  });
+
+  test("trivial split", () => {
+    expect(split("a", ",")).toEqual(["a"]);
+  });
+
+  test("string contains separator", () => {
+    expect(split(",", ",")).toEqual(["", ""]);
+  });
+
+  test("useful split", () => {
+    expect(split("a,b,c", ",")).toEqual(["a", "b", "c"]);
+  });
+
+  test("regex split", () => {
+    expect(split("a,b,c", /,/u)).toEqual(["a", "b", "c"]);
+  });
+
+  test("multiple types of separators", () => {
+    expect(split("a,b;c", /[;,]/u)).toEqual(["a", "b", "c"]);
+  });
+
+  test("regex with limit", () => {
+    expect(split("a,b,c", /,/u, 2)).toEqual(["a", "b"]);
+  });
+
+  test("limited split", () => {
+    expect(split("a,b,c", ",", 2)).toEqual(["a", "b"]);
+  });
+
+  test("limit is higher than splits", () => {
+    expect(split("a,b,c", ",", 5)).toEqual(["a", "b", "c"]);
+  });
+
+  test("multiple consecutive separators", () => {
+    expect(split("a,,b", ",")).toEqual(["a", "", "b"]);
+  });
+
+  test("separator at the start and end", () => {
+    expect(split(",a,b,", ",")).toEqual(["", "a", "b", ""]);
+  });
+
+  test("empty-string separator", () => {
+    expect(split("abcdef", "")).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  test("undefined limit", () => {
+    expect(split("a,b,c", ",", undefined)).toEqual(["a", "b", "c"]);
+  });
+
+  test("negative limit", () => {
+    expect(split("a,b,c", ",", -1)).toEqual(["a", "b", "c"]);
+  });
+
+  test("fractional limits", () => {
+    expect(split("a,b,c", ",", 1.5)).toEqual(["a"]);
+  });
+
+  test("0 limit", () => {
+    expect(split("a,b,c", ",", 0)).toEqual([]);
+  });
+
+  describe("dataLast", () => {
+    test("useful split", () => {
+      expect(pipe("a,b,c", split(","))).toEqual(["a", "b", "c"]);
+    });
+
+    test("regex split", () => {
+      expect(pipe("a,b,c", split(/,/u))).toEqual(["a", "b", "c"]);
+    });
+
+    test("limited split", () => {
+      expect(pipe("a,b,c", split(",", 2))).toEqual(["a", "b"]);
+    });
+
+    test("regex with limit", () => {
+      expect(pipe("a,b,c", split(/,/u, 2))).toEqual(["a", "b"]);
+    });
+
+    test("undefined limit", () => {
+      expect(pipe("a,b,c", split(",", undefined))).toEqual(["a", "b", "c"]);
+    });
+  });
+});
+
+describe("typing", () => {
+  test("non-literals", () => {
+    const result = split("" as string, "" as string);
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("non-literal data", () => {
+    const result = split("" as string, ",");
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("non-literal separator", () => {
+    const result = split("", "," as string);
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("non-literal limit", () => {
+    const result = split("", "", 1 as number);
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("literal empty strings", () => {
+    const result = split("", "");
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  test("trivial literals", () => {
+    const result = split("a", ",");
+    expectTypeOf(result).toEqualTypeOf<["a"]>();
+  });
+
+  test("trivial literals", () => {
+    const result = split("a", ",");
+    expectTypeOf(result).toEqualTypeOf<["a"]>();
+  });
+
+  test("string contains separator", () => {
+    const result = split(",", ",");
+    expectTypeOf(result).toEqualTypeOf<["", ""]>();
+  });
+
+  test("useful split", () => {
+    const result = split("a,b,c", ",");
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c"]>();
+  });
+
+  test("regex split", () => {
+    const result = split("a,b,c", /,/u);
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("limited split", () => {
+    const result = split("a,b,c", ",", 2);
+    expectTypeOf(result).toEqualTypeOf<["a", "b"]>();
+  });
+
+  test("limit is higher than splits", () => {
+    const result = split("a,b,c", ",", 5);
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c"]>();
+  });
+
+  test("undefined limit", () => {
+    const result = split("a,b,c", ",", undefined);
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c"]>();
+  });
+
+  test("multiple consecutive separators", () => {
+    const result = split("a,,b", ",");
+    expectTypeOf(result).toEqualTypeOf<["a", "", "b"]>();
+  });
+
+  test("separator at the start and end", () => {
+    const result = split(",a,b,", ",");
+    expectTypeOf(result).toEqualTypeOf<["", "a", "b", ""]>();
+  });
+
+  test("empty string separator", () => {
+    const result = split("abcdef", "");
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c", "d", "e", "f"]>();
+  });
+
+  test("empty everything", () => {
+    const result = split("", "");
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  test("literal string with multiple character separator", () => {
+    const result = split("a--b--c", "--");
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c"]>();
+  });
+
+  test("negative limit", () => {
+    const result = split("a,b,c", ",", -1);
+    expectTypeOf(result).toEqualTypeOf<["a", "b", "c"]>();
+  });
+
+  test("fractional limits", () => {
+    const result = split("a,b,c", ",", 1.5);
+    expectTypeOf(result).toEqualTypeOf<Array<string>>();
+  });
+
+  test("0 limit", () => {
+    const result = split("a,b,c", ",", 0);
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+});

--- a/src/split.ts
+++ b/src/split.ts
@@ -1,0 +1,114 @@
+import type {
+  ArraySlice,
+  IsFloat,
+  NonNegative,
+  Split as SplitBase,
+} from "type-fest";
+
+type Split<
+  S extends string,
+  Separator extends string,
+  N extends number | undefined = undefined,
+> = string extends S
+  ? Array<string>
+  : string extends Separator
+    ? Array<string>
+    : number extends N
+      ? Array<string>
+      : // TODO: We need a way to "floor" non-integer numbers, until then we return a lower fidelity type instead.
+        IsFloat<N> extends true
+        ? Array<string>
+        : ArraySlice<
+            // We can use the base (type-fest) split **only** if all the params
+            // are literals. For all other cases it would return the wrong type
+            // so we fallback to the built-in Array.prototype.split return type.
+            SplitBase<S, Separator>,
+            0,
+            // `undefined` and negative numbers are treated as non-limited
+            // splits, which is what we'd get when using `never` for ArraySlice.
+            N extends number ? NonNegative<N> : never
+          >;
+
+/**
+ * Takes a pattern and divides this string into an ordered list of substrings by
+ * searching for the pattern, puts these substrings into an array, and returns
+ * the array. This function mirrors the built-in [`String.prototype.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)
+ * method.
+ *
+ * @param data - The string to split.
+ * @param separator - The pattern describing where each split should occur. Can
+ * be a string, or a regular expression.
+ * @param limit - A non-negative integer specifying a limit on the number of
+ * substrings to be included in the array. If provided, splits the string at
+ * each occurrence of the specified separator, but stops when limit entries have
+ * been placed in the array. Any leftover text is not included in the array at
+ * all. The array may contain fewer entries than limit if the end of the string
+ * is reached before the limit is reached. If limit is 0, [] is returned.
+ * @returns An Array of strings, split at each point where the separator occurs
+ * in the given string.
+ * @signature
+ *   R.split(data, separator, limit);
+ * @example
+ *   R.split("a,b,c", ","); //=> ["a", "b", "c"]
+ *   R.split("a,b,c", ",", 2); //=> ["a", "b"]
+ *   R.split("a1b2c3d", /\d/u); //=> ["a", "b", "c", "d"]
+ * @dataFirst
+ * @category String
+ */
+export function split(
+  data: string,
+  separator: RegExp,
+  limit?: number,
+): Array<string>;
+export function split<
+  S extends string,
+  Separator extends string,
+  N extends number | undefined = undefined,
+>(data: S, separator: Separator, limit?: N): Split<S, Separator, N>;
+
+/**
+ * Takes a pattern and divides this string into an ordered list of substrings by
+ * searching for the pattern, puts these substrings into an array, and returns
+ * the array. This function mirrors the built-in [`String.prototype.split`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split)
+ * method.
+ *
+ * @param separator - The pattern describing where each split should occur. Can
+ * be a string, or a regular expression.
+ * @param limit - A non-negative integer specifying a limit on the number of
+ * substrings to be included in the array. If provided, splits the string at
+ * each occurrence of the specified separator, but stops when limit entries have
+ * been placed in the array. Any leftover text is not included in the array at
+ * all. The array may contain fewer entries than limit if the end of the string
+ * is reached before the limit is reached. If limit is 0, [] is returned.
+ * @returns An Array of strings, split at each point where the separator occurs
+ * in the given string.
+ * @signature
+ *   R.split(separator, limit)(data);
+ * @example
+ *   R.pipe("a,b,c", R.split(",")); //=> ["a", "b", "c"]
+ *   R.pipe("a,b,c", R.split(",", 2)); //=> ["a", "b"]
+ *   R.pipe("a1b2c3d", R.split(/\d/u)); //=> ["a", "b", "c", "d"]
+ * @dataLast
+ * @category String
+ */
+export function split(
+  separator: RegExp,
+  limit?: number,
+): (data: string) => Array<string>;
+export function split<
+  S extends string,
+  Separator extends string,
+  N extends number | undefined = undefined,
+>(separator: Separator, limit?: N): (data: S) => Split<S, Separator, N>;
+
+export function split(
+  dataOrSeparator: RegExp | string,
+  separatorOrLimit?: RegExp | number | string,
+  limit?: number,
+): unknown {
+  return typeof separatorOrLimit === "number" || separatorOrLimit === undefined
+    ? // dataLast
+      (data: string) => data.split(dataOrSeparator, separatorOrLimit)
+    : // dataFirst
+      (dataOrSeparator as string).split(separatorOrLimit, limit);
+}


### PR DESCRIPTION
Using the type-fest split type, but extending it to support arbitrary strings, and to include the limit param.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---
