### PR TITLE
feat(forEach): pass complex array shapes thru the pipe

### DIFF
--- a/src/forEach.test.ts
+++ b/src/forEach.test.ts
@@ -1,3 +1,4 @@
+import { doNothing } from "./doNothing";
 import { forEach } from "./forEach";
 import { pipe } from "./pipe";
 import { take } from "./take";
@@ -18,7 +19,9 @@ describe("runtime", () => {
     const data = [1, 2, 3];
     const cb = vi.fn();
 
-    const result = forEach(cb)(data);
+    // Because the callback is used before the data, we need to tell forEach
+    // what the expected type for the result is.
+    const result = forEach<typeof data>(cb)(data);
 
     expect(cb).toHaveBeenCalledWith(1, 0, data);
     expect(cb).toHaveBeenCalledWith(2, 1, data);
@@ -30,7 +33,10 @@ describe("runtime", () => {
 
   test("pipe", () => {
     const data = [1, 2, 3];
-    const cb = vi.fn();
+
+    // Callbacks take their type from the pipe itself, but because we construct
+    // it here outside of the pipe, we need to deliberately type it.
+    const cb = vi.fn((x: number) => x);
 
     const result = pipe(data, forEach(cb));
 
@@ -39,7 +45,7 @@ describe("runtime", () => {
     expect(cb).toHaveBeenCalledWith(3, 2, data);
 
     expect(result).toStrictEqual(data);
-    // The pipe reconstructs the array.
+    // The pipe reconstructs the array because it runs lazily.
     expect(result).not.toBe(data);
   });
 
@@ -54,5 +60,38 @@ describe("runtime", () => {
     );
     expect(count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 2]);
+  });
+});
+
+describe("typing", () => {
+  it("doesn't return anything on dataFirst invocations", () => {
+    const result = forEach([1, 2, 3], doNothing());
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- Intentionally
+    expectTypeOf(result).toEqualTypeOf<void>();
+  });
+
+  it("passes the item type to the callback", () => {
+    pipe(
+      [1, 2, 3] as const,
+      forEach((x) => {
+        expectTypeOf(x).toEqualTypeOf<1 | 2 | 3>();
+      }),
+    );
+  });
+
+  it("maintains the array shape", () => {
+    const data = [1, "a"] as [1 | 2, "a" | "b", ...Array<boolean>];
+
+    pipe(data, forEach(doNothing()), (x) => {
+      expectTypeOf(x).toEqualTypeOf<[1 | 2, "a" | "b", ...Array<boolean>]>();
+    });
+  });
+
+  it("makes the result mutable", () => {
+    const data = [] as ReadonlyArray<number>;
+
+    pipe(data, forEach(doNothing()), (x) => {
+      expectTypeOf(x).toEqualTypeOf<Array<number>>();
+    });
   });
 });

--- a/src/forEach.test.ts
+++ b/src/forEach.test.ts
@@ -19,8 +19,8 @@ describe("runtime", () => {
     const data = [1, 2, 3];
     const cb = vi.fn();
 
-    // Because the callback is used before the data, we need to tell forEach
-    // what the expected type for the result is.
+    // Because the callback is used before forEach "sees" `data`, we need to
+    // explicitly tell it the how to type the `data` param..
     const result = forEach<typeof data>(cb)(data);
 
     expect(cb).toHaveBeenCalledWith(1, 0, data);

--- a/src/forEach.ts
+++ b/src/forEach.ts
@@ -1,3 +1,5 @@
+import { type Writable } from "type-fest";
+import { type IterableContainer } from "./internal/types";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
@@ -22,9 +24,9 @@ import { purry } from "./purry";
  * @lazy
  * @category Array
  */
-export function forEach<T>(
-  data: ReadonlyArray<T>,
-  callbackfn: (value: T, index: number, data: ReadonlyArray<T>) => void,
+export function forEach<T extends IterableContainer>(
+  data: T,
+  callbackfn: (value: T[number], index: number, data: T) => void,
 ): void;
 
 /**
@@ -50,9 +52,9 @@ export function forEach<T>(
  * @lazy
  * @category Array
  */
-export function forEach<T>(
-  callbackfn: (value: T, index: number, data: ReadonlyArray<T>) => void,
-): (data: ReadonlyArray<T>) => Array<T>;
+export function forEach<T extends IterableContainer>(
+  callbackfn: (value: T[number], index: number, data: T) => void,
+): (data: T) => Writable<T>;
 
 export function forEach(...args: ReadonlyArray<unknown>): unknown {
   return purry(forEachImplementation, args, lazyImplementation);


### PR DESCRIPTION
The current implementation takes T as the array item type, and not the array type itself; this prevents us from using the shape in the returned type, which means we can't reconstruct the same shape on output.

This change is inline with how we treat array functions that return the sampe shape (like `map`).

The problem with this typing scheme is that it breaks non-piped ("function factory") dataLast invocations, where previously the type could be inferred from the param type of the callback (see test), but this is OK because that isn't a use-case we care about in the lib (as it doesn't seem very useful). This is the reason I called this a "feat" and not a "fix" in the semantic commits convention, so that it bumps the minor version and not just the patch version.