### PR TITLE
docs: Fix mobile navbar

### DIFF
--- a/docs/src/components/docs-page-nav.astro
+++ b/docs/src/components/docs-page-nav.astro
@@ -7,7 +7,7 @@ import { VERSIONS } from "./version-selector";
 import { getArticlesForPath } from "@/lib/docs";
 import { getMappingEntries } from "@/lib/mappings";
 
-const MIGRATION_REGEXP = /^\/migrate\/(?<library>\w+)$/iu;
+const MIGRATION_REGEXP = /^\/migrate\/(?<library>\w+)\/?$/iu;
 
 const { pathname } = Astro.url;
 const normalizedPathname = pathname.replace(/\/$/, "");

--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -15,10 +15,9 @@ import MigrationSelector from "./migration-selector.astro";
   >
     <a href="/" class="font-bold">Remeda</a>
     <NavLink href="/docs" additionalHrefs={["/v1"]}>Documentation</NavLink>
-    <MigrationSelector
-      ><NavLink directory as="span" href="/migrate">Migration Guides</NavLink
-      ></MigrationSelector
-    >
+    <MigrationSelector>
+      <NavLink directory as="span" href="/migrate"> Migration Guides </NavLink>
+    </MigrationSelector>
     <div class="flex-1"></div>
     <a
       href="https://github.com/remeda/remeda"

--- a/docs/src/components/migration-selector-island.tsx
+++ b/docs/src/components/migration-selector-island.tsx
@@ -17,7 +17,9 @@ export function MigrationSelectorIsland({
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <button type="button">{children}</button>
+        <button type="button" className="truncate">
+          {children}
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         {libraries.map((library) => (

--- a/docs/src/components/migration-selector.astro
+++ b/docs/src/components/migration-selector.astro
@@ -5,6 +5,6 @@ import { MigrationSelectorIsland } from "./migration-selector-island";
 const libraries = await getLibraries();
 ---
 
-<MigrationSelectorIsland client:load libraries={libraries}
-  ><slot /></MigrationSelectorIsland
->
+<MigrationSelectorIsland client:load libraries={libraries}>
+  <slot />
+</MigrationSelectorIsland>


### PR DESCRIPTION
Netlify are rewriting URLs to always have a terminal backslash (/). This breaks the regex we use to detect the migration pages for the mobile nav bar.

I also added some more overflow detection.