### PR TITLE
fix(build): remove test files from package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: 🔎 Type check
-        run: npm run typecheck
+        run: npm run check
 
   test-typing:
     name: Tests/📋 Types [TypeScript ${{ matrix.typescript-version }}]
@@ -69,7 +69,7 @@ jobs:
         run: npm run test:typing
 
       - name: 🚚 Check Outputs
-        run: npm run typecheck:dist
+        run: npm run check:dist
 
   test-runtime:
     name: Tests/🧪 Runtime [Node ${{ matrix.node }}]

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,7 +4,7 @@ export default {
   // array) so that no matter what file or how many, we will always run the same
   // command.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types -- this is stupid...
-  "*.ts?(x)": () => "npm run typecheck",
+  "*.ts?(x)": () => "npm run check",
 
   // Javascript and Typescript (including commonJs and esm variants)
   "*.@(js|jsx|ts|tsx|cjs|mjs)": ["eslint --fix", "prettier --write"],

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   ],
   "scripts": {
     "build": "tsup",
+    "check": "tsc --project tsconfig.source.json",
+    "check:dist": "tsc --project tsconfig.dist.json",
     "coverage": "vitest run --coverage",
     "docs:build": "cd docs && npm ci && npm run build:all",
     "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/ .",
@@ -56,9 +58,7 @@
     "release": "semantic-release",
     "test": "tsc --project tsconfig.tests.json && vitest --typecheck.enabled --typecheck.ignoreSourceErrors",
     "test:runtime": "tsc --project tsconfig.tests.json && vitest",
-    "test:typing": "vitest --typecheck.only --typecheck.ignoreSourceErrors",
-    "typecheck": "tsc --project tsconfig.source.json",
-    "typecheck:dist": "tsc --project tsconfig.dist.json"
+    "test:typing": "vitest --typecheck.only --typecheck.ignoreSourceErrors"
   },
   "dependencies": {
     "type-fest": "^4.21.0"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -39,7 +39,10 @@ async function getEntries(sourceDirectory: string): Promise<Array<string>> {
   const files = await ts.readdir(sourceDirectory);
   return files
     .filter(
-      (fileName) => fileName.endsWith(".ts") && !fileName.endsWith(".test.ts"),
+      (fileName) =>
+        fileName.endsWith(".ts") &&
+        !fileName.endsWith(".test.ts") &&
+        !fileName.endsWith(".test-d.ts"),
     )
     .map((fileName) => path.join(sourceDirectory, fileName));
 }


### PR DESCRIPTION
Since #774 was shipped we have been including `test-d.ts` in our build artifact.

I also renamed the "typecheck" script to "check" to match the script that does the same thing in the docs project.