### PR TITLE
feat(toSnakeCase): add toSnakeCase

### DIFF
--- a/docs/src/content/mapping/lodash/__MISSING.md
+++ b/docs/src/content/mapping/lodash/__MISSING.md
@@ -142,7 +142,6 @@ TODO: Go over: https://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore/#
 - parseInt
 - repeat
 - replace
-- snakeCase
 - startCase
 - template
 - trim

--- a/docs/src/content/mapping/lodash/snakeCase.md
+++ b/docs/src/content/mapping/lodash/snakeCase.md
@@ -1,0 +1,4 @@
+---
+category: String
+remeda: toSnakeCase
+---

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ export * from "./tap";
 export * from "./times";
 export * from "./toCamelCase";
 export * from "./toLowerCase";
+export * from "./toSnakeCase";
 export * from "./toUpperCase";
 export * from "./uncapitalize";
 export * from "./unique";

--- a/src/toCamelCase.ts
+++ b/src/toCamelCase.ts
@@ -17,7 +17,7 @@ const DEFAULT_OPTIONS = {
  * first word, capitalizing the rest, then joining them back together. This is
  * the runtime implementation of type-fest's [`CamelCase` type](https://github.com/sindresorhus/type-fest/blob/main/source/camel-case.d.ts).
  *
- * For other case manipulations see: `toLowerCase`, `toUpperCase`, `capitalize`,
+ * For other case manipulations see: `toSnakeCase`, `toLowerCase`, `toUpperCase`, `capitalize`,
  * and `uncapitalize`.
  *
  * For *PascalCase* use `capitalize(toCamelCase(data))`.
@@ -43,7 +43,7 @@ export function toCamelCase<
  * first word, capitalizing the rest, then joining them back together. This is
  * the runtime implementation of type-fest's [`CamelCase` type](https://github.com/sindresorhus/type-fest/blob/main/source/camel-case.d.ts).
  *
- * For other case manipulations see: `toLowerCase`, `toUpperCase`, `capitalize`,
+ * For other case manipulations see: `toSnakeCase`, `toLowerCase`, `toUpperCase`, `capitalize`,
  * and `uncapitalize`.
  *
  * !IMPORTANT: This function might work _incorrectly_ for **non-ascii** inputs.

--- a/src/toSnakeCase.test-d.ts
+++ b/src/toSnakeCase.test-d.ts
@@ -1,0 +1,137 @@
+import { pipe } from "./pipe";
+import { toSnakeCase } from "./toSnakeCase";
+
+describe("data-last", () => {
+  test("hello world", () => {
+    const result = pipe("hello world" as const, toSnakeCase());
+    expectTypeOf(result).toEqualTypeOf<"hello_world">();
+  });
+});
+
+describe("tests copied from type-fest's tests", () => {
+  test("pascal", () => {
+    const result = toSnakeCase("FooBar");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("kebab", () => {
+    const result = toSnakeCase("foo-bar");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("complex kebab", () => {
+    const result = toSnakeCase("foo-bar-abc-123");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar_abc_123">();
+  });
+
+  test("space", () => {
+    const result = toSnakeCase("foo bar");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("snake", () => {
+    const result = toSnakeCase("foo_bar");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("no delimiter from mono", () => {
+    const result = toSnakeCase("foobar");
+    expectTypeOf(result).toEqualTypeOf<"foobar">();
+  });
+
+  test("mixed", () => {
+    const result = toSnakeCase("foo-bar_abc xyzBarFoo");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar_abc_xyz_bar_foo">();
+  });
+
+  test("vendor prefixed css property", () => {
+    const result = toSnakeCase("-webkit-animation");
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(result).toEqualTypeOf<"webkit_animation">();
+  });
+
+  test("double prefixed kebab", () => {
+    const result = toSnakeCase("--very-prefixed");
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(result).toEqualTypeOf<"very_prefixed">();
+  });
+
+  test("repeated separators", () => {
+    const result = toSnakeCase("foo____bar");
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("uppercase", () => {
+    const result = toSnakeCase("FOO");
+    expectTypeOf(result).toEqualTypeOf<"foo">();
+  });
+
+  test("lowercase", () => {
+    const result = toSnakeCase("foo");
+    expectTypeOf(result).toEqualTypeOf<"foo">();
+  });
+
+  test("screaming snake case", () => {
+    const result = toSnakeCase("FOO_BAR");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("screaming kebab case", () => {
+    const result = toSnakeCase("FOO-BAR");
+    expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("preserveConsecutiveUppercase: fooBAR", () => {
+    const data = "fooBAR";
+    const whenTrue = toSnakeCase(data);
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(whenTrue).toEqualTypeOf<"foo_bar">();
+  });
+
+  test("preserveConsecutiveUppercase: fooBAR", () => {
+    const data = "fooBARBiz";
+    const whenTrue = toSnakeCase(data);
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(whenTrue).toEqualTypeOf<"foo_bar_biz">();
+  });
+
+  test("preserveConsecutiveUppercase: fooBAR", () => {
+    const data = "foo BAR-Biz_BUZZ";
+    const whenTrue = toSnakeCase(data);
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(whenTrue).toEqualTypeOf<"foo_bar_biz_buzz">();
+  });
+
+  test("preserveConsecutiveUppercase: fooBAR", () => {
+    const data = "foo\tBAR-Biz_BUZZ";
+    const whenTrue = toSnakeCase(data);
+    // TODO: to solve this we probably need to open a PR in type-fest first
+    // @ts-expect-error - as above
+    expectTypeOf(whenTrue).toEqualTypeOf<"foo_bar_biz_buzz">();
+  });
+});
+
+test("fallback when regular string", () => {
+  const result = toSnakeCase("hello world" as string);
+  expectTypeOf(result).toEqualTypeOf<string>();
+});
+
+test("with template literal type (lowercase)", () => {
+  const result = toSnakeCase("this_is_1" as `this_is_${number}`);
+  expectTypeOf(result).toEqualTypeOf<`this_is_${number}`>();
+});
+
+test("with template literal type (uppercase)", () => {
+  const result = toSnakeCase("THIS_IS_1" as `THIS_IS_${number}`);
+
+  // TODO: to solve this we probably need to open a PR in type-fest first
+  // @ts-expect-error - as above
+  expectTypeOf(result).toEqualTypeOf<`this_is_${number}`>();
+});

--- a/src/toSnakeCase.test.ts
+++ b/src/toSnakeCase.test.ts
@@ -1,0 +1,83 @@
+import { pipe } from "./pipe";
+import { toSnakeCase } from "./toSnakeCase";
+
+describe("data-last", () => {
+  test("hello world", () => {
+    expect(pipe("hello world", toSnakeCase())).toBe("helloWorld");
+  });
+});
+
+describe("tests copied from type-fest's tests", () => {
+  test("pascal", () => {
+    expect(toSnakeCase("FooBar")).toBe("foo_bar");
+  });
+
+  test("kebab", () => {
+    expect(toSnakeCase("foo-bar")).toBe("foo_bar");
+  });
+
+  test("complex kebab", () => {
+    expect(toSnakeCase("foo-bar-abc-123")).toBe("foo_bar_abc_123");
+  });
+
+  test("space", () => {
+    expect(toSnakeCase("foo bar")).toBe("foo_bar");
+  });
+
+  test("snake", () => {
+    expect(toSnakeCase("foo_bar")).toBe("foo_bar");
+  });
+
+  test("no delimiter from mono", () => {
+    expect(toSnakeCase("foobar")).toBe("foobar");
+  });
+
+  test("mixed", () => {
+    expect(toSnakeCase("foo-bar_abc xyzBarFoo")).toBe(
+      "foo_bar_abc_xyz_bar_foo",
+    );
+  });
+
+  test("vendor prefixed css property", () => {
+    expect(toSnakeCase("-webkit-animation")).toBe("webkit_animation");
+  });
+
+  test("double prefixed kebab", () => {
+    expect(toSnakeCase("--very-prefixed")).toBe("very_prefixed");
+  });
+
+  test("repeated separators", () => {
+    expect(toSnakeCase("foo____bar")).toBe("foo_bar");
+  });
+
+  test("uppercase", () => {
+    expect(toSnakeCase("FOO")).toBe("foo");
+  });
+
+  test("lowercase", () => {
+    expect(toSnakeCase("foo")).toBe("foo");
+  });
+
+  test("screaming snake case", () => {
+    expect(toSnakeCase("FOO_BAR")).toBe("foo_bar");
+  });
+
+  test("screaming kebab case", () => {
+    expect(toSnakeCase("FOO-BAR")).toBe("foo_bar");
+  });
+
+  test.each([
+    { input: "fooBAR", output: "fooBAR" },
+    { input: "fooBARBiz", output: "fooBARBiz" },
+    {
+      input: "foo BAR-Biz_BUZZ",
+      output: "fooBARBizBUZZ",
+    },
+    {
+      input: "foo\tBAR-Biz_BUZZ",
+      output: "fooBARBizBUZZ",
+    },
+  ])("$input -> $output", ({ input, output }) => {
+    expect(toSnakeCase(input)).toBe(output);
+  });
+});

--- a/src/toSnakeCase.ts
+++ b/src/toSnakeCase.ts
@@ -1,0 +1,48 @@
+import { type SnakeCase } from "type-fest";
+import { splitWords } from "./internal/splitWords";
+
+/**
+ * Convert a text to snake_case by splitting it into words, un-capitalizing, then joining them back together. This is
+ * the runtime implementation of type-fest's [`SnakeCase` type](https://github.com/sindresorhus/type-fest/blob/main/source/snake-case.d.ts).
+ *
+ * For other case manipulations see: `toCamelCase`, `toLowerCase`, `toUpperCase`, `capitalize`,
+ * and `uncapitalize`.
+ *
+ * @param data - A string.
+ * @signature
+ *   R.toSnakeCase(data);
+ * @example
+ *   R.toSnakeCase("hello world"); // "hello_world"
+ *   R.toSnakeCase("__HELLO_WORLD__"); // "hello_world"
+ * @dataFirst
+ * @category String
+ */
+export function toSnakeCase<T extends string>(data: T): SnakeCase<T>;
+
+/**
+ * Convert a text to snake_case by splitting it into words, un-capitalizing, then joining them back together. This is
+ * the runtime implementation of type-fest's [`SnakeCase` type](https://github.com/sindresorhus/type-fest/blob/main/source/snake-case.d.ts).
+ *
+ * For other case manipulations see: `toCamelCase`, `toLowerCase`, `toUpperCase`, `capitalize`,
+ * and `uncapitalize`.
+ *
+ * !IMPORTANT: This function might work _incorrectly_ for **non-ascii** inputs.
+ *
+ * @signature
+ *   R.toSnakeCase()(data);
+ * @example
+ *   R.pipe("hello world", R.toSnakeCase()); // "hello_world"
+ *   R.pipe("__HELLO_WORLD__", toSnakeCase()); // "hello_world"
+ * @dataLast
+ * @category String
+ */
+export function toSnakeCase(): <T extends string>(data: T) => SnakeCase<T>;
+
+export function toSnakeCase(optionalData?: string): unknown {
+  return typeof optionalData === "string"
+    ? toSnakeCaseImplementation(optionalData)
+    : (data: string) => toSnakeCaseImplementation(data);
+}
+
+const toSnakeCaseImplementation = (data: string): string =>
+  splitWords(data).join("_").toLowerCase();


### PR DESCRIPTION
Added toSnakeCase function

Related issue: https://github.com/remeda/remeda/issues/457

The js implementation is fairly simple, but I struggle with types a bit. Type-fest has `SnakeCase` but as visible in the tests it has some issues. Using `SnakeCase<CamelCase<T, { preserveConsecutiveUppercase: true }>>` was yielding much better effects, but it is not ideal. We'll probably need to make a PR to `type-fest` but I'm optimistic that it can be done with an implementation more similar to CamelCase but tailored for SnakeCase

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `perf`: changes to function implementations that improve a functions _runtime_ performance.
- `refactor`: changes to function implementations that are neither `fix` nor `perf`
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `style`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
