### PR TITLE
docs(isObjectType): fix typedoc

### DIFF
--- a/src/isObjectType.ts
+++ b/src/isObjectType.ts
@@ -25,6 +25,8 @@ import type { NarrowedTo } from "./internal/types";
  * @dataFirst
  * @category Guard
  */
-export const isObjectType = <T>(
+export function isObjectType<T>(
   data: T | object,
-): data is NarrowedTo<T, object> => typeof data === "object" && data !== null;
+): data is NarrowedTo<T, object> {
+  return typeof data === "object" && data !== null;
+}


### PR DESCRIPTION
Closed https://github.com/remeda/remeda/issues/766

I'm not sure how it works, but `typedoc` generates different formats for a constant and a function, which is why the data in `data.json` for this function is different from the others and is filtered during the `transform` process.

---

Make sure that you:

- [ ] Typedoc added for new methods and updated for changed
- [ ] Tests added for new methods and updated for changed
- [ ] New methods added to `src/index.ts`
- [ ] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
