### PR TITLE
docs: add migration guide in a more obvious place

### DIFF
--- a/docs/src/components/migration-selector-island.tsx
+++ b/docs/src/components/migration-selector-island.tsx
@@ -22,6 +22,9 @@ export function MigrationSelectorIsland({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
+        <DropdownMenuItem>
+          <a href={`/v1`}>Migrate from 1.x to 2.x</a>
+        </DropdownMenuItem>
         {libraries.map((library) => (
           <DropdownMenuItem key={library} className="capitalize">
             <a href={`/migrate/${library}`}>{library}</a>


### PR DESCRIPTION
I recently migrated to the second version. And I think these days this link is more important than migration from other libraries :)

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
