### PR TITLE
docs: shorten menu item label for v1 migration guide

### DIFF
--- a/docs/src/components/migration-selector-island.tsx
+++ b/docs/src/components/migration-selector-island.tsx
@@ -2,6 +2,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { Library } from "@/lib/mappings";
@@ -23,8 +24,9 @@ export function MigrationSelectorIsland({
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem>
-          <a href={`/v1`}>Migrate from 1.x to 2.x</a>
+          <a href={`/v1`}>Remeda@1.61.0</a>
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {libraries.map((library) => (
           <DropdownMenuItem key={library} className="capitalize">
             <a href={`/migrate/${library}`}>{library}</a>


### PR DESCRIPTION
The current label repeats the "migration" part which is already part of the menu title, and repeats the v2 part which isn't relevant for the viewer.