### PR TITLE
docs: Updates type hints in functional data last example

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -110,9 +110,9 @@ const DATA = [
 R.pipe(
   DATA,
   R.filter((x) => x.gender === "f"),
-  //              ^? 😔 'x' is of type 'unknown'
+  //              ^? (parameter) x: { name: string, age: number; gender: string }
   R.groupBy((x) => x.age),
-  //                 ^? 😔 Property 'age' does not exist on type 'P'
+  //                 ^? (property) age: number
 );
 
 // Ramda

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -132,7 +132,7 @@ _.flow(
   _.filter((x) => x.gender === "f"),
   //              ^? 😔 'x' is of type 'unknown'
   _.groupBy((x) => x.age),
-  //                 ^? 😔 Property 'age' does not exist on type 'P'
+  //               ^? 😔 'x' is of type 'unknown'
 )(DATA);
 ```
 

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -110,15 +110,15 @@ const DATA = [
 R.pipe(
   DATA,
   R.filter((x) => x.gender === "f"),
-  //              ^? (parameter) x: { name: string, age: number; gender: string }
   R.groupBy((x) => x.age),
-  //                 ^? (property) age: number
 );
 
 // Ramda
 R.pipe(
   R.filter((x) => x.gender === "f"),
+  //              ^? 😔 'x' is of type 'unknown'
   R.groupBy((x) => x.age),
+  //                 ^? 😔 Property 'age' does not exist on type 'P'
 )(DATA);
 
 // Lodash


### PR DESCRIPTION
Update the type hints (displayed as comments) to reflect that TypeScript does properly infer the types when using Remeda in this example.
