### PR TITLE
feat(times): Refined typing and improved perf

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   // several built-in patterns that are useful (like package-lock.json).
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.ts": "${capture}.test.ts"
+    "*.ts": "${capture}.*.ts"
   },
 
   // It's better to ensure that the project typescript is the one we use for the

--- a/src/times.bench.ts
+++ b/src/times.bench.ts
@@ -1,0 +1,256 @@
+import { bench } from "vitest";
+import { identity } from "./identity";
+
+const BENCH_OPTIONS = { iterations: 5000 };
+
+const mapper = identity();
+
+describe.each([[10], [100], [1000], [10_000], [-10], [10.5]])(
+  "length %d",
+  (length) => {
+    bench(
+      "sparse array, no checks",
+      () => {
+        try {
+          sparseArray(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "preconstructed array",
+      () => {
+        try {
+          preconstructedArray(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "empty array with index access",
+      () => {
+        try {
+          emptyArrayWithIndexAccess(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "current impl, no check (empty array with push)",
+      () => {
+        try {
+          currentImplementationNoRangeCheck(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "current implementation",
+      () => {
+        try {
+          currentImplementation(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "sparse with negative check",
+      () => {
+        try {
+          sparseArrayWithCheck(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "sparse with floor",
+      () => {
+        try {
+          sparseArrayWithFloor(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "sparse with checked floor",
+      () => {
+        try {
+          sparseArrayWithCheckedFloor(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "sparse with safe checked floor",
+      () => {
+        try {
+          sparseArrayWithSafeCheckedFloor(length, mapper);
+        } catch {
+          // do nothing
+        }
+      },
+      BENCH_OPTIONS,
+    );
+  },
+);
+
+function preconstructedArray<T>(
+  length: number,
+  fn: (n: number) => T,
+): Array<T> {
+  const res = Array.from<T>({ length });
+
+  for (let i = 0; i < length; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}
+
+function emptyArrayWithIndexAccess<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  const res: Array<T> = [];
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+  return res;
+}
+
+function currentImplementation<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  if (count < 0) {
+    throw new RangeError("n must be a non-negative number");
+  }
+
+  const res = [];
+  for (let i = 0; i < count; i++) {
+    res.push(fn(i));
+  }
+
+  return res;
+}
+
+function currentImplementationNoRangeCheck<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  const res = [];
+  for (let i = 0; i < count; i++) {
+    res.push(fn(i));
+  }
+
+  return res;
+}
+
+function sparseArray<T>(count: number, fn: (n: number) => T): Array<T> {
+  // eslint-disable-next-line unicorn/no-new-array
+  const res = new Array<T>(count);
+
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}
+
+function sparseArrayWithCheck<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  if (count < 0) {
+    return [];
+  }
+
+  // eslint-disable-next-line unicorn/no-new-array
+  const res = new Array<T>(count);
+
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}
+
+function sparseArrayWithFloor<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  if (count < 0) {
+    return [];
+  }
+
+  // eslint-disable-next-line unicorn/no-new-array
+  const res = new Array<T>(Math.floor(count));
+
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}
+
+function sparseArrayWithCheckedFloor<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  if (count < 0) {
+    return [];
+  }
+
+  // eslint-disable-next-line unicorn/no-new-array
+  const res = new Array<T>(Number.isInteger(count) ? count : Math.floor(count));
+
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}
+
+function sparseArrayWithSafeCheckedFloor<T>(
+  count: number,
+  fn: (n: number) => T,
+): Array<T> {
+  if (count < 0) {
+    return [];
+  }
+
+  // eslint-disable-next-line unicorn/no-new-array
+  const res = new Array<T>(
+    Number.isSafeInteger(count) ? count : Math.floor(count),
+  );
+
+  for (let i = 0; i < count; i++) {
+    res[i] = fn(i);
+  }
+
+  return res;
+}

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -81,3 +81,75 @@ describe("times", () => {
     });
   });
 });
+
+describe("typing", () => {
+  it("works with 0", () => {
+    const result = times(0, identity());
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it("works with non-literals", () => {
+    const result = times(10 as number, identity());
+    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+  });
+
+  it("works with positive integer literals", () => {
+    const result = times(10, identity());
+    expectTypeOf(result).toEqualTypeOf<
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+      ]
+    >();
+  });
+
+  it("works with negative integers", () => {
+    const result = times(-10, identity());
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it("works with non-integer positive literals", () => {
+    const result = times(10.5, identity());
+    expectTypeOf(result).toEqualTypeOf<
+      [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+      ]
+    >();
+  });
+
+  it("works with non-integer negative literals", () => {
+    const result = times(-10.5, identity());
+    expectTypeOf(result).toEqualTypeOf<[]>();
+  });
+
+  it("works with literal unions", () => {
+    const result = times(1 as 1 | 3, identity());
+    expectTypeOf(result).toEqualTypeOf<[number, number, number] | [number]>();
+  });
+
+  it("could be 'disabled' with large literals", () => {
+    const largeNumber = 10_000;
+
+    // @ts-expect-error [ts(2589)] - Intentionally bringing typescript to it's limits
+    times(largeNumber, identity());
+
+    times(largeNumber as number, identity());
+  });
+});

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -1,26 +1,26 @@
+import { constant } from "./constant";
+import { identity } from "./identity";
+import { multiply } from "./multiply";
+import { pipe } from "./pipe";
 import { times } from "./times";
-
-const noop = (): undefined => undefined;
-const one = () => 1 as const;
-const mul1 = (idx: number): number => idx;
-const mul2 = (idx: number): number => idx * 2;
 
 describe("times", () => {
   describe("data_first", () => {
-    it("throws error on invalid idx", () => {
-      expect(() => times(-1, noop)).toThrow();
-      expect(() => times(-1000, noop)).toThrow();
-      expect(() => times(Number.MIN_SAFE_INTEGER, noop)).toThrow();
+    it("returns a trivial empty array for non-positive values", () => {
+      const zeroResult = times(0, identity());
+      expect(zeroResult).toStrictEqual([]);
+
+      const negativeResult = times(-1000, identity());
+      expect(negativeResult).toStrictEqual([]);
+
+      // Make sure that the array returned is new, and not the same copy.
+      expect(zeroResult).not.toBe(negativeResult);
+
+      expect(times(-5.5, identity())).toStrictEqual([]);
     });
 
-    it("returns empty array", () => {
-      const res = times(0, noop);
-      expect(res).toEqual([]);
-    });
-
-    it("returns arr with fn result", () => {
-      expect(times(1, one)).toEqual([1]);
-      expect(times(5, one)).toEqual([1, 1, 1, 1, 1]);
+    it("creates an array of the correct length", () => {
+      expect(times(123 as number, constant(1))).toHaveLength(123);
     });
 
     it("passes idx to fn", () => {
@@ -34,33 +34,36 @@ describe("times", () => {
     });
 
     it("returns fn results as arr", () => {
-      expect(times(5, mul1)).toEqual([0, 1, 2, 3, 4]);
-      expect(times(5, mul2)).toEqual([0, 2, 4, 6, 8]);
+      expect(times(5, identity())).toStrictEqual([0, 1, 2, 3, 4]);
+      expect(times(5, multiply(2))).toStrictEqual([0, 2, 4, 6, 8]);
+    });
+
+    it("rounds down non-integer numbers", () => {
+      expect(times(5.5, identity())).toStrictEqual([0, 1, 2, 3, 4]);
     });
   });
 
   describe("data_last", () => {
-    it("throws error on invalid idx", () => {
-      const noopTimes = times(noop);
-      expect(() => noopTimes(-1)).toThrow();
-      expect(() => noopTimes(-1000)).toThrow();
-      expect(() => noopTimes(Number.MIN_SAFE_INTEGER)).toThrow();
+    it("returns a trivial empty array for non-positive values", () => {
+      const zeroResult = pipe(0, times(identity()));
+      expect(zeroResult).toStrictEqual([]);
+
+      const negativeResult = pipe(-1000, times(identity()));
+      expect(negativeResult).toStrictEqual([]);
+
+      // Make sure that the array returned is new, and not the same copy.
+      expect(zeroResult).not.toBe(negativeResult);
+
+      expect(pipe(-5.5, times(identity()))).toStrictEqual([]);
     });
 
-    it("returns empty array", () => {
-      const res = times(noop)(0);
-      expect(res).toEqual([]);
-    });
-
-    it("returns arr with fn result", () => {
-      const oneTime = times(one);
-      expect(oneTime(1)).toEqual([1]);
-      expect(oneTime(5)).toEqual([1, 1, 1, 1, 1]);
+    it("creates an array of the correct length", () => {
+      expect(pipe(123 as number, times(constant(1)))).toHaveLength(123);
     });
 
     it("passes idx to fn", () => {
       const fn = vi.fn();
-      times(fn)(5);
+      pipe(5, times(fn));
       expect(fn).toHaveBeenCalledWith(0);
       expect(fn).toHaveBeenCalledWith(1);
       expect(fn).toHaveBeenCalledWith(2);
@@ -69,8 +72,12 @@ describe("times", () => {
     });
 
     it("returns fn results as arr", () => {
-      expect(times(mul1)(5)).toEqual([0, 1, 2, 3, 4]);
-      expect(times(mul2)(5)).toEqual([0, 2, 4, 6, 8]);
+      expect(pipe(5, times(identity()))).toStrictEqual([0, 1, 2, 3, 4]);
+      expect(pipe(5, times(multiply(2)))).toStrictEqual([0, 2, 4, 6, 8]);
+    });
+
+    it("rounds down non-integer numbers", () => {
+      expect(pipe(5.5, times(identity()))).toStrictEqual([0, 1, 2, 3, 4]);
     });
   });
 });

--- a/src/times.ts
+++ b/src/times.ts
@@ -26,8 +26,15 @@ type TimesArray<
  * `fn` is passed one argument: The current value of `n`, which begins at `0`
  * and is gradually incremented to `n - 1`.
  *
- * @param count - A value between `0` and `n - 1`. Increments after each function call.
- * @param fn - The function to invoke. Passed one argument, the current value of `n`.
+ * NOTE: The function returns a strict tuple with exactly N elements in it, but
+ * for very large literals TypeScript might not be able to compute it, for those
+ * cases cast the number to a primitive `number` (e.g. `1000 as number`) to
+ * bypass the refined typing.
+ *
+ * @param count - A value between `0` and `n - 1`. Increments after each
+ * function call.
+ * @param fn - The function to invoke. Passed one argument, the current value of
+ * `n`.
  * @returns An array containing the return values of all calls to `fn`.
  * @signature
  *    R.times(count, fn)
@@ -48,7 +55,13 @@ export function times<T, N extends number>(
  * `fn` is passed one argument: The current value of `n`, which begins at `0`
  * and is gradually incremented to `n - 1`.
  *
- * @param fn - The function to invoke. Passed one argument, the current value of `n`.
+ * NOTE: The function returns a strict tuple with exactly N elements in it, but
+ * for very large literals TypeScript might not be able to compute it, for those
+ * cases cast the number to a primitive `number` (e.g. `1000 as number`) to
+ * bypass the refined typing.
+ *
+ * @param fn - The function to invoke. Passed one argument, the current value of
+ * `n`.
  * @returns An array containing the return values of all calls to `fn`.
  * @signature
  *    R.times(fn)(count)

--- a/src/times.ts
+++ b/src/times.ts
@@ -42,13 +42,22 @@ export function times(...args: ReadonlyArray<unknown>): unknown {
 }
 
 function timesImplementation<T>(count: number, fn: (n: number) => T): Array<T> {
-  if (count < 0) {
-    throw new RangeError("n must be a non-negative number");
+  if (count < 1) {
+    // We prefer to return trivial results on trivial inputs vs throwing errors.
+    return [];
   }
 
-  const res = [];
+  // eslint-disable-next-line unicorn/no-new-array -- This is the most efficient way to create the array, check out the benchmarks in the PR that added this comment.
+  const res = new Array<T>(
+    // Non-integer numbers would cause `new Array` to throw, but it makes more
+    // sense to simply round them down to the nearest integer instead; but
+    // rounding has some performance implications so we only do it when we have
+    // to.
+    Number.isInteger(count) ? count : Math.floor(count),
+  );
+
   for (let i = 0; i < count; i++) {
-    res.push(fn(i));
+    res[i] = fn(i);
   }
 
   return res;


### PR DESCRIPTION
The current typing implementation doesn't use the provided size param to build the output, this means that even for cases like times(5, ...) our returned array type is not non-empty.

I also noticed that we are throwing on "invalid" inputs in a way which doesn't conform with how we handle these kind of cases in other functions. Instead, we should almost always fallback to a runtime behaviour that makes sense, especially when a semanticly correct option exists, and even more so when we can make the types work for it too.

Looking into this fix, I also wanted to try sparse arrays again, we have a lint rule which might not make sense for us driving us away from sparse arrays and it might not always be the right call. For this function we can get performance benefits of about 2x-3x on large arrays using sparse arrays.
I added a bunch of benchmarks to see what implementation is the best. I will remove them before the merge because they won't make sense once this PR is approved.