### PR TITLE
fix(drop): an even more accurate return type for literal Ns

### DIFF
--- a/src/drop.test-d.ts
+++ b/src/drop.test-d.ts
@@ -1,5 +1,5 @@
-import { pipe } from "./pipe";
 import { drop } from "./drop";
+import { pipe } from "./pipe";
 
 describe("data-first", () => {
   test("empty array", () => {
@@ -24,12 +24,16 @@ describe("data-first", () => {
 
   test("suffix array", () => {
     const result = drop([1] as [...Array<boolean>, number], 2);
-    expectTypeOf(result).toEqualTypeOf<Array<boolean | number>>();
+    expectTypeOf(result).toEqualTypeOf<
+      [...Array<boolean>, number] | [] | [number]
+    >();
   });
 
   test("array with suffix and prefix", () => {
     const result = drop([1, "a"] as [number, ...Array<boolean>, string], 2);
-    expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
+    expectTypeOf(result).toEqualTypeOf<
+      [...Array<boolean>, string] | [] | [string]
+    >();
   });
 
   test("tuple", () => {
@@ -76,7 +80,9 @@ describe("data-last", () => {
 
   test("suffix array", () => {
     const result = pipe([1] as [...Array<boolean>, number], drop(2));
-    expectTypeOf(result).toEqualTypeOf<Array<boolean | number>>();
+    expectTypeOf(result).toEqualTypeOf<
+      [...Array<boolean>, number] | [] | [number]
+    >();
   });
 
   test("array with suffix and prefix", () => {
@@ -84,7 +90,9 @@ describe("data-last", () => {
       [1, "a"] as [number, ...Array<boolean>, string],
       drop(2),
     );
-    expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
+    expectTypeOf(result).toEqualTypeOf<
+      [...Array<boolean>, string] | [] | [string]
+    >();
   });
 
   test("tuple", () => {

--- a/src/drop.test-d.ts
+++ b/src/drop.test-d.ts
@@ -17,23 +17,76 @@ describe("data-first", () => {
     expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
   });
 
-  test("prefix array", () => {
+  test("prefixed array", () => {
     const result = drop([1] as [number, ...Array<boolean>], 2);
     expectTypeOf(result).toEqualTypeOf<Array<boolean>>();
   });
 
-  test("suffix array", () => {
+  test("suffixed array", () => {
     const result = drop([1] as [...Array<boolean>, number], 2);
     expectTypeOf(result).toEqualTypeOf<
       [...Array<boolean>, number] | [] | [number]
     >();
   });
 
-  test("array with suffix and prefix", () => {
-    const result = drop([1, "a"] as [number, ...Array<boolean>, string], 2);
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean>, string] | [] | [string]
-    >();
+  describe("arrays with a prefix (2) and a suffix (2)", () => {
+    test("N === 0 (no drop)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        0,
+      );
+      expectTypeOf(result).toEqualTypeOf<
+        [number, number, ...Array<boolean>, string, string]
+      >();
+    });
+
+    test("N === 1 (drop from the prefix)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        1,
+      );
+      expectTypeOf(result).toEqualTypeOf<
+        [number, ...Array<boolean>, string, string]
+      >();
+    });
+
+    test("N === 2 (remove the prefix)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        2,
+      );
+      expectTypeOf(result).toEqualTypeOf<[...Array<boolean>, string, string]>();
+    });
+
+    test("N === 3 (drop the whole prefix, remove from the suffix)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        3,
+      );
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<boolean>, string, string] | [string, string] | [string]
+      >();
+    });
+
+    test("N === 4 (drop the whole prefix, drop the whole suffix)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        4,
+      );
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<boolean>, string, string] | [] | [string, string] | [string]
+      >();
+    });
+
+    test("N > 4 (drop more than the constant parts of the array)", () => {
+      const result = drop(
+        [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
+        5,
+      );
+      expectTypeOf(result).toEqualTypeOf<
+        [...Array<boolean>, string, string] | [] | [string, string] | [string]
+      >();
+    });
   });
 
   test("tuple", () => {

--- a/src/drop.test-d.ts
+++ b/src/drop.test-d.ts
@@ -100,13 +100,13 @@ describe("data-first", () => {
   });
 
   test("negative count", () => {
-    const result = drop([1] as Array<number>, -1);
+    const result = drop([] as Array<number>, -1);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   test("generalized typed count", () => {
-    const result = drop([1] as Array<number>, 1 as number);
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
+    const result = drop(["a", 1, true] as const, 1 as number);
+    expectTypeOf(result).toEqualTypeOf<Array<"a" | 1 | true>>();
   });
 });
 

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,5 +1,6 @@
-import { type IfNever, type Subtract } from "type-fest";
+import { type IsInteger, type IsNegative, type Subtract } from "type-fest";
 import {
+  type CoercedArray,
   type IterableContainer,
   type NTuple,
   type TupleParts,
@@ -8,41 +9,77 @@ import { SKIP_ITEM, lazyIdentityEvaluator } from "./internal/utilityEvaluators";
 import type { LazyEvaluator } from "./pipe";
 import { purry } from "./purry";
 
-type Drop<T extends IterableContainer, N extends number> = number extends N
-  ? Array<T[number]>
-  : `${N}` extends `-${number}`
-    ? T
-    : TupleParts<T>["prefix"] extends [
-          ...NTuple<unknown, N>,
-          ...infer Remaining,
-        ]
-      ? [
-          ...Remaining,
-          ...IfNever<TupleParts<T>["item"], [], Array<TupleParts<T>["item"]>>,
-          ...TupleParts<T>["suffix"],
-        ]
-      : IfNever<
-          TupleParts<T>["item"],
-          [],
+type Drop<T extends IterableContainer, N extends number> =
+  IsNegative<N> extends true
+    ? // Negative numbers result in nothing being dropped.
+      T
+    : IsInteger<N> extends false
+      ? // We can't compute accurate types for non-integer numbers so we
+        // fallback to the "legacy" typing where we convert our output to a
+        // simple array. This is also the case when N is not a literal value
+        // (e.g. it is `number`).
+        // TODO: We can improve this type by returning a union of all possible
+        // dropped shapes (e.g. the equivalent of Drop<T, 1> | Drop<T, 2> |
+        // Drop<T, 3> | ...).
+        Array<T[number]>
+      : // We have an non-negative integer N so we start chopping up the array.
+        // first we take a look at its prefix:
+        TupleParts<T>["prefix"] extends [
+            ...NTuple<unknown, N>,
+            ...infer Remaining,
+          ]
+        ? // If the prefix is as long as N, we know the drop would only remove
+          // items from the prefix, so we reconstruct the array with any
+          // remaining items from the prefix, and the rest of the array as it
+          // is...
+          [
+            ...Remaining,
+            ...CoercedArray<TupleParts<T>["item"]>,
+            ...TupleParts<T>["suffix"],
+          ]
+        : // But if the prefix is shorter than N, the drop would also remove
+          // items from the rest param and possibly the suffix.
           0 extends TupleParts<T>["suffix"]["length"]
-            ? Array<TupleParts<T>["item"]>
-            :
-                | DropUpTo<
-                    TupleParts<T>["suffix"],
-                    Subtract<N, TupleParts<T>["prefix"]["length"]>
-                  >
-                | [...Array<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]]
-        >;
+          ? // When there is no suffix the result is simply the rest param, and
+            // dropping items from a simple array results in the same array
+            // type.
+            CoercedArray<TupleParts<T>["item"]>
+          : // But if we have a suffix, the drop could remove items from it.
+            | DropUpTo<
+                  TupleParts<T>["suffix"],
+                  // If the suffix has any items dropped, it would be after all
+                  // prefix items have been removed, so we need to take those
+                  // into account when counting how many items to drop from the
+                  // suffix.
+                  Subtract<N, TupleParts<T>["prefix"]["length"]>
+                >
+              // And because we have a rest component, we also need to
+              // consider that all items were removed from that part, leaving
+              // the suffix intact.
+              | [...Array<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]];
 
+/**
+ * Arrays with a fixed suffix will result in any number of items being dropped,
+ * up to N, and not just N itself. This is because we don't know during typing
+ * how many items the "rest" part of the tuple will have in runtime.
+ *
+ * !Important: This is an internal type and assumes that T is a fixed-size
+ * tuple! It will not work if T has a rest element.
+ */
 type DropUpTo<
   T,
   N,
   Dropped extends ReadonlyArray<unknown> = [],
 > = Dropped["length"] extends N
-  ? T
+  ? // The last item had been dropped off T
+    T
   : T extends [unknown, ...infer Rest]
-    ? DropUpTo<Rest, N, [...Dropped, unknown]> | T
-    : T;
+    ? // Take the current value, and then recurse with the array where it is
+      // dropped, while counting how many items we've already dropped.
+      DropUpTo<Rest, N, [...Dropped, unknown]> | T
+    : // T is most likely [] at this point, but we use T instead of [] just to
+      // be on the safe side.
+      T;
 
 /**
  * Removes first `n` elements from the `array`.

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,6 @@
 import {
   type EmptyObject,
+  type IfNever,
   type IsAny,
   type IsLiteral,
   type IsNever,
@@ -274,6 +275,17 @@ export type TupleParts<
           suffix: Suffix;
         }
       : never;
+
+/**
+ * `never[]` and `[]` are not the same type, and in some cases they aren't
+ * interchangeable.
+ *
+ * This type makes it easier to use the result of TupleParts when the input is a
+ * fixed-length tuple but we still want to spread the rest of the array. e.g.
+ * `[...CoercedArray<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]]`.
+ *
+ */
+export type CoercedArray<T> = IfNever<T, [], Array<T>>;
 
 /**
  * The result of running a function that would dedupe an array (`unique`,


### PR DESCRIPTION
In #795 a better type for drop was introduced. This touched almost all cases, but still missed some nuances for suffix-arrays. Here I cover the remaining issues with that type.