### PR TITLE
feat(unique, uniqueWith, uniqueBy): Use input shape to improve return type.

### DIFF
--- a/src/internal/types.test-d.ts
+++ b/src/internal/types.test-d.ts
@@ -1,9 +1,11 @@
 import { type EmptyObject } from "type-fest";
 import {
   type Branded,
-  type IfBoundedRecord,
+  type Deduped,
   type EnumerableStringKeyedValueOf,
   type EnumerableStringKeyOf,
+  type IfBoundedRecord,
+  type IterableContainer,
   type NTuple,
   type TupleParts,
 } from "./types";
@@ -467,6 +469,103 @@ describe("TupleParts", () => {
   });
 });
 
+describe("DeDupped", () => {
+  describe("mutable", () => {
+    test("empty array", () => {
+      const result = deduped([] as []);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
+
+    test("simple array", () => {
+      const result = deduped([1, 2, 3] as Array<number>);
+      expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    });
+
+    test("array with prefix", () => {
+      const result = deduped(["a"] as [string, ...Array<number>]);
+      expectTypeOf(result).toEqualTypeOf<[string, ...Array<number>]>();
+    });
+
+    test("array with suffix", () => {
+      const result = deduped(["a"] as [...Array<number>, string]);
+      expectTypeOf(result).toEqualTypeOf<
+        [number | string, ...Array<number | string>]
+      >();
+    });
+
+    test("array with both prefix and suffix", () => {
+      const result = deduped(["a", true] as [
+        string,
+        ...Array<number>,
+        boolean,
+      ]);
+      expectTypeOf(result).toEqualTypeOf<
+        [string, ...Array<boolean | number>]
+      >();
+    });
+
+    test("union of arrays", () => {
+      const result = deduped(["a"] as
+        | [number, ...Array<number>]
+        | [string, ...Array<string>]);
+      expectTypeOf(result).toEqualTypeOf<
+        [number, ...Array<number>] | [string, ...Array<string>]
+      >();
+    });
+  });
+
+  describe("readonly", () => {
+    test("empty array", () => {
+      const result = deduped([] as const);
+      expectTypeOf(result).toEqualTypeOf<[]>();
+    });
+
+    test("simple array", () => {
+      const result = deduped([1, 2, 3] as ReadonlyArray<number>);
+      expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    });
+
+    test("array with prefix", () => {
+      const result = deduped(["a"] as readonly [string, ...Array<number>]);
+      expectTypeOf(result).toEqualTypeOf<[string, ...Array<number>]>();
+    });
+
+    test("array with suffix", () => {
+      const result = deduped(["a"] as readonly [...Array<number>, string]);
+      expectTypeOf(result).toEqualTypeOf<
+        [number | string, ...Array<number | string>]
+      >();
+    });
+
+    test("array with both prefix and suffix", () => {
+      const result = deduped(["a", true] as readonly [
+        string,
+        ...Array<number>,
+        boolean,
+      ]);
+      expectTypeOf(result).toEqualTypeOf<
+        [string, ...Array<boolean | number>]
+      >();
+    });
+
+    test("union of arrays", () => {
+      const result = deduped(["a"] as
+        | readonly [number, ...Array<number>]
+        | readonly [string, ...Array<string>]);
+      expectTypeOf(result).toEqualTypeOf<
+        [number, ...Array<number>] | [string, ...Array<string>]
+      >();
+    });
+
+    test("constant tuple", () => {
+      const result = deduped([1, 2, 3] as const);
+      expectTypeOf(result).toEqualTypeOf<[1, ...Array<2 | 3>]>();
+    });
+  });
+});
+
 declare function nTuple<T, N extends number>(x: T, n: N): NTuple<T, N>;
 
 declare function tupleParts<T>(x: T): TupleParts<T>;
+
+declare function deduped<T extends IterableContainer>(data: T): Deduped<T>;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -276,12 +276,12 @@ export type TupleParts<
       : never;
 
 /**
- * The result of running a function that would dedup an array (e.g. `unique`).
+ * The result of running a function that would dedupe an array (e.g. `unique`).
  *
  * There are certain traits of the output which are unique to a deduped array
  * that allow us to create a better type; see comments inline.
  */
-export type DeDupped<T extends IterableContainer> = T extends readonly []
+export type Deduped<T extends IterableContainer> = T extends readonly []
   ? // An empty input is an empty output.
     []
   : T extends readonly [infer Head, ...infer Rest]

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -274,3 +274,12 @@ export type TupleParts<
           suffix: Suffix;
         }
       : never;
+
+export type Unique<T extends IterableContainer> = T extends readonly [
+  infer Head,
+  ...infer Rest,
+]
+  ? [Head, ...Array<Rest[number]>]
+  : T extends readonly [...Array<unknown>, unknown]
+    ? [T[number], ...Array<T[number]>]
+    : Array<T[number]>;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -276,10 +276,18 @@ export type TupleParts<
       : never;
 
 /**
- * The result of running a function that would dedupe an array (e.g. `unique`).
+ * The result of running a function that would dedupe an array (`unique`,
+ * `uniqueBy`, and `uniqueWith`).
  *
  * There are certain traits of the output which are unique to a deduped array
  * that allow us to create a better type; see comments inline.
+ *
+ * !Note: We can build better types for each of the unique functions
+ * _separately_ by taking advantage of _other_ characteristics that are unique
+ * to each one (e.g. in `unique` we know that each item that has a disjoint type
+ * to all previous items would be part of the output, even when it isn't the
+ * first), but to make this utility the most useful we kept it simple and
+ * generic for now.
  */
 export type Deduped<T extends IterableContainer> = T extends readonly []
   ? // An empty input is an empty output.

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -146,7 +146,6 @@ describe("non-const sampleSize", () => {
 });
 
 function generateRandomArray(): NonEmptyArray<number> {
-  // @ts-expect-error [ts2322]: we know this array isn't empty!
   return unique(times(100, Math.random));
 }
 

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type IterableContainer, type Unique } from "./internal/types";
+import { type DeDupped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -16,7 +16,7 @@ import type { LazyEvaluator } from "./pipe";
  * @lazy
  * @category Array
  */
-export function unique<T extends IterableContainer>(data: T): Unique<T>;
+export function unique<T extends IterableContainer>(data: T): DeDupped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -34,7 +34,7 @@ export function unique<T extends IterableContainer>(data: T): Unique<T>;
  * @lazy
  * @category Array
  */
-export function unique(): <T extends IterableContainer>(data: T) => Unique<T>;
+export function unique(): <T extends IterableContainer>(data: T) => DeDupped<T>;
 
 export function unique(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type DeDupped, type IterableContainer } from "./internal/types";
+import { type Deduped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -16,7 +16,7 @@ import type { LazyEvaluator } from "./pipe";
  * @lazy
  * @category Array
  */
-export function unique<T extends IterableContainer>(data: T): DeDupped<T>;
+export function unique<T extends IterableContainer>(data: T): Deduped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -34,7 +34,7 @@ export function unique<T extends IterableContainer>(data: T): DeDupped<T>;
  * @lazy
  * @category Array
  */
-export function unique(): <T extends IterableContainer>(data: T) => DeDupped<T>;
+export function unique(): <T extends IterableContainer>(data: T) => Deduped<T>;
 
 export function unique(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/unique.ts
+++ b/src/unique.ts
@@ -1,4 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
+import { type IterableContainer, type Unique } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -6,7 +7,7 @@ import type { LazyEvaluator } from "./pipe";
  * Returns a new array containing only one copy of each element in the original
  * list. Elements are compared by reference using Set.
  *
- * @param array - The array to filter.
+ * @param data - The array to filter.
  * @signature
  *    R.unique(array)
  * @example
@@ -15,7 +16,7 @@ import type { LazyEvaluator } from "./pipe";
  * @lazy
  * @category Array
  */
-export function unique<T>(array: ReadonlyArray<T>): Array<T>;
+export function unique<T extends IterableContainer>(data: T): Unique<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -33,7 +34,7 @@ export function unique<T>(array: ReadonlyArray<T>): Array<T>;
  * @lazy
  * @category Array
  */
-export function unique<T>(): (array: ReadonlyArray<T>) => Array<T>;
+export function unique(): <T extends IterableContainer>(data: T) => Unique<T>;
 
 export function unique(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueBy.ts
+++ b/src/uniqueBy.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type DeDupped, type IterableContainer } from "./internal/types";
+import { type Deduped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -23,7 +23,7 @@ import type { LazyEvaluator } from "./pipe";
 export function uniqueBy<T extends IterableContainer, K>(
   data: T,
   keyFunction: (item: T[number], index: number, data: T) => K,
-): DeDupped<T>;
+): Deduped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -44,7 +44,7 @@ export function uniqueBy<T extends IterableContainer, K>(
  */
 export function uniqueBy<T extends IterableContainer, K>(
   keyFunction: (item: T[number], index: number, data: T) => K,
-): (data: T) => DeDupped<T>;
+): (data: T) => Deduped<T>;
 
 export function uniqueBy(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueBy.ts
+++ b/src/uniqueBy.ts
@@ -1,4 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
+import { type IterableContainer, type Unique } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -19,10 +20,10 @@ import type { LazyEvaluator } from "./pipe";
  * @lazy
  * @category Array
  */
-export function uniqueBy<T, K>(
-  data: ReadonlyArray<T>,
-  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
-): Array<T>;
+export function uniqueBy<T extends IterableContainer, K>(
+  data: T,
+  keyFunction: (item: T[number], index: number, data: T) => K,
+): Unique<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -41,9 +42,9 @@ export function uniqueBy<T, K>(
  * @lazy
  * @category Array
  */
-export function uniqueBy<T, K>(
-  keyFunction: (item: T, index: number, data: ReadonlyArray<T>) => K,
-): (data: ReadonlyArray<T>) => Array<T>;
+export function uniqueBy<T extends IterableContainer, K>(
+  keyFunction: (item: T[number], index: number, data: T) => K,
+): (data: T) => Unique<T>;
 
 export function uniqueBy(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueBy.ts
+++ b/src/uniqueBy.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type IterableContainer, type Unique } from "./internal/types";
+import { type DeDupped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 
@@ -23,7 +23,7 @@ import type { LazyEvaluator } from "./pipe";
 export function uniqueBy<T extends IterableContainer, K>(
   data: T,
   keyFunction: (item: T[number], index: number, data: T) => K,
-): Unique<T>;
+): DeDupped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -44,7 +44,7 @@ export function uniqueBy<T extends IterableContainer, K>(
  */
 export function uniqueBy<T extends IterableContainer, K>(
   keyFunction: (item: T[number], index: number, data: T) => K,
-): (data: T) => Unique<T>;
+): (data: T) => DeDupped<T>;
 
 export function uniqueBy(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -1,4 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
+import { type IterableContainer, type Unique } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { type LazyEvaluator } from "./pipe";
 
@@ -21,10 +22,10 @@ type IsEquals<T> = (a: T, b: T) => boolean;
  * @lazy
  * @category Array
  */
-export function uniqueWith<T>(
-  data: ReadonlyArray<T>,
-  isEquals: IsEquals<T>,
-): Array<T>;
+export function uniqueWith<T extends IterableContainer>(
+  data: T,
+  isEquals: IsEquals<T[number]>,
+): Unique<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -45,9 +46,9 @@ export function uniqueWith<T>(
  * @lazy
  * @category Array
  */
-export function uniqueWith<T>(
-  isEquals: IsEquals<T>,
-): (data: ReadonlyArray<T>) => Array<T>;
+export function uniqueWith<T extends IterableContainer>(
+  isEquals: IsEquals<T[number]>,
+): (data: T) => Unique<T>;
 
 export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type DeDupped, type IterableContainer } from "./internal/types";
+import { type Deduped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { type LazyEvaluator } from "./pipe";
 
@@ -25,7 +25,7 @@ type IsEquals<T> = (a: T, b: T) => boolean;
 export function uniqueWith<T extends IterableContainer>(
   data: T,
   isEquals: IsEquals<T[number]>,
-): DeDupped<T>;
+): Deduped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -48,7 +48,7 @@ export function uniqueWith<T extends IterableContainer>(
  */
 export function uniqueWith<T extends IterableContainer>(
   isEquals: IsEquals<T[number]>,
-): (data: T) => DeDupped<T>;
+): (data: T) => Deduped<T>;
 
 export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -1,5 +1,5 @@
 import { purryFromLazy } from "./internal/purryFromLazy";
-import { type IterableContainer, type Unique } from "./internal/types";
+import { type DeDupped, type IterableContainer } from "./internal/types";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { type LazyEvaluator } from "./pipe";
 
@@ -25,7 +25,7 @@ type IsEquals<T> = (a: T, b: T) => boolean;
 export function uniqueWith<T extends IterableContainer>(
   data: T,
   isEquals: IsEquals<T[number]>,
-): Unique<T>;
+): DeDupped<T>;
 
 /**
  * Returns a new array containing only one copy of each element in the original
@@ -48,7 +48,7 @@ export function uniqueWith<T extends IterableContainer>(
  */
 export function uniqueWith<T extends IterableContainer>(
   isEquals: IsEquals<T[number]>,
-): (data: T) => Unique<T>;
+): (data: T) => DeDupped<T>;
 
 export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);


### PR DESCRIPTION
The unique functions return a simple array, ignoring the shape of the input. This means that some fidelity is lost when they are used in more complex computations. We can use some basic characteristics of a deduped array to improve the return type.

This isn't a perfect solution for all cases, as the test examples show, because we don't dedupe stuff at the type level, we just build the output based on the general character of the deduped array. This is intentional, so that the same type could be used for all uniqueXXX functions.