### PR TITLE
feat(shuffle): Maintain input shape

### DIFF
--- a/src/shuffle.test-d.ts
+++ b/src/shuffle.test-d.ts
@@ -1,0 +1,44 @@
+import { pipe } from "./pipe";
+import { shuffle } from "./shuffle";
+
+test("regular array", () => {
+  const result = shuffle([] as Array<string>);
+  expectTypeOf(result).toEqualTypeOf<Array<string>>();
+});
+
+test("non-empty tail-rest array", () => {
+  const result = shuffle([1] as [number, ...Array<number>]);
+  expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
+});
+
+test("non-empty head-rest array", () => {
+  const result = shuffle([1] as [...Array<number>, number]);
+  expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
+});
+
+test("fixed size tuple", () => {
+  const result = shuffle([1, "a", true] as [number, string, boolean]);
+  expectTypeOf(result).toEqualTypeOf<
+    [
+      boolean | number | string,
+      boolean | number | string,
+      boolean | number | string,
+    ]
+  >();
+});
+
+it("removes readonlyness from array", () => {
+  const result = shuffle([] as ReadonlyArray<string>);
+  expectTypeOf(result).toEqualTypeOf<Array<string>>();
+});
+
+it("infers type via a pipe", () => {
+  const result = pipe(["a", 1, true] as [string, number, boolean], shuffle());
+  expectTypeOf(result).toEqualTypeOf<
+    [
+      boolean | number | string,
+      boolean | number | string,
+      boolean | number | string,
+    ]
+  >();
+});

--- a/src/shuffle.test.ts
+++ b/src/shuffle.test.ts
@@ -1,40 +1,33 @@
-import { filter } from "./filter";
-import { isIncludedIn } from "./isIncludedIn";
-import { isNot } from "./isNot";
+import { difference } from "./difference";
 import { pipe } from "./pipe";
 import { shuffle } from "./shuffle";
 
-describe("data_first", () => {
-  test("shuffle", () => {
-    const input = [4, 2, 7, 5] as const;
+test("data-first", () => {
+  const input = [4, 2, 7, 5] as const;
 
-    const shuffled = shuffle(input);
+  const shuffled = shuffle(input);
 
-    // Shuffled array has the same items
-    expect(shuffled.length).toEqual(4);
-    expect(difference(input, shuffled).length).toEqual(0);
-    expect(difference(shuffled, input).length).toEqual(0);
+  // Shuffled array has the same items
+  expect(shuffled).toHaveLength(4);
+  expect(difference(input, shuffled)).toHaveLength(0);
+  expect(difference(shuffled, input)).toHaveLength(0);
 
-    // Original array not mutated
-    expect(input).toEqual([4, 2, 7, 5]);
-  });
+  // Original array not mutated
+  expect(shuffled).not.toBe(input);
+  expect(input).toStrictEqual([4, 2, 7, 5]);
 });
 
-describe("data_last", () => {
-  test("shuffle", () => {
-    const input = [4, 2, 7, 5] as const;
+test("data-last", () => {
+  const input = [4, 2, 7, 5] as const;
 
-    const shuffled = pipe(input, shuffle());
+  const shuffled = pipe(input, shuffle());
 
-    // Shuffled array has the same items
-    expect(shuffled.length).toEqual(4);
-    expect(difference(input, shuffled).length).toEqual(0);
-    expect(difference(shuffled, input).length).toEqual(0);
+  // Shuffled array has the same items
+  expect(shuffled).toHaveLength(4);
+  expect(difference(input, shuffled)).toHaveLength(0);
+  expect(difference(shuffled, input)).toHaveLength(0);
 
-    // Original array not mutated
-    expect(input).toEqual([4, 2, 7, 5]);
-  });
+  // Original array not mutated
+  expect(shuffled).not.toBe(input);
+  expect(input).toStrictEqual([4, 2, 7, 5]);
 });
-
-const difference = <T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): Array<T> =>
-  filter(a, isNot(isIncludedIn(b)));

--- a/src/shuffle.ts
+++ b/src/shuffle.ts
@@ -1,3 +1,4 @@
+import { type IterableContainer, type ReorderedArray } from "./internal/types";
 import { purry } from "./purry";
 
 /**
@@ -11,7 +12,9 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Array
  */
-export function shuffle<T>(items: ReadonlyArray<T>): Array<T>;
+export function shuffle<T extends IterableContainer>(
+  items: T,
+): ReorderedArray<T>;
 
 /**
  * Shuffles the input array, returning a new array with the same elements in a random order.
@@ -23,7 +26,9 @@ export function shuffle<T>(items: ReadonlyArray<T>): Array<T>;
  * @dataLast
  * @category Array
  */
-export function shuffle<T>(): (items: ReadonlyArray<T>) => Array<T>;
+export function shuffle(): <T extends IterableContainer>(
+  items: T,
+) => ReorderedArray<T>;
 
 export function shuffle(...args: ReadonlyArray<unknown>): unknown {
   return purry(shuffleImplementation, args);


### PR DESCRIPTION
Currently we reconstruct the output from the input member types.

Instead we can use the input type itself to build the output. This allows us to pass through qualities of the input like non-emptyness to the output.

In other words, shuffle should have the same return type as sortBy because it is effectively a sortBy a random number, so it can use the same return type.