### PR TITLE
fix(clone): Support File instances

### DIFF
--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -152,6 +152,20 @@ describe("built-in types", () => {
     expect(cloned.ignoreCase).toStrictEqual(pattern.ignoreCase);
     expect(cloned.multiline).toStrictEqual(pattern.multiline);
   });
+
+  it("clones File objects", async () => {
+    const content = "Hello, World!";
+    const file = new File([content], "foo.txt", { type: "text/plain" });
+    const cloned = clone(file);
+
+    expect(cloned.size).toBe(file.size);
+    expect(cloned.type).toBe(file.type);
+    expect(await cloned.text()).toBe(content);
+
+    // These aren't cloned!
+    expect(cloned.name).toBe(undefined);
+    expect(cloned.lastModified).toBe(undefined);
+  });
 });
 
 describe("nested mixed objects", () => {

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -50,7 +50,8 @@ function cloneImplementation<T>(
     typeof value !== "object" ||
     value === null ||
     value instanceof Date ||
-    value instanceof RegExp
+    value instanceof RegExp ||
+    value instanceof File
   ) {
     // We can use the built-in deep cloning function.
     return structuredClone(value);


### PR DESCRIPTION
Fixes: #782

Exempting File instances like we with the other built-in types Date and RegExp...

I don't know exactly what the use-case is for cloning a File, so can't say if using structuredClone is the right approach here...