### PR TITLE
chore(lint): add eslint-plugin-vitest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import vitest from "@vitest/eslint-plugin";
 import prettierConfig from "eslint-config-prettier";
 import jsdoc from "eslint-plugin-jsdoc";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
@@ -424,8 +425,41 @@ export default tseslint.config(
     },
   },
   {
-    files: ["src/**/*.test.ts", "src/**/*.test-d.ts", "test/**/*.*"],
+    files: ["src/**/*.test.ts", "test/**/*.*"],
+    plugins: {
+      vitest,
+    },
     rules: {
+      ...vitest.configs.recommended.rules,
+      "@typescript-eslint/class-methods-use-this": "off",
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-useless-undefined": [
+        "warn",
+        { checkArguments: false, checkArrowFunctionBody: false },
+      ],
+    },
+  },
+  {
+    // Type Tests
+    files: ["src/**/*.test-d.ts"],
+    plugins: {
+      vitest,
+    },
+    settings: {
+      vitest: {
+        typecheck: true,
+      },
+    },
+    languageOptions: {
+      globals: {
+        ...vitest.environments.env.globals,
+      },
+    },
+    rules: {
+      ...vitest.configs.recommended.rules,
+      "vitest/expect-expect": "off",
       "@typescript-eslint/class-methods-use-this": "off",
       "@typescript-eslint/no-magic-numbers": "off",
       "@typescript-eslint/restrict-template-expressions": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -431,21 +431,12 @@ export default tseslint.config(
     },
     rules: {
       ...vitest.configs.all.rules,
-
-      // TODO: 1178 instances
-      "vitest/prefer-expect-assertions": "off",
-
-      // TODO: 640 instances
-      "vitest/consistent-test-it": "off",
-
-      // TODO: 289 instances
-      "vitest/require-top-level-describe": "off",
+      // The `all` config doesn't actually contain all the rules, its missing
+      // all the recommended ones...
+      ...vitest.configs.recommended.rules,
 
       // TODO: 273 instances
       "vitest/prefer-strict-equal": "off",
-
-      // TODO: 28 instances
-      "vitest/max-expects": "off",
 
       // The range of things that are acceptable for truthy and falsy is wider
       // than just the boolean `true` and `false`. We prefer our tests to only
@@ -457,6 +448,27 @@ export default tseslint.config(
       // preferable to use them as they make it clear that the tests relies on
       // some weird setup.
       "vitest/no-hooks": "off",
+
+      // I don't agree with this rule, `it` and `test` should be used based on
+      // the situation. Some times we are testing a specific behavior or trait,
+      // and sometimes we have a specific flow, input, or edge-case that needs
+      // to be tested against.
+      "vitest/consistent-test-it": "off",
+
+      // Wrapping tests with a describe just because is stupid, it adds another
+      // level of indentation without really adding any interesting semantics.
+      "vitest/require-top-level-describe": "off",
+
+      // TODO: When none of the "onlyXXX" options are enabled this rule isn't
+      // valuable and doesn't improve the quality of the tests. We can consider
+      // enabling some (or all of) those options and see if it makes the tests
+      // better without the code being a mess.
+      "vitest/prefer-expect-assertions": "off",
+
+      // TODO: This rule might be useful to guide people to break tests into
+      // smaller tests that only test one thing, but there's no reasonable value
+      // we can configure it to that won't end up feeling arbitrary and noisy.
+      "vitest/max-expects": "off",
 
       // These aren't valuable when writing tests, they'll just make the tests
       // harder to read and maintain.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -425,7 +425,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ["src/**/*.test.ts", "test/**/*.*"],
+    files: ["src/**/*.test.ts", "src/**/*.test-d.ts", "test/**/*.*"],
     plugins: {
       vitest,
     },
@@ -435,6 +435,33 @@ export default tseslint.config(
       // all the recommended ones...
       ...vitest.configs.recommended.rules,
 
+      // I don't agree with this rule, `it` and `test` should be used based on
+      // the situation. Some times we are testing a specific behavior or trait,
+      // and sometimes we have a specific flow, input, or edge-case that needs
+      // to be tested against.
+      "vitest/consistent-test-it": "off",
+
+      // This rule's docs don't provide justification for enabling it and what
+      // value it adds. Going by the rule just adds another level of indentation
+      // without really adding any interesting semantics.
+      "vitest/require-top-level-describe": "off",
+
+      // TODO: When none of the "onlyXXX" options are enabled this rule isn't
+      // valuable and doesn't improve the quality of the tests. We can consider
+      // enabling some (or all of) those options and see if it makes the tests
+      // better without the code being a mess.
+      "vitest/prefer-expect-assertions": "off",
+
+      // These aren't valuable when writing tests, they'll just make the tests
+      // harder to read and maintain.
+      "@typescript-eslint/no-magic-numbers": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "unicorn/no-null": "off",
+    },
+  },
+  {
+    files: ["src/**/*.test.ts"],
+    rules: {
       // The range of things that are acceptable for truthy and falsy is wider
       // than just the boolean `true` and `false`. We prefer our tests only pass
       // on the narrowest cases.
@@ -446,40 +473,16 @@ export default tseslint.config(
       // some weird setup.
       "vitest/no-hooks": "off",
 
-      // I don't agree with this rule, `it` and `test` should be used based on
-      // the situation. Some times we are testing a specific behavior or trait,
-      // and sometimes we have a specific flow, input, or edge-case that needs
-      // to be tested against.
-      "vitest/consistent-test-it": "off",
-
-      // Wrapping tests with a describe just because is stupid, it adds another
-      // level of indentation without really adding any interesting semantics.
-      "vitest/require-top-level-describe": "off",
-
-      // TODO: When none of the "onlyXXX" options are enabled this rule isn't
-      // valuable and doesn't improve the quality of the tests. We can consider
-      // enabling some (or all of) those options and see if it makes the tests
-      // better without the code being a mess.
-      "vitest/prefer-expect-assertions": "off",
-
       // TODO: This rule might be useful to guide people to break tests into
-      // smaller tests that only test one thing, but there's no reasonable value
-      // we can configure it to that won't end up feeling arbitrary and noisy.
+      // smaller tests that only expect one thing, but there's no reasonable
+      // max value we can configure it to that won't end up feeling arbitrary
+      // and noisy.
       "vitest/max-expects": "off",
-
-      // These aren't valuable when writing tests, they'll just make the tests
-      // harder to read and maintain.
-      "@typescript-eslint/no-magic-numbers": "off",
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "unicorn/no-null": "off",
     },
   },
   {
     // Type Tests
     files: ["src/**/*.test-d.ts"],
-    plugins: {
-      vitest,
-    },
     settings: {
       vitest: {
         typecheck: true,
@@ -491,11 +494,6 @@ export default tseslint.config(
       },
     },
     rules: {
-      ...vitest.configs.all.rules,
-      // The `all` config doesn't actually contain all the rules, its missing
-      // all the recommended ones...
-      ...vitest.configs.recommended.rules,
-
       // A lot of our type tests use @ts-expect-error as the primary way to test
       // that function params are typed correctly. This isn't detected properly
       // by this rule and there's no way to configure it to work; so we disable
@@ -509,28 +507,6 @@ export default tseslint.config(
       // because there's no risk of the code not running, the type-checker will
       // check both branches.
       "vitest/no-conditional-in-test": "off",
-
-      // I don't agree with this rule, `it` and `test` should be used based on
-      // the situation. Some times we are testing a specific behavior or trait,
-      // and sometimes we have a specific flow, input, or edge-case that needs
-      // to be tested against.
-      "vitest/consistent-test-it": "off",
-
-      // Wrapping tests with a describe just because is stupid, it adds another
-      // level of indentation without really adding any interesting semantics.
-      "vitest/require-top-level-describe": "off",
-
-      // TODO: When none of the "onlyXXX" options are enabled this rule isn't
-      // valuable and doesn't improve the quality of the tests. We can consider
-      // enabling some (or all of) those options and see if it makes the tests
-      // better without the code being a mess.
-      "vitest/prefer-expect-assertions": "off",
-
-      // These aren't valuable when writing tests, they'll just make the tests
-      // harder to read and maintain.
-      "@typescript-eslint/no-magic-numbers": "off",
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "unicorn/no-null": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -431,14 +431,12 @@ export default tseslint.config(
     },
     rules: {
       ...vitest.configs.recommended.rules,
-      "@typescript-eslint/class-methods-use-this": "off",
+
+      // These aren't valuable when writing tests, they'll just make the tests
+      // harder to read and maintain.
       "@typescript-eslint/no-magic-numbers": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
       "unicorn/no-null": "off",
-      "unicorn/no-useless-undefined": [
-        "warn",
-        { checkArguments: false, checkArrowFunctionBody: false },
-      ],
     },
   },
   {
@@ -459,15 +457,19 @@ export default tseslint.config(
     },
     rules: {
       ...vitest.configs.recommended.rules,
+
+      // A lot of our type tests use @ts-expect-error as the primary way to test
+      // that function params are typed correctly. This isn't detected properly
+      // by this rule and there's no way to configure it to work; so we disable
+      // it for now... There might be other ways to write the tests so that they
+      // conform to this rule.
       "vitest/expect-expect": "off",
-      "@typescript-eslint/class-methods-use-this": "off",
+
+      // These aren't valuable when writing tests, they'll just make the tests
+      // harder to read and maintain.
       "@typescript-eslint/no-magic-numbers": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
       "unicorn/no-null": "off",
-      "unicorn/no-useless-undefined": [
-        "warn",
-        { checkArguments: false, checkArrowFunctionBody: false },
-      ],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -436,8 +436,8 @@ export default tseslint.config(
       ...vitest.configs.recommended.rules,
 
       // The range of things that are acceptable for truthy and falsy is wider
-      // than just the boolean `true` and `false`. We prefer our tests to only
-      // pass with in the narrowest cases.
+      // than just the boolean `true` and `false`. We prefer our tests only pass
+      // on the narrowest cases.
       "vitest/prefer-to-be-truthy": "off",
       "vitest/prefer-to-be-falsy": "off",
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -435,9 +435,6 @@ export default tseslint.config(
       // all the recommended ones...
       ...vitest.configs.recommended.rules,
 
-      // TODO: 273 instances
-      "vitest/prefer-strict-equal": "off",
-
       // The range of things that are acceptable for truthy and falsy is wider
       // than just the boolean `true` and `false`. We prefer our tests to only
       // pass with in the narrowest cases.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -435,6 +435,11 @@ export default tseslint.config(
       // all the recommended ones...
       ...vitest.configs.recommended.rules,
 
+      "vitest/prefer-lowercase-title": [
+        "warn",
+        { ignoreTopLevelDescribe: true },
+      ],
+
       // I don't agree with this rule, `it` and `test` should be used based on
       // the situation. Some times we are testing a specific behavior or trait,
       // and sometimes we have a specific flow, input, or edge-case that needs

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -430,7 +430,33 @@ export default tseslint.config(
       vitest,
     },
     rules: {
-      ...vitest.configs.recommended.rules,
+      ...vitest.configs.all.rules,
+
+      // TODO: 1178 instances
+      "vitest/prefer-expect-assertions": "off",
+
+      // TODO: 640 instances
+      "vitest/consistent-test-it": "off",
+
+      // TODO: 289 instances
+      "vitest/require-top-level-describe": "off",
+
+      // TODO: 273 instances
+      "vitest/prefer-strict-equal": "off",
+
+      // TODO: 28 instances
+      "vitest/max-expects": "off",
+
+      // The range of things that are acceptable for truthy and falsy is wider
+      // than just the boolean `true` and `false`. We prefer our tests to only
+      // pass with in the narrowest cases.
+      "vitest/prefer-to-be-truthy": "off",
+      "vitest/prefer-to-be-falsy": "off",
+
+      // It's rare that hooks are even needed, but in those cases it's probably
+      // preferable to use them as they make it clear that the tests relies on
+      // some weird setup.
+      "vitest/no-hooks": "off",
 
       // These aren't valuable when writing tests, they'll just make the tests
       // harder to read and maintain.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -491,6 +491,9 @@ export default tseslint.config(
       },
     },
     rules: {
+      ...vitest.configs.all.rules,
+      // The `all` config doesn't actually contain all the rules, its missing
+      // all the recommended ones...
       ...vitest.configs.recommended.rules,
 
       // A lot of our type tests use @ts-expect-error as the primary way to test
@@ -499,6 +502,29 @@ export default tseslint.config(
       // it for now... There might be other ways to write the tests so that they
       // conform to this rule.
       "vitest/expect-expect": "off",
+
+      // When testing type-predicates (guards) we need to test what happens to
+      // the input type after the predicate succeeds and/or fails; we can only
+      // do that using conditionals. This rule doesn't matter for type tests
+      // because there's no risk of the code not running, the type-checker will
+      // check both branches.
+      "vitest/no-conditional-in-test": "off",
+
+      // I don't agree with this rule, `it` and `test` should be used based on
+      // the situation. Some times we are testing a specific behavior or trait,
+      // and sometimes we have a specific flow, input, or edge-case that needs
+      // to be tested against.
+      "vitest/consistent-test-it": "off",
+
+      // Wrapping tests with a describe just because is stupid, it adds another
+      // level of indentation without really adding any interesting semantics.
+      "vitest/require-top-level-describe": "off",
+
+      // TODO: When none of the "onlyXXX" options are enabled this rule isn't
+      // valuable and doesn't improve the quality of the tests. We can consider
+      // enabling some (or all of) those options and see if it makes the tests
+      // better without the code being a mess.
+      "vitest/prefer-expect-assertions": "off",
 
       // These aren't valuable when writing tests, they'll just make the tests
       // harder to read and maintain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,25 +12,25 @@
         "type-fest": "^4.26.1"
       },
       "devDependencies": {
-        "@arethetypeswrong/cli": "^0.16.2",
-        "@eslint/js": "^9.10.0",
+        "@arethetypeswrong/cli": "^0.16.4",
+        "@eslint/js": "^9.11.1",
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
-        "@types/node": "^22.5.4",
+        "@types/node": "^22.6.1",
         "@vitest/coverage-v8": "^2.1.1",
         "@vitest/eslint-plugin": "^1.1.4",
-        "eslint": "^9.10.0",
+        "eslint": "^9.11.1",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-jsdoc": "^50.2.2",
+        "eslint-plugin-jsdoc": "^50.2.4",
         "eslint-plugin-unicorn": "^55.0.0",
-        "husky": "^9.1.5",
+        "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
-        "publint": "^0.2.10",
+        "publint": "^0.2.11",
         "semantic-release": "^24.1.0",
         "tsup": "^8.2.4",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.6.0",
+        "typescript-eslint": "^8.7.0",
         "vitest": "^2.1.1"
       }
     },
@@ -55,13 +55,13 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.16.2.tgz",
-      "integrity": "sha512-QW1jjQayokcn4KmKyuqvWJl+FyRMagX/D/kwNEddhUEbAhLCL6PXPduHLYxRtQSE+e8QllGS2qcGxqrLJeExAw==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.16.4.tgz",
+      "integrity": "sha512-qMmdVlJon5FtA+ahn0c1oAVNxiq4xW5lqFiTZ21XHIeVwAVIQ+uRz4UEivqRMsjVV1grzRgJSKqaOrq1MvlVyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "0.16.2",
+        "@arethetypeswrong/core": "0.16.4",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.16.2.tgz",
-      "integrity": "sha512-gAYzWaIbq8m9MuvxKmeDn24Or4mIWCSpRR0NNXAVoGUTPraB1SP3blPa5NycUPTnToKLA5DAwHLhwtWpslMbKQ==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.16.4.tgz",
+      "integrity": "sha512-RI3HXgSuKTfcBf1hSEg1P9/cOvmI0flsMm6/QL3L3wju4AlHDqd55JFPfXs4pzgEAgy5L9pul4/HPPz99x2GvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -746,6 +746,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -771,9 +781,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-      "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+      "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -791,9 +801,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1831,9 +1841,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
+      "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1855,17 +1865,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
-      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/type-utils": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/type-utils": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1889,16 +1899,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
-      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1918,14 +1928,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0"
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1936,14 +1946,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
-      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1961,9 +1971,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1975,14 +1985,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2030,16 +2040,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
-      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0"
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2053,13 +2063,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -3456,21 +3466,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
-      "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+      "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.6.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.10.0",
-        "@eslint/plugin-kit": "^0.1.0",
+        "@eslint/js": "9.11.1",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3529,9 +3542,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.2.tgz",
-      "integrity": "sha512-i0ZMWA199DG7sjxlzXn5AeYZxpRfMJjDPUl7lL9eJJX8TPRoIaxJU4ys/joP5faM5AXE1eqW/dslCj3uj4Nqpg==",
+      "version": "50.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.2.4.tgz",
+      "integrity": "sha512-020jA+dXaXdb+TML3ZJBvpPmzwbNROjnYuTYi/g6A5QEmEjhptz4oPJDKkOGMIByNxsPpdTLzSU1HYVqebOX1w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3629,6 +3642,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.0.0",
@@ -4326,9 +4346,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
-      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8830,14 +8850,14 @@
       "license": "ISC"
     },
     "node_modules/publint": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.2.10.tgz",
-      "integrity": "sha512-5TzYaAFiGpgkYX/k6VaItRMT2uHI4zO5OWJ2k7Er0Ot3jutBCNTJB1qRHuy1lYq07JhRczzFs6HFPB4D+A47xA==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.2.11.tgz",
+      "integrity": "sha512-/kxbd+sD/uEG515N/ZYpC6gYs8h89cQ4UIsAq1y6VT4qlNh8xmiSwcP2xU2MbzXFl8J0l2IdONKFweLfYoqhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "npm-packlist": "^5.1.3",
-        "picocolors": "^1.0.1",
+        "picocolors": "^1.1.0",
         "sade": "^1.8.1"
       },
       "bin": {
@@ -11161,15 +11181,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
-      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+      "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.6.0",
-        "@typescript-eslint/parser": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0"
+        "@typescript-eslint/eslint-plugin": "8.7.0",
+        "@typescript-eslint/parser": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,9 @@
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/node": "^22.5.4",
-        "@vitest/coverage-v8": "^2.0.5",
-        "eslint": "^9.10.0",
+        "@vitest/coverage-v8": "^2.1.1",
+        "@vitest/eslint-plugin": "^1.1.4",
+        "eslint": "^9.11.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-unicorn": "^55.0.0",
@@ -29,8 +30,8 @@
         "semantic-release": "^24.1.0",
         "tsup": "^8.2.4",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.5.0",
-        "vitest": "^2.0.5"
+        "typescript-eslint": "^8.6.0",
+        "vitest": "^2.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -770,9 +771,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-      "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.0.tgz",
+      "integrity": "sha512-LPkkenkDqyzTFauZLLAPhIb48fj6drrfMvRGSL9tS3AcZBSVTllemLSNyCvHNNL2t797S/6DJNSIwRwXgMO/eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -790,9 +791,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -979,9 +980,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1854,17 +1855,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
-      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
+      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/type-utils": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/type-utils": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1888,16 +1889,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
-      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
+      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1917,14 +1918,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
-      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
+      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0"
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1935,14 +1936,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
-      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
+      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1960,9 +1961,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
-      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
+      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1974,14 +1975,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
-      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
+      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2029,16 +2030,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0"
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2052,13 +2053,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
-      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
+      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -2070,19 +2071,20 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.0.5.tgz",
-      "integrity": "sha512-qeFcySCg5FLO2bHHSa0tAZAOnAUbp4L6/A5JDuj9+bt53JREl8hpLjLHEWF0e/gWc8INVpJaqA7+Ene2rclpZg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.1.tgz",
+      "integrity": "sha512-md/A7A3c42oTT8JUHSqjP5uKTWJejzUW4jalpvs+rZ27gsURsMU8DEb+8Jf8C6Kj2gwfSHJqobDNBuoqlm0cFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^0.2.3",
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.10",
+        "magic-string": "^0.30.11",
         "magicast": "^0.3.4",
         "std-env": "^3.7.0",
         "test-exclude": "^7.0.1",
@@ -2092,17 +2094,48 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "2.0.5"
+        "@vitest/browser": "2.1.1",
+        "vitest": "2.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.4.tgz",
+      "integrity": "sha512-kudjgefmJJ7xQ2WfbUU6pZbm7Ou4gLYRaao/8Ynide3G0QhVKHd978sDyWX4KOH0CCMH9cyrGAkFd55eGzJ48Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/utils": ">= 8.0",
+        "eslint": ">= 8.57.0",
+        "typescript": ">= 5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
-      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
+      "integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.0.5",
-        "@vitest/utils": "2.0.5",
+        "@vitest/spy": "2.1.1",
+        "@vitest/utils": "2.1.1",
         "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -2110,11 +2143,40 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
-      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
+      "integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "^2.1.0-beta.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.11"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/spy": "2.1.1",
+        "msw": "^2.3.5",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
+      "integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
@@ -2123,12 +2185,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
-      "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
+      "integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.0.5",
+        "@vitest/utils": "2.1.1",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -2136,13 +2199,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
-      "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
+      "integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.0.5",
-        "magic-string": "^0.30.10",
+        "@vitest/pretty-format": "2.1.1",
+        "magic-string": "^0.30.11",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -2150,10 +2214,11 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
-      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
+      "integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.0"
       },
@@ -2162,13 +2227,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
-      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.0.5",
-        "estree-walker": "^3.0.3",
+        "@vitest/pretty-format": "2.1.1",
         "loupe": "^3.1.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -2368,6 +2433,7 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -2537,6 +2603,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
       "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -2580,6 +2647,7 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
@@ -3186,6 +3254,7 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3387,9 +3456,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
-      "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.0.tgz",
+      "integrity": "sha512-yVS6XODx+tMFMDFcG4+Hlh+qG7RM6cCJXtQhCKLSsr3XkLvWggHjCqjfh0XsPPnt1c56oaT6PMgW9XWQQjdHXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3397,8 +3466,8 @@
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.10.0",
-        "@eslint/plugin-kit": "^0.1.0",
+        "@eslint/js": "9.11.0",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3645,6 +3714,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -3984,6 +4054,7 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -5130,6 +5201,7 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
       "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -5142,13 +5214,13 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/magicast": {
@@ -8480,13 +8552,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
@@ -10293,9 +10367,16 @@
       }
     },
     "node_modules/tinybench": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
-      "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
+      "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10319,10 +10400,11 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
-      "integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -11078,15 +11160,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.5.0.tgz",
-      "integrity": "sha512-uD+XxEoSIvqtm4KE97etm32Tn5MfaZWgWfMMREStLxR6JzvHkc2Tkj7zhTEK5XmtpTmKHNnG8Sot6qDfhHtR1Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
+      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.5.0",
-        "@typescript-eslint/parser": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0"
+        "@typescript-eslint/eslint-plugin": "8.6.0",
+        "@typescript-eslint/parser": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11269,10 +11351,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
+      "integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11328,15 +11411,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
-      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
+      "integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.5",
+        "debug": "^4.3.6",
         "pathe": "^1.1.2",
-        "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0"
       },
       "bin": {
@@ -11350,29 +11433,30 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
-      "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
+      "integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@vitest/expect": "2.0.5",
-        "@vitest/pretty-format": "^2.0.5",
-        "@vitest/runner": "2.0.5",
-        "@vitest/snapshot": "2.0.5",
-        "@vitest/spy": "2.0.5",
-        "@vitest/utils": "2.0.5",
+        "@vitest/expect": "2.1.1",
+        "@vitest/mocker": "2.1.1",
+        "@vitest/pretty-format": "^2.1.1",
+        "@vitest/runner": "2.1.1",
+        "@vitest/snapshot": "2.1.1",
+        "@vitest/spy": "2.1.1",
+        "@vitest/utils": "2.1.1",
         "chai": "^5.1.1",
-        "debug": "^4.3.5",
-        "execa": "^8.0.1",
-        "magic-string": "^0.30.10",
+        "debug": "^4.3.6",
+        "magic-string": "^0.30.11",
         "pathe": "^1.1.2",
         "std-env": "^3.7.0",
-        "tinybench": "^2.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.0",
         "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.0.5",
+        "vite-node": "2.1.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -11387,8 +11471,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.0.5",
-        "@vitest/ui": "2.0.5",
+        "@vitest/browser": "2.1.1",
+        "@vitest/ui": "2.1.1",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^22.5.4",
         "@vitest/coverage-v8": "^2.1.1",
         "@vitest/eslint-plugin": "^1.1.4",
-        "eslint": "^9.11.0",
+        "eslint": "^9.10.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsdoc": "^50.2.2",
         "eslint-plugin-unicorn": "^55.0.0",
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.0.tgz",
-      "integrity": "sha512-LPkkenkDqyzTFauZLLAPhIb48fj6drrfMvRGSL9tS3AcZBSVTllemLSNyCvHNNL2t797S/6DJNSIwRwXgMO/eQ==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
+      "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
+      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3456,9 +3456,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.0.tgz",
-      "integrity": "sha512-yVS6XODx+tMFMDFcG4+Hlh+qG7RM6cCJXtQhCKLSsr3XkLvWggHjCqjfh0XsPPnt1c56oaT6PMgW9XWQQjdHXA==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
+      "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3466,8 +3466,8 @@
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.11.0",
-        "@eslint/plugin-kit": "^0.2.0",
+        "@eslint/js": "9.10.0",
+        "@eslint/plugin-kit": "^0.1.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
@@ -10381,9 +10381,9 @@
       "license": "MIT"
     },
     "node_modules/tinypool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
-      "integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10395,6 +10395,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
       "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,25 +64,25 @@
     "type-fest": "^4.26.1"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.16.2",
-    "@eslint/js": "^9.10.0",
+    "@arethetypeswrong/cli": "^0.16.4",
+    "@eslint/js": "^9.11.1",
     "@types/eslint__js": "^8.42.3",
     "@types/eslint-config-prettier": "^6.11.3",
-    "@types/node": "^22.5.4",
+    "@types/node": "^22.6.1",
     "@vitest/coverage-v8": "^2.1.1",
     "@vitest/eslint-plugin": "^1.1.4",
-    "eslint": "^9.10.0",
+    "eslint": "^9.11.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-jsdoc": "^50.2.2",
+    "eslint-plugin-jsdoc": "^50.2.4",
     "eslint-plugin-unicorn": "^55.0.0",
-    "husky": "^9.1.5",
+    "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
-    "publint": "^0.2.10",
+    "publint": "^0.2.11",
     "semantic-release": "^24.1.0",
     "tsup": "^8.2.4",
     "typescript": "^5.6.2",
-    "typescript-eslint": "^8.6.0",
+    "typescript-eslint": "^8.7.0",
     "vitest": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/node": "^22.5.4",
     "@vitest/coverage-v8": "^2.1.1",
     "@vitest/eslint-plugin": "^1.1.4",
-    "eslint": "^9.11.0",
+    "eslint": "^9.10.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-unicorn": "^55.0.0",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
     "@types/eslint__js": "^8.42.3",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/node": "^22.5.4",
-    "@vitest/coverage-v8": "^2.0.5",
-    "eslint": "^9.10.0",
+    "@vitest/coverage-v8": "^2.1.1",
+    "@vitest/eslint-plugin": "^1.1.4",
+    "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-unicorn": "^55.0.0",
@@ -81,7 +82,7 @@
     "semantic-release": "^24.1.0",
     "tsup": "^8.2.4",
     "typescript": "^5.6.2",
-    "typescript-eslint": "^8.5.0",
-    "vitest": "^2.0.5"
+    "typescript-eslint": "^8.6.0",
+    "vitest": "^2.1.1"
   }
 }

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,11 +1,11 @@
 import { add } from "./add";
 
 test("data-first", () => {
-  expect(add(10, 5)).toEqual(15);
-  expect(add(10, -5)).toEqual(5);
+  expect(add(10, 5)).toBe(15);
+  expect(add(10, -5)).toBe(5);
 });
 
 test("data-last", () => {
-  expect(add(5)(10)).toEqual(15);
-  expect(add(-5)(10)).toEqual(5);
+  expect(add(5)(10)).toBe(15);
+  expect(add(-5)(10)).toBe(5);
 });

--- a/src/addProp.test.ts
+++ b/src/addProp.test.ts
@@ -5,7 +5,7 @@ describe("data first", () => {
   test("simple", () => {
     const actual = addProp({ a: 1 }, "b", 2);
 
-    expect(actual).toEqual({ a: 1, b: 2 });
+    expect(actual).toStrictEqual({ a: 1, b: 2 });
   });
 });
 
@@ -13,6 +13,6 @@ describe("data last", () => {
   test("simple", () => {
     const actual = pipe({ a: 1 }, addProp("b", 2));
 
-    expect(actual).toEqual({ a: 1, b: 2 });
+    expect(actual).toStrictEqual({ a: 1, b: 2 });
   });
 });

--- a/src/addProp.test.ts
+++ b/src/addProp.test.ts
@@ -4,6 +4,7 @@ import { pipe } from "./pipe";
 describe("data first", () => {
   test("simple", () => {
     const actual = addProp({ a: 1 }, "b", 2);
+
     expect(actual).toEqual({ a: 1, b: 2 });
   });
 });
@@ -11,6 +12,7 @@ describe("data first", () => {
 describe("data last", () => {
   test("simple", () => {
     const actual = pipe({ a: 1 }, addProp("b", 2));
+
     expect(actual).toEqual({ a: 1, b: 2 });
   });
 });

--- a/src/allPass.test.ts
+++ b/src/allPass.test.ts
@@ -4,16 +4,16 @@ const fns = [(x: number) => x % 3 === 0, (x: number) => x % 4 === 0] as const;
 
 describe("data first", () => {
   test("allPass", () => {
-    expect(allPass(12, fns)).toEqual(true);
-    expect(allPass(4, fns)).toEqual(false);
-    expect(allPass(3, fns)).toEqual(false);
+    expect(allPass(12, fns)).toBe(true);
+    expect(allPass(4, fns)).toBe(false);
+    expect(allPass(3, fns)).toBe(false);
   });
 });
 
 describe("data last", () => {
   test("allPass", () => {
-    expect(allPass(fns)(12)).toEqual(true);
-    expect(allPass(fns)(4)).toEqual(false);
-    expect(allPass(fns)(3)).toEqual(false);
+    expect(allPass(fns)(12)).toBe(true);
+    expect(allPass(fns)(4)).toBe(false);
+    expect(allPass(fns)(3)).toBe(false);
   });
 });

--- a/src/anyPass.test.ts
+++ b/src/anyPass.test.ts
@@ -4,16 +4,16 @@ const fns = [(x: number) => x === 3, (x: number) => x === 4] as const;
 
 describe("data first", () => {
   test("anyPass", () => {
-    expect(anyPass(3, fns)).toEqual(true);
-    expect(anyPass(4, fns)).toEqual(true);
-    expect(anyPass(1, fns)).toEqual(false);
+    expect(anyPass(3, fns)).toBe(true);
+    expect(anyPass(4, fns)).toBe(true);
+    expect(anyPass(1, fns)).toBe(false);
   });
 });
 
 describe("data last", () => {
   test("anyPass", () => {
-    expect(anyPass(fns)(3)).toEqual(true);
-    expect(anyPass(fns)(4)).toEqual(true);
-    expect(anyPass(fns)(1)).toEqual(false);
+    expect(anyPass(fns)(3)).toBe(true);
+    expect(anyPass(fns)(4)).toBe(true);
+    expect(anyPass(fns)(1)).toBe(false);
   });
 });

--- a/src/ceil.test.ts
+++ b/src/ceil.test.ts
@@ -8,36 +8,30 @@ describe("data-first", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(ceil(8123.4317, -2)).toEqual(8200);
-    expect(ceil(8123.4317, -4)).toEqual(10_000);
+    expect(ceil(8123.4317, -2)).toBe(8200);
+    expect(ceil(8123.4317, -4)).toBe(10_000);
   });
 
   test("should work with precision = 0", () => {
-    expect(ceil(8123.4317, 0)).toEqual(8124);
+    expect(ceil(8123.4317, 0)).toBe(8124);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => ceil(1, val)).toThrowError(
+      expect(() => ceil(1, val)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => ceil(1, 21.37)).toThrowError(
-      "precision must be an integer: 21.37",
-    );
+    expect(() => ceil(1, 21.37)).toThrow("precision must be an integer: 21.37");
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => ceil(1, 16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => ceil(1, -16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => ceil(1, 16)).toThrow("precision must be between -15 and 15");
+    expect(() => ceil(1, -16)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
@@ -58,36 +52,30 @@ describe("data-last", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(ceil(-2)(8123.4317)).toEqual(8200);
-    expect(ceil(-4)(8123.4317)).toEqual(10_000);
+    expect(ceil(-2)(8123.4317)).toBe(8200);
+    expect(ceil(-4)(8123.4317)).toBe(10_000);
   });
 
   test("should work with precision = 0", () => {
-    expect(ceil(0)(8123.4317)).toEqual(8124);
+    expect(ceil(0)(8123.4317)).toBe(8124);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => ceil(val)(1)).toThrowError(
+      expect(() => ceil(val)(1)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => ceil(21.37)(1)).toThrowError(
-      "precision must be an integer: 21.37",
-    );
+    expect(() => ceil(21.37)(1)).toThrow("precision must be an integer: 21.37");
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => ceil(-16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => ceil(16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => ceil(-16)(1)).toThrow("precision must be between -15 and 15");
+    expect(() => ceil(16)(1)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(

--- a/src/ceil.test.ts
+++ b/src/ceil.test.ts
@@ -2,9 +2,9 @@ import { ceil } from "./ceil";
 
 describe("data-first", () => {
   test("should work with positive precision", () => {
-    expect(ceil(8123.4317, 3)).toEqual(8123.432);
-    expect(ceil(483.222_43, 1)).toEqual(483.3);
-    expect(ceil(123.4317, 5)).toEqual(123.4317);
+    expect(ceil(8123.4317, 3)).toBe(8123.432);
+    expect(ceil(483.222_43, 1)).toBe(483.3);
+    expect(ceil(123.4317, 5)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -38,7 +38,7 @@ describe("data-first", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(ceil(val, precision)).toStrictEqual(val);
+        expect(ceil(val, precision)).toBe(val);
       }
     },
   );
@@ -46,9 +46,9 @@ describe("data-first", () => {
 
 describe("data-last", () => {
   test("should work with positive precision", () => {
-    expect(ceil(3)(8123.4317)).toEqual(8123.432);
-    expect(ceil(1)(483.222_43)).toEqual(483.3);
-    expect(ceil(5)(123.4317)).toEqual(123.4317);
+    expect(ceil(3)(8123.4317)).toBe(8123.432);
+    expect(ceil(1)(483.222_43)).toBe(483.3);
+    expect(ceil(5)(123.4317)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -82,7 +82,7 @@ describe("data-last", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(ceil(precision)(val)).toStrictEqual(val);
+        expect(ceil(precision)(val)).toBe(val);
       }
     },
   );

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -46,6 +46,7 @@ describe("edge-cases", () => {
   test("size > data.length", () => {
     const data = [1, 2, 3] as const;
     const result = chunk(data, 10);
+
     expect(result).toStrictEqual([data]);
     // We expect the result to be a shallow clone
     expect(result[0]).not.toBe(data);
@@ -54,6 +55,7 @@ describe("edge-cases", () => {
   test("chunk of size 1", () => {
     const data = [1, 2, 3, 4, 5] as const;
     const result = chunk(data, 1);
+
     expect(result).toStrictEqual([[1], [2], [3], [4], [5]]);
   });
 });

--- a/src/chunk.test.ts
+++ b/src/chunk.test.ts
@@ -2,28 +2,31 @@ import { chunk } from "./chunk";
 
 describe("data first", () => {
   test("equal size", () => {
-    expect(chunk(["a", "b", "c", "d"], 2)).toEqual([
+    expect(chunk(["a", "b", "c", "d"], 2)).toStrictEqual([
       ["a", "b"],
       ["c", "d"],
     ]);
   });
 
   test("not equal size", () => {
-    expect(chunk(["a", "b", "c", "d"], 3)).toEqual([["a", "b", "c"], ["d"]]);
+    expect(chunk(["a", "b", "c", "d"], 3)).toStrictEqual([
+      ["a", "b", "c"],
+      ["d"],
+    ]);
   });
 
   test("1 element", () => {
-    expect(chunk(["x"], 3)).toEqual([["x"]]);
+    expect(chunk(["x"], 3)).toStrictEqual([["x"]]);
   });
 
   test("empty array", () => {
-    expect(chunk([], 3)).toEqual([]);
+    expect(chunk([], 3)).toStrictEqual([]);
   });
 });
 
 describe("data last", () => {
   test("equal size", () => {
-    expect(chunk(2)(["a", "b", "c", "d"])).toEqual([
+    expect(chunk(2)(["a", "b", "c", "d"])).toStrictEqual([
       ["a", "b"],
       ["c", "d"],
     ]);

--- a/src/clamp.test.ts
+++ b/src/clamp.test.ts
@@ -1,13 +1,13 @@
 import { clamp } from "./clamp";
 
 it("min value", () => {
-  expect(clamp(10, { min: 20 })).toEqual(20);
+  expect(clamp(10, { min: 20 })).toBe(20);
 });
 
 it("max value", () => {
-  expect(clamp(10, { max: 5 })).toEqual(5);
+  expect(clamp(10, { max: 5 })).toBe(5);
 });
 
 it("ok value", () => {
-  expect(clamp(10, { max: 20, min: 5 })).toEqual(10);
+  expect(clamp(10, { max: 20, min: 5 })).toBe(10);
 });

--- a/src/clone.test.ts
+++ b/src/clone.test.ts
@@ -26,6 +26,7 @@ describe("objects", () => {
   it("clones shallow object", () => {
     const obj = { a: 1, b: "foo", c: true, d: new Date(2013, 11, 25) };
     const cloned = clone(obj);
+
     expect(cloned).not.toBe(obj);
     expect(cloned).toStrictEqual(obj);
 
@@ -43,6 +44,7 @@ describe("objects", () => {
   it("clones deep object", () => {
     const obj = { a: { b: { c: "foo" } } };
     const cloned = clone(obj);
+
     expect(cloned).not.toBe(obj);
     expect(cloned).toStrictEqual(obj);
 
@@ -74,6 +76,7 @@ describe("objects", () => {
     expect(cloned.c.b.a.c).toStrictEqual(x.c.b.a.c);
 
     x.c.b = 1;
+
     expect(cloned.c.b).not.toStrictEqual(x.c.b);
   });
 });
@@ -82,10 +85,12 @@ describe("arrays", () => {
   it("clones shallow arrays", () => {
     const list = [1, 2, 3];
     const cloned = clone(list);
+
     expect(cloned).not.toBe(list);
     expect(cloned).toStrictEqual(list);
 
     list.pop();
+
     expect(cloned).not.toStrictEqual(list);
     expect(cloned).toStrictEqual([1, 2, 3]);
   });
@@ -93,6 +98,7 @@ describe("arrays", () => {
   it("clones deep arrays", () => {
     const list: any = [1, [1, 2, 3], [[[5]]]];
     const cloned = clone(list);
+
     expect(cloned).not.toBe(list);
     expect(cloned).toStrictEqual(list);
 
@@ -110,6 +116,7 @@ describe("functions", () => {
   it("keep reference to function", () => {
     const list = [{ a: (x: number): number => x + x }] as const;
     const cloned = clone(list);
+
     expect(cloned).not.toBe(list);
     expect(cloned).toStrictEqual(list);
 
@@ -127,7 +134,7 @@ describe("built-in types", () => {
     expect(cloned).not.toBe(date);
     expect(cloned).toStrictEqual(new Date(2014, 10, 14, 23, 59, 59, 999));
 
-    expect(cloned.getDay()).toStrictEqual(5); // friday
+    expect(cloned.getDay()).toBe(5); // friday
   });
 
   it.each([
@@ -144,6 +151,7 @@ describe("built-in types", () => {
     /x/,
   ])("clones RegExp object: %s", (pattern) => {
     const cloned = clone(pattern);
+
     expect(cloned).not.toBe(pattern);
     expect(cloned).toStrictEqual(pattern);
     expect(cloned.constructor).toStrictEqual(RegExp);
@@ -159,6 +167,7 @@ describe("nested mixed objects", () => {
     const list: any = [{ a: { b: 1 } }, [{ c: { d: 1 } }]];
     const cloned = clone(list);
     list[1][0] = null;
+
     expect(cloned).toStrictEqual([{ a: { b: 1 } }, [{ c: { d: 1 } }]]);
   });
 
@@ -167,6 +176,7 @@ describe("nested mixed objects", () => {
       const list: Array<Array<any>> = [[1], [[3]]];
       const cloned = clone(list);
       list[1]![0] = null;
+
       expect(cloned).toStrictEqual([[1], [[3]]]);
     });
 
@@ -186,6 +196,7 @@ describe("nested mixed objects", () => {
       expect(cloned[1]?.b).toStrictEqual({ a: 1 });
 
       obj.a = 2;
+
       expect(cloned[0]?.b).toStrictEqual({ a: 1 });
       expect(cloned[1]?.b).toStrictEqual({ a: 1 });
     });
@@ -203,11 +214,13 @@ describe("edge cases", () => {
 
   test("empty object", () => {
     const obj = {} as const;
+
     expect(clone(obj)).not.toBe(obj);
   });
 
   test("empty array", () => {
     const array = [] as const;
+
     expect(clone(array)).not.toBe(array);
   });
 });

--- a/src/concat.test.ts
+++ b/src/concat.test.ts
@@ -5,7 +5,7 @@ describe("data first", () => {
   test("concat", () => {
     const actual = concat([1, 2, 3] as const, ["a"] as const);
 
-    expect(actual).toEqual([1, 2, 3, "a"] as const);
+    expect(actual).toStrictEqual([1, 2, 3, "a"] as const);
   });
 });
 
@@ -13,6 +13,6 @@ describe("data last", () => {
   test("concat", () => {
     const actual = pipe([1, 2, 3] as const, concat(["a"] as const));
 
-    expect(actual).toEqual([1, 2, 3, "a"]);
+    expect(actual).toStrictEqual([1, 2, 3, "a"]);
   });
 });

--- a/src/concat.test.ts
+++ b/src/concat.test.ts
@@ -4,6 +4,7 @@ import { pipe } from "./pipe";
 describe("data first", () => {
   test("concat", () => {
     const actual = concat([1, 2, 3] as const, ["a"] as const);
+
     expect(actual).toEqual([1, 2, 3, "a"] as const);
   });
 });
@@ -11,6 +12,7 @@ describe("data first", () => {
 describe("data last", () => {
   test("concat", () => {
     const actual = pipe([1, 2, 3] as const, concat(["a"] as const));
+
     expect(actual).toEqual([1, 2, 3, "a"]);
   });
 });

--- a/src/conditional.test.ts
+++ b/src/conditional.test.ts
@@ -13,7 +13,7 @@ describe("runtime (dataFirst)", () => {
         "Jokic",
         conditional.defaultCase(() => "hello"),
       ),
-    ).toEqual("hello");
+    ).toBe("hello");
   });
 
   it("works with a single case", () => {
@@ -61,6 +61,7 @@ describe("runtime (dataLast)", () => {
         [isDeepEqual("Jokic"), () => "mvp"],
       ),
     );
+
     expect(value).toBe("center");
   });
 });

--- a/src/constant.test.ts
+++ b/src/constant.test.ts
@@ -7,6 +7,7 @@ import { times } from "./times";
 
 test("works", () => {
   const one = constant(1);
+
   expect(one()).toBe(1);
 });
 
@@ -14,6 +15,7 @@ test("returns identity (doesn't clone)", () => {
   const obj = {} as { a?: boolean };
   const emptyObj = constant(obj);
   const firstInvocation = emptyObj();
+
   expect(firstInvocation).toEqual({});
   expect(firstInvocation).toBe(obj);
 
@@ -27,6 +29,7 @@ test("returns identity (doesn't clone)", () => {
 
 test("works with more than one argument", () => {
   const one = constant(1);
+
   expect(one(1)).toBe(1);
   expect(one(1, 2)).toBe(1);
   expect(one(1, 2, "a")).toBe(1);
@@ -37,6 +40,7 @@ test("works with more than one argument", () => {
 test("works with variadic arguments", () => {
   const data = [1, 2, 3] as const;
   const one = constant("a");
+
   expect(one(...data)).toBe("a");
 });
 
@@ -45,7 +49,7 @@ test("can be put in a pipe", () => {
 });
 
 test("can completely change the type of the pipe", () => {
-  expect(pipe([1, 2, 3], constant("hello world"), sliceString(0, 4))).toEqual(
+  expect(pipe([1, 2, 3], constant("hello world"), sliceString(0, 4))).toBe(
     "hell",
   );
 });

--- a/src/constant.test.ts
+++ b/src/constant.test.ts
@@ -16,14 +16,14 @@ test("returns identity (doesn't clone)", () => {
   const emptyObj = constant(obj);
   const firstInvocation = emptyObj();
 
-  expect(firstInvocation).toEqual({});
+  expect(firstInvocation).toStrictEqual({});
   expect(firstInvocation).toBe(obj);
 
   obj.a = true;
 
-  expect(firstInvocation).toEqual({ a: true });
+  expect(firstInvocation).toStrictEqual({ a: true });
 
-  expect(emptyObj()).toEqual({ a: true });
+  expect(emptyObj()).toStrictEqual({ a: true });
   expect(emptyObj()).toBe(obj);
 });
 
@@ -45,7 +45,9 @@ test("works with variadic arguments", () => {
 });
 
 test("can be put in a pipe", () => {
-  expect(pipe([1, 2, 3], constant([2, 3, 4]), map(add(1)))).toEqual([3, 4, 5]);
+  expect(pipe([1, 2, 3], constant([2, 3, 4]), map(add(1)))).toStrictEqual([
+    3, 4, 5,
+  ]);
 });
 
 test("can completely change the type of the pipe", () => {
@@ -55,7 +57,7 @@ test("can completely change the type of the pipe", () => {
 });
 
 test("can be used as a fill function (with times)", () => {
-  expect(times(10, constant("a"))).toEqual([
+  expect(times(10, constant("a"))).toStrictEqual([
     "a",
     "a",
     "a",

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -11,7 +11,7 @@ describe("main functionality", () => {
       debouncer.call("a"),
       debouncer.call("b"),
       debouncer.call("c"),
-    ]).toEqual([undefined, undefined, undefined]);
+    ]).toStrictEqual([undefined, undefined, undefined]);
     expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(128);
@@ -21,7 +21,7 @@ describe("main functionality", () => {
       debouncer.call("d"),
       debouncer.call("e"),
       debouncer.call("f"),
-    ]).toEqual(["c", "c", "c"]);
+    ]).toStrictEqual(["c", "c", "c"]);
     expect(mockFn).toHaveBeenCalledTimes(1);
 
     await sleep(256);
@@ -106,11 +106,17 @@ describe("main functionality", () => {
   it("subsequent leading debounced calls return the last `func` result", async () => {
     const debouncer = debounce(identity(), { waitMs: 32, timing: "leading" });
 
-    expect([debouncer.call("a"), debouncer.call("b")]).toEqual(["a", "a"]);
+    expect([debouncer.call("a"), debouncer.call("b")]).toStrictEqual([
+      "a",
+      "a",
+    ]);
 
     await sleep(64);
 
-    expect([debouncer.call("c"), debouncer.call("d")]).toEqual(["c", "c"]);
+    expect([debouncer.call("c"), debouncer.call("d")]).toStrictEqual([
+      "c",
+      "c",
+    ]);
   });
 
   it("should support a `trailing` option", async () => {
@@ -271,7 +277,7 @@ describe("additional functionality", () => {
 
     await sleep(32);
 
-    expect(debouncer.call()).toEqual(data);
+    expect(debouncer.call()).toStrictEqual(data);
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -1,7 +1,7 @@
 import { debounce } from "./debounce";
 import { identity } from "./identity";
 
-describe("Main functionality", () => {
+describe("main functionality", () => {
   it("should debounce a function", async () => {
     const mockFn = vi.fn(identity());
 
@@ -12,21 +12,21 @@ describe("Main functionality", () => {
       debouncer.call("b"),
       debouncer.call("c"),
     ]).toEqual([undefined, undefined, undefined]);
-    expect(mockFn).toBeCalledTimes(0);
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(128);
 
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
     expect([
       debouncer.call("d"),
       debouncer.call("e"),
       debouncer.call("f"),
     ]).toEqual(["c", "c", "c"]);
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
 
     await sleep(256);
 
-    expect(mockFn).toBeCalledTimes(2);
+    expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
   it("subsequent debounced calls return the last `func` result", async () => {
@@ -34,10 +34,12 @@ describe("Main functionality", () => {
     debouncer.call("a");
 
     await sleep(64);
-    expect(debouncer.call("b")).toEqual("a");
+
+    expect(debouncer.call("b")).toBe("a");
 
     await sleep(128);
-    expect(debouncer.call("c")).toEqual("b");
+
+    expect(debouncer.call("c")).toBe("b");
   });
 
   it("should not immediately call `func` when `wait` is `0`", async () => {
@@ -47,10 +49,12 @@ describe("Main functionality", () => {
 
     debouncer.call();
     debouncer.call();
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(5);
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
   it("should apply default options", async () => {
@@ -59,10 +63,12 @@ describe("Main functionality", () => {
     const debouncer = debounce(mockFn, { waitMs: 32 });
 
     debouncer.call();
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(64);
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
   it("should support a `leading` option", async () => {
@@ -75,7 +81,8 @@ describe("Main functionality", () => {
     });
 
     withLeading.call();
-    expect(leadingMockFn).toBeCalledTimes(1);
+
+    expect(leadingMockFn).toHaveBeenCalledTimes(1);
 
     const withLeadingAndTrailing = debounce(bothMockFn, {
       waitMs: 32,
@@ -84,13 +91,16 @@ describe("Main functionality", () => {
 
     withLeadingAndTrailing.call();
     withLeadingAndTrailing.call();
-    expect(bothMockFn).toBeCalledTimes(1);
+
+    expect(bothMockFn).toHaveBeenCalledTimes(1);
 
     await sleep(64);
-    expect(bothMockFn).toBeCalledTimes(2);
+
+    expect(bothMockFn).toHaveBeenCalledTimes(2);
 
     withLeading.call();
-    expect(leadingMockFn).toBeCalledTimes(2);
+
+    expect(leadingMockFn).toHaveBeenCalledTimes(2);
   });
 
   it("subsequent leading debounced calls return the last `func` result", async () => {
@@ -99,6 +109,7 @@ describe("Main functionality", () => {
     expect([debouncer.call("a"), debouncer.call("b")]).toEqual(["a", "a"]);
 
     await sleep(64);
+
     expect([debouncer.call("c"), debouncer.call("d")]).toEqual(["c", "c"]);
   });
 
@@ -108,14 +119,16 @@ describe("Main functionality", () => {
     const withTrailing = debounce(mockFn, { waitMs: 32, timing: "trailing" });
 
     withTrailing.call();
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(64);
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("Optional param maxWaitMs", () => {
+describe("optional param maxWaitMs", () => {
   it("should support a `maxWait` option", async () => {
     const mockFn = vi.fn(identity());
 
@@ -123,16 +136,21 @@ describe("Optional param maxWaitMs", () => {
 
     debouncer.call("a");
     debouncer.call("b");
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(128);
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
     debouncer.call("c");
     debouncer.call("d");
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
 
     await sleep(256);
-    expect(mockFn).toBeCalledTimes(2);
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
   it("should support `maxWait` in a tight loop", async () => {
@@ -149,8 +167,9 @@ describe("Optional param maxWaitMs", () => {
     }
 
     await sleep(1);
-    expect(withoutMockFn).toBeCalledTimes(0);
-    expect(withMockFn).not.toBeCalledTimes(0);
+
+    expect(withoutMockFn).toHaveBeenCalledTimes(0);
+    expect(withMockFn).not.toHaveBeenCalledTimes(0);
   });
 
   it("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
@@ -171,7 +190,8 @@ describe("Optional param maxWaitMs", () => {
     }, 210);
 
     await sleep(500);
-    expect(mockFn).toBeCalledTimes(2);
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
   it("should cancel `maxDelayed` when `delayed` is invoked", async () => {
@@ -183,10 +203,12 @@ describe("Optional param maxWaitMs", () => {
 
     await sleep(128);
     debouncer.call();
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
 
     await sleep(192);
-    expect(mockFn).toBeCalledTimes(2);
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
   it("works like a leaky bucket when only maxWaitMs is set", async () => {
@@ -195,31 +217,36 @@ describe("Optional param maxWaitMs", () => {
     const debouncer = debounce(mockFn, { maxWaitMs: 32 });
 
     debouncer.call();
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(16);
 
     // Without maxWaitMs this call would cause the actual invocation to be
     // postponed for a full window.
     debouncer.call();
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(17);
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("Additional functionality", () => {
+describe("additional functionality", () => {
   it("can cancel before the timer starts", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
+
     expect(() => {
       debouncer.cancel();
     }).not.toThrow();
 
     expect(debouncer.call("hello")).toBeUndefined();
+
     await sleep(32);
 
-    expect(debouncer.call("world")).toEqual("hello");
+    expect(debouncer.call("world")).toBe("hello");
   });
 
   it("can cancel the timer", async () => {
@@ -228,28 +255,34 @@ describe("Additional functionality", () => {
     const debouncer = debounce(mockFn, { waitMs: 32 });
 
     expect(debouncer.call()).toBeUndefined();
-    expect(mockFn).toBeCalledTimes(0);
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(1);
+
     expect(debouncer.call()).toBeUndefined();
-    expect(mockFn).toBeCalledTimes(0);
+    expect(mockFn).toHaveBeenCalledTimes(0);
+
     debouncer.cancel();
 
     await sleep(32);
+
     expect(debouncer.call()).toBeUndefined();
-    expect(mockFn).toBeCalledTimes(0);
+    expect(mockFn).toHaveBeenCalledTimes(0);
 
     await sleep(32);
+
     expect(debouncer.call()).toEqual(data);
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
   it("can cancel after the timer ends", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
+
     expect(debouncer.call("hello")).toBeUndefined();
+
     await sleep(32);
 
-    expect(debouncer.call("world")).toEqual("hello");
+    expect(debouncer.call("world")).toBe("hello");
     expect(() => {
       debouncer.cancel();
     }).not.toThrow();
@@ -257,83 +290,101 @@ describe("Additional functionality", () => {
 
   it("can cancel maxWait timer", async () => {
     const debouncer = debounce(identity(), { waitMs: 16, maxWaitMs: 32 });
+
     expect(debouncer.call("hello")).toBeUndefined();
 
     await sleep(1);
     debouncer.cancel();
 
     await sleep(32);
+
     expect(debouncer.call("world")).toBeUndefined();
   });
 
   it("can return a cached value", () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
+
     expect(debouncer.cachedValue).toBeUndefined();
-    expect(debouncer.call("hello")).toEqual("hello");
-    expect(debouncer.cachedValue).toEqual("hello");
+    expect(debouncer.call("hello")).toBe("hello");
+    expect(debouncer.cachedValue).toBe("hello");
   });
 
   it("can check for inflight timers (trailing)", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
-    expect(debouncer.isPending).toEqual(false);
+
+    expect(debouncer.isPending).toBe(false);
 
     expect(debouncer.call("hello")).toBeUndefined();
-    expect(debouncer.isPending).toEqual(true);
+    expect(debouncer.isPending).toBe(true);
 
     await sleep(1);
-    expect(debouncer.isPending).toEqual(true);
+
+    expect(debouncer.isPending).toBe(true);
 
     await sleep(32);
-    expect(debouncer.isPending).toEqual(false);
+
+    expect(debouncer.isPending).toBe(false);
   });
 
   it("can check for inflight timers (leading)", async () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
-    expect(debouncer.isPending).toEqual(false);
 
-    expect(debouncer.call("hello")).toEqual("hello");
-    expect(debouncer.isPending).toEqual(true);
+    expect(debouncer.isPending).toBe(false);
+
+    expect(debouncer.call("hello")).toBe("hello");
+    expect(debouncer.isPending).toBe(true);
 
     await sleep(1);
-    expect(debouncer.isPending).toEqual(true);
+
+    expect(debouncer.isPending).toBe(true);
 
     await sleep(32);
-    expect(debouncer.isPending).toEqual(false);
+
+    expect(debouncer.isPending).toBe(false);
   });
 
   it("can flush before a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
+
     expect(debouncer.flush()).toBeUndefined();
 
     expect(debouncer.call("hello")).toBeUndefined();
+
     await sleep(32);
 
-    expect(debouncer.call("world")).toEqual("hello");
+    expect(debouncer.call("world")).toBe("hello");
   });
 
   it("can flush during a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
+
     expect(debouncer.call("hello")).toBeUndefined();
 
     await sleep(1);
+
     expect(debouncer.call("world")).toBeUndefined();
 
     await sleep(1);
-    expect(debouncer.flush()).toEqual("world");
+
+    expect(debouncer.flush()).toBe("world");
   });
 
   it("can flush after a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
+
     expect(debouncer.call("hello")).toBeUndefined();
 
     await sleep(32);
-    expect(debouncer.flush()).toEqual("hello");
+
+    expect(debouncer.flush()).toBe("hello");
   });
 });
 
 describe("errors", () => {
   it("prevents maxWaitMs to be less then waitMs", () => {
-    expect(() => debounce(identity(), { waitMs: 32, maxWaitMs: 16 })).toThrow();
+    expect(() => debounce(identity(), { waitMs: 32, maxWaitMs: 16 })).toThrow(
+      "debounce: maxWaitMs (16) cannot be less than waitMs (32)",
+    );
   });
 });
 

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -287,7 +287,7 @@ describe("Additional functionality", () => {
     expect(debouncer.isPending).toEqual(false);
   });
 
-  it("can check for inflight timers (trailing)", async () => {
+  it("can check for inflight timers (leading)", async () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
     expect(debouncer.isPending).toEqual(false);
 

--- a/src/difference.test.ts
+++ b/src/difference.test.ts
@@ -75,5 +75,5 @@ test("lazy", () => {
   );
 
   expect(mock).toHaveBeenCalledTimes(4);
-  expect(result).toEqual([1, 4]);
+  expect(result).toStrictEqual([1, 4]);
 });

--- a/src/difference.test.ts
+++ b/src/difference.test.ts
@@ -15,6 +15,7 @@ it("removes nothing on empty other array", () => {
 it("returns a shallow clone when nothing is removed", () => {
   const data = [1, 2, 3];
   const result = difference(data, [4, 5, 6]);
+
   expect(result).toStrictEqual(data);
   expect(result).not.toBe(data);
 });
@@ -51,6 +52,7 @@ it("works with strings", () => {
 
 it("works with objects", () => {
   const item = { a: 2 };
+
   expect(difference([item, { b: 3 }, item], [item, item])).toStrictEqual([
     { b: 3 },
   ]);
@@ -71,6 +73,7 @@ test("lazy", () => {
     difference([2, 3]),
     take(2),
   );
+
   expect(mock).toHaveBeenCalledTimes(4);
   expect(result).toEqual([1, 4]);
 });

--- a/src/differenceWith.test.ts
+++ b/src/differenceWith.test.ts
@@ -42,6 +42,7 @@ describe("data_last", () => {
       differenceWith([{ a: 2 }, { a: 3 }], isDeepEqual),
       take(2),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(4);
     expect(result).toEqual([{ a: 1 }, { a: 4 }]);
   });

--- a/src/differenceWith.test.ts
+++ b/src/differenceWith.test.ts
@@ -10,19 +10,19 @@ const expected = [{ a: 1 }, { a: 4 }];
 
 describe("data_first", () => {
   test("should return difference", () => {
-    expect(differenceWith(source, other, isDeepEqual)).toEqual(expected);
+    expect(differenceWith(source, other, isDeepEqual)).toStrictEqual(expected);
   });
 
   test("should allow differencing different data types", () => {
     expect(
       differenceWith([1, 2, 3, 4], ["2", "3"], (a, b) => a.toString() === b),
-    ).toEqual([1, 4]);
+    ).toStrictEqual([1, 4]);
   });
 });
 
 describe("data_last", () => {
   test("should return difference", () => {
-    expect(differenceWith(other, isDeepEqual)(source)).toEqual(expected);
+    expect(differenceWith(other, isDeepEqual)(source)).toStrictEqual(expected);
   });
 
   test("should allow differencing different data types", () => {
@@ -31,7 +31,7 @@ describe("data_last", () => {
         [1, 2, 3, 4],
         differenceWith(["2", "3"], (a, b) => a.toString() === b),
       ),
-    ).toEqual([1, 4]);
+    ).toStrictEqual([1, 4]);
   });
 
   test("lazy", () => {
@@ -44,6 +44,6 @@ describe("data_last", () => {
     );
 
     expect(counter.count).toHaveBeenCalledTimes(4);
-    expect(result).toEqual([{ a: 1 }, { a: 4 }]);
+    expect(result).toStrictEqual([{ a: 1 }, { a: 4 }]);
   });
 });

--- a/src/divide.test.ts
+++ b/src/divide.test.ts
@@ -1,9 +1,9 @@
 import { divide } from "./divide";
 
 test("data-first", () => {
-  expect(divide(12, 3)).toEqual(4);
+  expect(divide(12, 3)).toBe(4);
 });
 
 test("data-last", () => {
-  expect(divide(3)(12)).toEqual(4);
+  expect(divide(3)(12)).toBe(4);
 });

--- a/src/doNothing.test.ts
+++ b/src/doNothing.test.ts
@@ -1,15 +1,33 @@
+//! IMPORTANT: It's impossible to verify that a function does nothing without checking it's implementation, so there aren't any obvious way to expect some result. This clashes with the expectations of the vitest eslint plugin rule vitest/valid-expect. To work around this we wrapped all our calls and expect them not to throw. It doesn't mean we think this function would throw in **any** case!
+
 import { doNothing } from "./doNothing";
 
-test("works", () => {
+it("does nothing when called with no arguments", () => {
   const doesNothing = doNothing();
-  doesNothing();
+  expect(() => {
+    doesNothing();
+  }).not.toThrow();
 });
 
-test("works with more than one argument", () => {
+it("ignores any parameters sent to the function", () => {
   const doesNothing = doNothing();
-  doesNothing(1);
-  doesNothing(1, 2);
-  doesNothing(1, 2, "a");
-  doesNothing(undefined);
-  doesNothing(["a"]);
+  expect(() => {
+    doesNothing(1);
+  }).not.toThrow();
+
+  expect(() => {
+    doesNothing(1, 2);
+  }).not.toThrow();
+
+  expect(() => {
+    doesNothing(1, 2, "a");
+  }).not.toThrow();
+
+  expect(() => {
+    doesNothing(undefined);
+  }).not.toThrow();
+
+  expect(() => {
+    doesNothing(["a"]);
+  }).not.toThrow();
 });

--- a/src/doNothing.test.ts
+++ b/src/doNothing.test.ts
@@ -4,6 +4,7 @@ import { doNothing } from "./doNothing";
 
 it("does nothing when called with no arguments", () => {
   const doesNothing = doNothing();
+
   expect(() => {
     doesNothing();
   }).not.toThrow();
@@ -11,6 +12,7 @@ it("does nothing when called with no arguments", () => {
 
 it("ignores any parameters sent to the function", () => {
   const doesNothing = doNothing();
+
   expect(() => {
     doesNothing(1);
   }).not.toThrow();

--- a/src/drop.test-d.ts
+++ b/src/drop.test-d.ts
@@ -30,7 +30,7 @@ describe("data-first", () => {
   });
 
   describe("arrays with a prefix (2) and a suffix (2)", () => {
-    test("N === 0 (no drop)", () => {
+    test("n === 0 (no drop)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         0,
@@ -40,7 +40,7 @@ describe("data-first", () => {
       >();
     });
 
-    test("N === 1 (drop from the prefix)", () => {
+    test("n === 1 (drop from the prefix)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         1,
@@ -50,7 +50,7 @@ describe("data-first", () => {
       >();
     });
 
-    test("N === 2 (remove the prefix)", () => {
+    test("n === 2 (remove the prefix)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         2,
@@ -58,7 +58,7 @@ describe("data-first", () => {
       expectTypeOf(result).toEqualTypeOf<[...Array<boolean>, string, string]>();
     });
 
-    test("N === 3 (drop the whole prefix, remove from the suffix)", () => {
+    test("n === 3 (drop the whole prefix, remove from the suffix)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         3,
@@ -68,7 +68,7 @@ describe("data-first", () => {
       >();
     });
 
-    test("N === 4 (drop the whole prefix, drop the whole suffix)", () => {
+    test("n === 4 (drop the whole prefix, drop the whole suffix)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         4,
@@ -78,7 +78,7 @@ describe("data-first", () => {
       >();
     });
 
-    test("N > 4 (drop more than the constant parts of the array)", () => {
+    test("n > 4 (drop more than the constant parts of the array)", () => {
       const result = drop(
         [1, 2, "a", "b"] as [number, number, ...Array<boolean>, string, string],
         5,

--- a/src/drop.test.ts
+++ b/src/drop.test.ts
@@ -24,6 +24,7 @@ describe("data first", () => {
   test("returns a shallow clone when no items are dropped", () => {
     const data = [1, 2, 3, 4, 5];
     const result = drop(data, 0);
+
     expect(result).toStrictEqual([1, 2, 3, 4, 5]);
     expect(result).not.toBe(data);
   });
@@ -49,6 +50,7 @@ describe("data last", () => {
   test("lazy impl", () => {
     const mockFunc = vi.fn(identity());
     pipe([1, 2, 3, 4, 5], map(mockFunc), drop(2), take(2));
+
     expect(mockFunc).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/dropFirstBy.test.ts
+++ b/src/dropFirstBy.test.ts
@@ -5,27 +5,32 @@ import { pipe } from "./pipe";
 describe("runtime (dataFirst)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(dropFirstBy(data, 2, identity())).toEqual([5, 6, 4, 3, 7]);
   });
 
   it("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
+
     expect(dropFirstBy(data, 1, identity())).toHaveLength(0);
   });
 
   it("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(dropFirstBy(data, -3, identity())).toHaveLength(data.length);
   });
 
   it("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(dropFirstBy(data, 100, identity())).toHaveLength(0);
   });
 
   it("clones the input when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = dropFirstBy(data, 0, identity());
+
     expect(result).not.toBe(data);
     expect(result).toEqual(data);
   });
@@ -43,6 +48,7 @@ describe("runtime (dataFirst)", () => {
       "b",
       "aaaaa",
     ];
+
     expect(dropFirstBy(data, 3, (x) => x.length, identity())).toEqual([
       "bbbbb",
       "aaa",
@@ -58,6 +64,7 @@ describe("runtime (dataFirst)", () => {
 describe("runtime (dataLast)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -68,6 +75,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
+
     expect(
       pipe(
         data,
@@ -78,6 +86,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -88,6 +97,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -102,6 +112,7 @@ describe("runtime (dataLast)", () => {
       data,
       dropFirstBy(0, (x) => x),
     );
+
     expect(result).not.toBe(data);
     expect(result).toEqual(data);
   });
@@ -119,6 +130,7 @@ describe("runtime (dataLast)", () => {
       "b",
       "aaaaa",
     ];
+
     expect(
       pipe(
         data,

--- a/src/dropFirstBy.test.ts
+++ b/src/dropFirstBy.test.ts
@@ -6,7 +6,7 @@ describe("runtime (dataFirst)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
-    expect(dropFirstBy(data, 2, identity())).toEqual([5, 6, 4, 3, 7]);
+    expect(dropFirstBy(data, 2, identity())).toStrictEqual([5, 6, 4, 3, 7]);
   });
 
   it("handles empty arrays gracefully", () => {
@@ -32,7 +32,7 @@ describe("runtime (dataFirst)", () => {
     const result = dropFirstBy(data, 0, identity());
 
     expect(result).not.toBe(data);
-    expect(result).toEqual(data);
+    expect(result).toStrictEqual(data);
   });
 
   it("works with complex compare rules", () => {
@@ -49,7 +49,7 @@ describe("runtime (dataFirst)", () => {
       "aaaaa",
     ];
 
-    expect(dropFirstBy(data, 3, (x) => x.length, identity())).toEqual([
+    expect(dropFirstBy(data, 3, (x) => x.length, identity())).toStrictEqual([
       "bbbbb",
       "aaa",
       "bbb",
@@ -70,7 +70,7 @@ describe("runtime (dataLast)", () => {
         data,
         dropFirstBy(2, (x) => x),
       ),
-    ).toEqual([5, 6, 4, 3, 7]);
+    ).toStrictEqual([5, 6, 4, 3, 7]);
   });
 
   it("handles empty arrays gracefully", () => {
@@ -114,7 +114,7 @@ describe("runtime (dataLast)", () => {
     );
 
     expect(result).not.toBe(data);
-    expect(result).toEqual(data);
+    expect(result).toStrictEqual(data);
   });
 
   it("works with complex compare rules", () => {
@@ -140,6 +140,6 @@ describe("runtime (dataLast)", () => {
           (x) => x,
         ),
       ),
-    ).toEqual(["bbbbb", "aaa", "bbb", "bbbb", "aaaa", "bb", "aaaaa"]);
+    ).toStrictEqual(["bbbbb", "aaa", "bbb", "bbbb", "aaaa", "bb", "aaaaa"]);
   });
 });

--- a/src/dropLast.test.ts
+++ b/src/dropLast.test.ts
@@ -4,29 +4,30 @@ test("empty array", () => {
   expect(dropLast([], 2)).toStrictEqual([]);
 });
 
-test("N < 0", () => {
+test("n < 0", () => {
   expect(dropLast([1, 2, 3, 4, 5], -1)).toStrictEqual([1, 2, 3, 4, 5]);
 });
 
-test("N === 0", () => {
+test("n === 0", () => {
   expect(dropLast([1, 2, 3, 4, 5], 0)).toStrictEqual([1, 2, 3, 4, 5]);
 });
 
-test("N < length", () => {
+test("n < length", () => {
   expect(dropLast([1, 2, 3, 4, 5], 2)).toStrictEqual([1, 2, 3]);
 });
 
-test("N === length", () => {
+test("n === length", () => {
   expect(dropLast([1, 2, 3, 4, 5], 5)).toStrictEqual([]);
 });
 
-test("N > length", () => {
+test("n > length", () => {
   expect(dropLast([1, 2, 3, 4, 5], 10)).toStrictEqual([]);
 });
 
 test("should return a new array even if there was no drop", () => {
   const data = [1, 2, 3, 4, 5];
   const result = dropLast(data, 0);
+
   expect(result).not.toBe(data);
   expect(result).toStrictEqual(data);
 });

--- a/src/dropLastWhile.test.ts
+++ b/src/dropLastWhile.test.ts
@@ -21,6 +21,7 @@ describe("data first", () => {
   it("should return a copy of the array when the last item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = dropLastWhile(data, (n) => n !== 4);
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -69,6 +70,7 @@ describe("data last", () => {
       data,
       dropLastWhile((n) => n !== 4),
     );
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });

--- a/src/dropWhile.test.ts
+++ b/src/dropWhile.test.ts
@@ -21,6 +21,7 @@ describe("data first", () => {
   it("should return a copy of the array when the first item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = dropWhile(data, (n) => n !== 1);
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -69,6 +70,7 @@ describe("data last", () => {
       data,
       dropWhile((n) => n !== 1),
     );
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });

--- a/src/endsWith.test-d.ts
+++ b/src/endsWith.test-d.ts
@@ -109,6 +109,7 @@ describe("data-last", () => {
 
   test("template literal data that matches", () => {
     const [yes, no] = partition([] as Array<`${number}_bar`>, endsWith("bar"));
+    // eslint-disable-next-line vitest/valid-expect -- the `branded` accessor isn't currently supported by the plugin. See https://github.com/vitest-dev/eslint-plugin-vitest/issues/539
     expectTypeOf(yes).branded.toEqualTypeOf<Array<`${number}_bar`>>();
     expectTypeOf(no).toEqualTypeOf<Array<never>>();
   });
@@ -137,6 +138,7 @@ describe("data-last", () => {
       [] as Array<`${boolean}_dog` | `${number}_cat`>,
       endsWith("t"),
     );
+    // eslint-disable-next-line vitest/valid-expect -- the `branded` accessor isn't currently supported by the plugin. See https://github.com/vitest-dev/eslint-plugin-vitest/issues/539
     expectTypeOf(yes).branded.toEqualTypeOf<Array<`${number}_cat`>>();
     expectTypeOf(no).toEqualTypeOf<Array<`${boolean}_dog`>>();
   });

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -18,10 +18,12 @@ it("should turn numbers to strings", () => {
 
 it("returns symbol values", () => {
   const mySymbol = Symbol("hello");
+
   expect(entries({ a: mySymbol })).toStrictEqual([["a", mySymbol]]);
 });
 
 it("works with complex objects as values", () => {
   const complexObject = { a: { b: { c: [{ d: true }, { d: false }] } } };
+
   expect(entries({ a: complexObject })).toStrictEqual([["a", complexObject]]);
 });

--- a/src/evolve.test.ts
+++ b/src/evolve.test.ts
@@ -40,6 +40,7 @@ describe("data first", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = evolve(data, { n: add(1) });
+
     expect(data).toStrictEqual({ n: 100 });
     expect(result).toStrictEqual(expected);
     expect(result).not.toBe(expected);
@@ -100,7 +101,8 @@ describe("data first", () => {
     const mySymbol = Symbol("a");
     // @ts-expect-error [ts2418] - We want to test the runtime even if the typing prevents it.
     evolve({ [mySymbol]: "hello" }, { [mySymbol]: mock });
-    expect(mock).toBeCalledTimes(0);
+
+    expect(mock).toHaveBeenCalledTimes(0);
   });
 
   it("ignore transformers for non-object values", () => {
@@ -144,6 +146,7 @@ describe("data last", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = pipe(data, evolve({ n: add(1) }));
+
     expect(data).toStrictEqual({ n: 100 });
     expect(result).toStrictEqual(expected);
     expect(result).not.toBe(expected);

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -5,16 +5,19 @@ import { pipe } from "./pipe";
 describe("data_first", () => {
   it("filter", () => {
     const result = filter([1, 2, 3], (x) => x % 2 === 1);
+
     expect(result).toEqual([1, 3]);
   });
 
   it("data_first with typescript guard", () => {
     const result = filter([1, 2, 3, "abc", true], isNumber);
+
     expect(result).toEqual([1, 2, 3]);
   });
 
   it("filter indexed", () => {
     const result = filter([1, 2, 3], (x, i) => x % 2 === 1 && i !== 1);
+
     expect(result).toEqual([1, 3]);
   });
 });
@@ -27,6 +30,7 @@ describe("data_last", () => {
       filter((x) => x % 2 === 1),
       map(counter),
     );
+
     expect(counter).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });
@@ -38,6 +42,7 @@ describe("data_last", () => {
       filter(isNumber),
       map(counter),
     );
+
     expect(counter).toHaveBeenCalledTimes(3);
     expect(result).toEqual([1, 2, 3]);
   });
@@ -49,6 +54,7 @@ describe("data_last", () => {
       filter((x, i) => x % 2 === 1 && i !== 1),
       map(counter),
     );
+
     expect(counter).toHaveBeenCalledTimes(2);
     expect(result).toEqual([1, 3]);
   });

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -6,19 +6,19 @@ describe("data_first", () => {
   it("filter", () => {
     const result = filter([1, 2, 3], (x) => x % 2 === 1);
 
-    expect(result).toEqual([1, 3]);
+    expect(result).toStrictEqual([1, 3]);
   });
 
   it("data_first with typescript guard", () => {
     const result = filter([1, 2, 3, "abc", true], isNumber);
 
-    expect(result).toEqual([1, 2, 3]);
+    expect(result).toStrictEqual([1, 2, 3]);
   });
 
   it("filter indexed", () => {
     const result = filter([1, 2, 3], (x, i) => x % 2 === 1 && i !== 1);
 
-    expect(result).toEqual([1, 3]);
+    expect(result).toStrictEqual([1, 3]);
   });
 });
 
@@ -32,7 +32,7 @@ describe("data_last", () => {
     );
 
     expect(counter).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([1, 3]);
+    expect(result).toStrictEqual([1, 3]);
   });
 
   it("filter with typescript guard", () => {
@@ -44,7 +44,7 @@ describe("data_last", () => {
     );
 
     expect(counter).toHaveBeenCalledTimes(3);
-    expect(result).toEqual([1, 2, 3]);
+    expect(result).toStrictEqual([1, 2, 3]);
   });
 
   it("filter indexed", () => {
@@ -56,7 +56,7 @@ describe("data_last", () => {
     );
 
     expect(counter).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([1, 3]);
+    expect(result).toStrictEqual([1, 3]);
   });
 });
 

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -64,6 +64,7 @@ describe("data last", () => {
       map(counter),
       find(({ b }, idx) => b === 2 && idx === 1),
     );
+
     expect(counter).toHaveBeenCalledTimes(2);
     expect(actual).toEqual({ a: 1, b: 2 });
   });

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -17,7 +17,7 @@ describe("data first", () => {
     ).toEqual({ a: 1, b: 2 });
   });
 
-  test("indexed ", () => {
+  test("indexed", () => {
     expect(
       find(
         [

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -14,7 +14,7 @@ describe("data first", () => {
         ],
         ({ b }) => b === 2,
       ),
-    ).toEqual({ a: 1, b: 2 });
+    ).toStrictEqual({ a: 1, b: 2 });
   });
 
   test("indexed", () => {
@@ -28,7 +28,7 @@ describe("data first", () => {
         ],
         ({ b }, idx) => b === 2 && idx === 1,
       ),
-    ).toEqual({ a: 1, b: 2 });
+    ).toStrictEqual({ a: 1, b: 2 });
   });
 });
 
@@ -48,7 +48,7 @@ describe("data last", () => {
     );
 
     expect(counter).toHaveBeenCalledTimes(2);
-    expect(actual).toEqual({ a: 1, b: 2 });
+    expect(actual).toStrictEqual({ a: 1, b: 2 });
   });
 
   test("indexed", () => {
@@ -66,6 +66,6 @@ describe("data last", () => {
     );
 
     expect(counter).toHaveBeenCalledTimes(2);
-    expect(actual).toEqual({ a: 1, b: 2 });
+    expect(actual).toStrictEqual({ a: 1, b: 2 });
   });
 });

--- a/src/findIndex.test.ts
+++ b/src/findIndex.test.ts
@@ -18,7 +18,7 @@ describe("data last", () => {
         [10, 20, 30],
         findIndex((x) => x === 20),
       ),
-    ).toEqual(1);
+    ).toBe(1);
   });
 
   test("not found", () => {
@@ -27,6 +27,6 @@ describe("data last", () => {
         [2, 3, 4],
         findIndex((x) => x === 20),
       ),
-    ).toEqual(-1);
+    ).toBe(-1);
   });
 });

--- a/src/findLast.test.ts
+++ b/src/findLast.test.ts
@@ -3,14 +3,17 @@ import { pipe } from "./pipe";
 
 describe("data first", () => {
   test("findLast", () => {
-    expect(findLast([1, 2, 3, 4], (x) => x % 2 === 1)).toEqual(3);
+    expect(findLast([1, 2, 3, 4], (x) => x % 2 === 1)).toBe(3);
   });
+
   test("indexed", () => {
-    expect(findLast([1, 2, 3, 4], (x, i) => x === 3 && i === 2)).toEqual(3);
+    expect(findLast([1, 2, 3, 4], (x, i) => x === 3 && i === 2)).toBe(3);
   });
+
   test("findLast first value", () => {
-    expect(findLast([1, 2, 3, 4], (x) => x === 1)).toEqual(1);
+    expect(findLast([1, 2, 3, 4], (x) => x === 1)).toBe(1);
   });
+
   test("findLast no match", () => {
     expect(findLast([1, 2, 3, 4], (x) => x === 5)).toBeUndefined();
   });
@@ -23,7 +26,7 @@ describe("data last", () => {
         [1, 2, 3, 4],
         findLast((x) => x % 2 === 1),
       ),
-    ).toEqual(3);
+    ).toBe(3);
   });
 
   test("indexed", () => {
@@ -32,6 +35,6 @@ describe("data last", () => {
         [1, 2, 3, 4],
         findLast((x, i) => x === 3 && i === 2),
       ),
-    ).toEqual(3);
+    ).toBe(3);
   });
 });

--- a/src/findLastIndex.test.ts
+++ b/src/findLastIndex.test.ts
@@ -7,7 +7,7 @@ describe("data first", () => {
   });
 
   test("findLast first value", () => {
-    expect(findLastIndex([1, 2, 3, 4], (x) => x === 1)).toEqual(0);
+    expect(findLastIndex([1, 2, 3, 4], (x) => x === 1)).toBe(0);
   });
 
   test("findLastIndex -1", () => {
@@ -22,7 +22,7 @@ describe("data last", () => {
         [1, 2, 3, 4],
         findLastIndex((x) => x % 2 === 1),
       ),
-    ).toEqual(2);
+    ).toBe(2);
   });
 
   test("not found", () => {

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -4,19 +4,20 @@ import { first } from "./first";
 import { pipe } from "./pipe";
 
 test("should return first", () => {
-  expect(first([1, 2, 3] as const)).toEqual(1);
+  expect(first([1, 2, 3] as const)).toBe(1);
 });
 
 test("empty array", () => {
-  expect(first([])).toEqual(undefined);
+  expect(first([])).toBeUndefined();
 });
 
 describe("pipe", () => {
   test("as fn", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe([1, 2, 3, 4, 5, 6] as const, counter.fn(), first());
+
     expect(counter.count).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(1);
+    expect(result).toBe(1);
   });
 
   test("with filter", () => {
@@ -29,15 +30,17 @@ describe("pipe", () => {
       assertIsDefined,
       (x) => x + 1,
     );
+
     expect(counter.count).toHaveBeenCalledTimes(3);
-    expect(result).toEqual(5);
+    expect(result).toBe(5);
   });
 
   test("empty array", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe([] as const, counter.fn(), first());
+
     expect(counter.count).toHaveBeenCalledTimes(0);
-    expect(result).toEqual(undefined);
+    expect(result).toBeUndefined();
   });
 
   test("2 x first()", () => {
@@ -49,8 +52,9 @@ describe("pipe", () => {
       assertIsDefined,
       first(),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(1);
+    expect(result).toBe(1);
   });
 
   test("complex", () => {
@@ -66,106 +70,123 @@ describe("pipe", () => {
       filter((x) => x % 2 === 1),
       first(),
     );
+
     expect(counter1.count).toHaveBeenCalledTimes(3);
     expect(counter2.count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual(5);
+    expect(result).toBe(5);
   });
 });
 
 test("simple empty array", () => {
   const arr: Array<number> = [];
   const result = first(arr);
-  expect(result).toEqual(undefined);
+
+  expect(result).toBeUndefined();
 });
 
 test("simple array", () => {
   const arr: Array<number> = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("simple non-empty array", () => {
   const arr: [number, ...Array<number>] = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("simple tuple", () => {
   const arr: [number, string] = [1, "a"];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("array with more than one item", () => {
   const arr: [number, number, ...Array<number>] = [1, 2];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("trivial empty array", () => {
   const arr: [] = [];
   const result = first(arr);
-  expect(result).toEqual(undefined);
+
+  expect(result).toBeUndefined();
 });
 
 test("array with last", () => {
   const arr: [...Array<number>, number] = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("tuple with last", () => {
   const arr: [...Array<string>, number] = ["a", 1];
   const result = first(arr);
-  expect(result).toEqual("a");
+
+  expect(result).toBe("a");
 });
 
 test("simple empty readonly array", () => {
   const arr: ReadonlyArray<number> = [];
   const result = first(arr);
-  expect(result).toEqual(undefined);
+
+  expect(result).toBeUndefined();
 });
 
 test("simple readonly array", () => {
   const arr: ReadonlyArray<number> = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("simple non-empty readonly array", () => {
   const arr: readonly [number, ...Array<number>] = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("simple readonly tuple", () => {
   const arr: readonly [number, string] = [1, "a"];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("readonly array with more than one item", () => {
   const arr: readonly [number, number, ...Array<number>] = [1, 2];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("readonly trivial empty array", () => {
   const arr: readonly [] = [];
   const result = first(arr);
-  expect(result).toEqual(undefined);
+
+  expect(result).toBeUndefined();
 });
 
 test("readonly array with last", () => {
   const arr: readonly [...Array<number>, number] = [1];
   const result = first(arr);
-  expect(result).toEqual(1);
+
+  expect(result).toBe(1);
 });
 
 test("readonly tuple with last", () => {
   const arr: readonly [...Array<string>, number] = ["a", 1];
   const result = first(arr);
-  expect(result).toEqual("a");
+
+  expect(result).toBe("a");
 });
 
 const assertIsDefined = <T>(v: T | null | undefined): T => v!;

--- a/src/firstBy.test.ts
+++ b/src/firstBy.test.ts
@@ -33,6 +33,7 @@ describe("runtime (dataFirst)", () => {
 
   it("breaks ties with multiple order rules", () => {
     const data = ["a", "bb", "b", "aaaa", "bbb", "aa", "aaa", "bbbb"];
+
     expect(firstBy(data, (x) => x.length, identity())).toBe("a");
     expect(firstBy(data, [(x) => x.length, "desc"], identity())).toBe("aaaa");
     expect(firstBy(data, (x) => x.length, [identity(), "desc"])).toBe("b");
@@ -94,6 +95,7 @@ describe("runtime (dataLast)", () => {
 
   it("breaks ties with multiple order rules", () => {
     const data = ["a", "bb", "b", "aaaa", "bbb", "aa", "aaa", "bbbb"];
+
     expect(
       pipe(
         data,

--- a/src/firstBy.test.ts
+++ b/src/firstBy.test.ts
@@ -55,9 +55,9 @@ describe("runtime (dataFirst)", () => {
   });
 
   it("can compare valueOfs", () => {
-    expect(firstBy([new Date(), new Date(1), new Date(2)], identity())).toEqual(
-      new Date(1),
-    );
+    expect(
+      firstBy([new Date(), new Date(1), new Date(2)], identity()),
+    ).toStrictEqual(new Date(1));
   });
 });
 
@@ -136,6 +136,6 @@ describe("runtime (dataLast)", () => {
   it("can compare valueOfs", () => {
     expect(
       pipe([new Date(), new Date(1), new Date(2)], firstBy(identity())),
-    ).toEqual(new Date(1));
+    ).toStrictEqual(new Date(1));
   });
 });

--- a/src/flat.test-d.ts
+++ b/src/flat.test-d.ts
@@ -17,13 +17,11 @@ it("works on a single level of nesting", () => {
 });
 
 it("stops after the first level of nesting (depth === 1)", () => {
-  const result = flat([] as Array<Array<Array<string>>>, 1);
-  expectTypeOf(result).toEqualTypeOf<Array<Array<string>>>();
-});
+  const threeDeepResult = flat([] as Array<Array<Array<string>>>, 1);
+  expectTypeOf(threeDeepResult).toEqualTypeOf<Array<Array<string>>>();
 
-it("stops after the first level of nesting (depth === 1)", () => {
-  const result = flat([] as Array<Array<Array<Array<string>>>>, 1);
-  expectTypeOf(result).toEqualTypeOf<Array<Array<Array<string>>>>();
+  const fourDeepResult = flat([] as Array<Array<Array<Array<string>>>>, 1);
+  expectTypeOf(fourDeepResult).toEqualTypeOf<Array<Array<Array<string>>>>();
 });
 
 it("works with mixed types", () => {
@@ -107,7 +105,7 @@ it("works on tuples inside arrays", () => {
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("works on tuples inside arrays", () => {
+it("works on arrays inside tuples", () => {
   const result = flat([1, [], 4] as [1, Array<[2, 3]>, 4], 2);
   expectTypeOf(result).toEqualTypeOf<[1, ...Array<2 | 3>, 4]>();
 });

--- a/src/flat.test-d.ts
+++ b/src/flat.test-d.ts
@@ -49,7 +49,7 @@ it("keeps the typing of trivial tuples", () => {
   expectTypeOf(result).toEqualTypeOf<[1, 2]>();
 });
 
-it("Works on simple tuples", () => {
+it("works on simple tuples", () => {
   const result = flat(
     [
       [1, 2],

--- a/src/flat.test.ts
+++ b/src/flat.test.ts
@@ -39,6 +39,7 @@ describe("dataFirst", () => {
   it("clones the array on depth 0", () => {
     const data = [1, 2, 3];
     const result = flat(data, 0);
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -46,6 +47,7 @@ describe("dataFirst", () => {
   it("clones the array when no nested items", () => {
     const data = [1, 2, 3];
     const result = flat(data, 1);
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -95,9 +97,10 @@ describe("dataLast", () => {
       map(afterMock),
       find((x) => x - 1 === 2),
     );
+
     expect(beforeMock).toHaveBeenCalledTimes(2);
     expect(afterMock).toHaveBeenCalledTimes(3);
-    expect(result).toStrictEqual(3);
+    expect(result).toBe(3);
   });
 
   it("works lazily (deep)", () => {
@@ -110,14 +113,16 @@ describe("dataLast", () => {
       map(afterMock),
       find((x) => x - 1 === 2),
     );
+
     expect(beforeMock).toHaveBeenCalledTimes(2);
     expect(afterMock).toHaveBeenCalledTimes(4);
-    expect(result).toStrictEqual(3);
+    expect(result).toBe(3);
   });
 
   it("works lazily with trivial depth === 0", () => {
     const data = [1, [2, 3], [4, [5, 6], [7, [8, 9], [[10]]]]];
     const result = pipe(data, flat(0));
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -133,7 +138,7 @@ it("can go very very deep", () => {
 // as flat that existed in previous versions of Remeda. We copy the tests so
 // that we can ensure that the new function is equivalent. In the future these
 // can be deleted.
-describe("LEGACY", () => {
+describe("lEGACY", () => {
   describe("`flatten` equivalent (depth = 1)", () => {
     test("flatten", () => {
       expect(flat([[1, 2], 3, [4, 5]])).toStrictEqual([1, 2, 3, 4, 5]);
@@ -169,9 +174,10 @@ describe("LEGACY", () => {
           counter2.fn(),
           find((x) => x - 1 === 2),
         );
+
         expect(counter1.count).toHaveBeenCalledTimes(2);
         expect(counter2.count).toHaveBeenCalledTimes(3);
-        expect(result).toStrictEqual(3);
+        expect(result).toBe(3);
       });
     });
   });
@@ -203,9 +209,10 @@ describe("LEGACY", () => {
         counter2.fn(),
         find((x) => x - 1 === 2),
       );
+
       expect(counter1.count).toHaveBeenCalledTimes(2);
       expect(counter2.count).toHaveBeenCalledTimes(3);
-      expect(result).toStrictEqual(3);
+      expect(result).toBe(3);
     });
   });
 });

--- a/src/flat.test.ts
+++ b/src/flat.test.ts
@@ -138,7 +138,7 @@ it("can go very very deep", () => {
 // as flat that existed in previous versions of Remeda. We copy the tests so
 // that we can ensure that the new function is equivalent. In the future these
 // can be deleted.
-describe("lEGACY", () => {
+describe("LEGACY", () => {
   describe("`flatten` equivalent (depth = 1)", () => {
     test("flatten", () => {
       expect(flat([[1, 2], 3, [4, 5]])).toStrictEqual([1, 2, 3, 4, 5]);

--- a/src/flatMap.test.ts
+++ b/src/flatMap.test.ts
@@ -8,13 +8,13 @@ describe("dataFirst", () => {
   it("flatMap", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3]);
 
-    expect(result).toEqual([2, 3, 4, 6]);
+    expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
   it("should accept fn returning a readonly array", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3] as const);
 
-    expect(result).toEqual([2, 3, 4, 6]);
+    expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 });
 
@@ -22,7 +22,7 @@ describe("dataLast", () => {
   it("flatMap", () => {
     const result = flatMap((x: number) => [x * 2, x * 3])([1, 2]);
 
-    expect(result).toEqual([2, 3, 4, 6]);
+    expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
   it("should accept fn returning a readonly array", () => {
@@ -30,7 +30,7 @@ describe("dataLast", () => {
       1, 2,
     ] as const);
 
-    expect(result).toEqual([2, 3, 4, 6]);
+    expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
   it("works with non array outputs", () => {

--- a/src/flatMap.test.ts
+++ b/src/flatMap.test.ts
@@ -7,11 +7,13 @@ import { pipe } from "./pipe";
 describe("dataFirst", () => {
   it("flatMap", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3]);
+
     expect(result).toEqual([2, 3, 4, 6]);
   });
 
   it("should accept fn returning a readonly array", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3] as const);
+
     expect(result).toEqual([2, 3, 4, 6]);
   });
 });
@@ -19,6 +21,7 @@ describe("dataFirst", () => {
 describe("dataLast", () => {
   it("flatMap", () => {
     const result = flatMap((x: number) => [x * 2, x * 3])([1, 2]);
+
     expect(result).toEqual([2, 3, 4, 6]);
   });
 
@@ -26,6 +29,7 @@ describe("dataLast", () => {
     const result = flatMap((x: number) => [x * 2, x * 3] as const)([
       1, 2,
     ] as const);
+
     expect(result).toEqual([2, 3, 4, 6]);
   });
 
@@ -44,9 +48,10 @@ describe("dataLast", () => {
         counter2.fn(),
         find((x) => x === 22),
       );
+
       expect(counter1.count).toHaveBeenCalledTimes(2);
       expect(counter2.count).toHaveBeenCalledTimes(7);
-      expect(result).toEqual(22);
+      expect(result).toBe(22);
     });
   });
 });

--- a/src/floor.test.ts
+++ b/src/floor.test.ts
@@ -8,36 +8,32 @@ describe("data-first", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(floor(8123.4317, -2)).toEqual(8100);
-    expect(floor(8123.4317, -4)).toEqual(0);
+    expect(floor(8123.4317, -2)).toBe(8100);
+    expect(floor(8123.4317, -4)).toBe(0);
   });
 
   test("should work with precision = 0", () => {
-    expect(floor(8123.4317, 0)).toEqual(8123);
+    expect(floor(8123.4317, 0)).toBe(8123);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => floor(1, val)).toThrowError(
+      expect(() => floor(1, val)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => floor(1, 21.37)).toThrowError(
+    expect(() => floor(1, 21.37)).toThrow(
       "precision must be an integer: 21.37",
     );
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => floor(1, 16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => floor(1, -16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => floor(1, 16)).toThrow("precision must be between -15 and 15");
+    expect(() => floor(1, -16)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
@@ -58,36 +54,32 @@ describe("data-last", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(floor(-2)(8123.4317)).toEqual(8100);
-    expect(floor(-4)(8123.4317)).toEqual(0);
+    expect(floor(-2)(8123.4317)).toBe(8100);
+    expect(floor(-4)(8123.4317)).toBe(0);
   });
 
   test("should work with precision = 0", () => {
-    expect(floor(0)(8123.4317)).toEqual(8123);
+    expect(floor(0)(8123.4317)).toBe(8123);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => floor(val)(1)).toThrowError(
+      expect(() => floor(val)(1)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => floor(21.37)(1)).toThrowError(
+    expect(() => floor(21.37)(1)).toThrow(
       "precision must be an integer: 21.37",
     );
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => floor(16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => floor(-16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => floor(16)(1)).toThrow("precision must be between -15 and 15");
+    expect(() => floor(-16)(1)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(

--- a/src/floor.test.ts
+++ b/src/floor.test.ts
@@ -2,9 +2,9 @@ import { floor } from "./floor";
 
 describe("data-first", () => {
   test("should work with positive precision", () => {
-    expect(floor(8123.4317, 3)).toEqual(8123.431);
-    expect(floor(483.222_43, 1)).toEqual(483.2);
-    expect(floor(123.4317, 5)).toEqual(123.4317);
+    expect(floor(8123.4317, 3)).toBe(8123.431);
+    expect(floor(483.222_43, 1)).toBe(483.2);
+    expect(floor(123.4317, 5)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -40,7 +40,7 @@ describe("data-first", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(floor(val, precision)).toStrictEqual(val);
+        expect(floor(val, precision)).toBe(val);
       }
     },
   );
@@ -48,9 +48,9 @@ describe("data-first", () => {
 
 describe("data-last", () => {
   test("should work with positive precision", () => {
-    expect(floor(3)(8123.4317)).toEqual(8123.431);
-    expect(floor(1)(483.222_43)).toEqual(483.2);
-    expect(floor(5)(123.4317)).toEqual(123.4317);
+    expect(floor(3)(8123.4317)).toBe(8123.431);
+    expect(floor(1)(483.222_43)).toBe(483.2);
+    expect(floor(5)(123.4317)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -86,7 +86,7 @@ describe("data-last", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(floor(precision)(val)).toStrictEqual(val);
+        expect(floor(precision)(val)).toBe(val);
       }
     },
   );

--- a/src/forEach.test.ts
+++ b/src/forEach.test.ts
@@ -56,6 +56,7 @@ test("with take", () => {
     }),
     take(2),
   );
+
   expect(count).toHaveBeenCalledTimes(2);
   expect(result).toEqual([1, 2]);
 });

--- a/src/forEach.test.ts
+++ b/src/forEach.test.ts
@@ -58,5 +58,5 @@ test("with take", () => {
   );
 
   expect(count).toHaveBeenCalledTimes(2);
-  expect(result).toEqual([1, 2]);
+  expect(result).toStrictEqual([1, 2]);
 });

--- a/src/forEachObj.test-d.ts
+++ b/src/forEachObj.test-d.ts
@@ -1,14 +1,14 @@
 import { forEachObj } from "./forEachObj";
 import { pipe } from "./pipe";
 
-test("Typing is sound when only symbol keys", () => {
+test("typing is sound when only symbol keys", () => {
   forEachObj({ [Symbol("a")]: 4 }, (value, key) => {
     expectTypeOf(key).toBeNever();
     expectTypeOf(value).toBeNever();
   });
 });
 
-test("Symbol keys are ignored", () => {
+test("symbol keys are ignored", () => {
   forEachObj({ [Symbol("a")]: 4, a: "hello", b: true }, (value, key) => {
     expectTypeOf(key).toEqualTypeOf<"a" | "b">();
     expectTypeOf(value).toEqualTypeOf<boolean | string>();

--- a/src/fromEntries.test.ts
+++ b/src/fromEntries.test.ts
@@ -28,7 +28,7 @@ test("empty array", () => {
   expect(fromEntries([])).toStrictEqual({});
 });
 
-test("Single entry", () => {
+test("single entry", () => {
   expect(fromEntries([["a", 1]])).toStrictEqual({ a: 1 });
 });
 

--- a/src/fromKeys.test.ts
+++ b/src/fromKeys.test.ts
@@ -16,6 +16,7 @@ it("works with duplicates", () => {
 
 it("uses the last value", () => {
   let counter = 0;
+
   expect(
     fromKeys(["a", "a"], () => {
       counter += 1;
@@ -30,11 +31,13 @@ it("works with number keys", () => {
 
 it("works with symbols", () => {
   const symbol = Symbol("a");
+
   expect(fromKeys([symbol], () => 1)).toEqual({ [symbol]: 1 });
 });
 
 it("works with a mix of key types", () => {
   const symbol = Symbol("a");
+
   expect(fromKeys(["a", 123, symbol], (item) => typeof item)).toEqual({
     a: "string",
     123: "number",
@@ -72,6 +75,7 @@ describe("dataLast", () => {
 
   it("uses the last value", () => {
     let counter = 0;
+
     expect(
       pipe(
         ["a", "a"],
@@ -89,6 +93,7 @@ describe("dataLast", () => {
 
   it("works with symbols", () => {
     const symbol = Symbol("a");
+
     expect(
       pipe(
         [symbol],
@@ -99,6 +104,7 @@ describe("dataLast", () => {
 
   it("works with a mix of key types", () => {
     const symbol = Symbol("a");
+
     expect(
       pipe(
         ["a", 123, symbol],

--- a/src/fromKeys.test.ts
+++ b/src/fromKeys.test.ts
@@ -3,15 +3,15 @@ import { fromKeys } from "./fromKeys";
 import { pipe } from "./pipe";
 
 it("works on trivially empty arrays", () => {
-  expect(fromKeys([] as Array<string>, (item) => `${item}_`)).toEqual({});
+  expect(fromKeys([] as Array<string>, (item) => `${item}_`)).toStrictEqual({});
 });
 
 it("works on regular arrays", () => {
-  expect(fromKeys(["a"], (item) => `${item}_`)).toEqual({ a: "a_" });
+  expect(fromKeys(["a"], (item) => `${item}_`)).toStrictEqual({ a: "a_" });
 });
 
 it("works with duplicates", () => {
-  expect(fromKeys(["a", "a"], (item) => `${item}_`)).toEqual({ a: "a_" });
+  expect(fromKeys(["a", "a"], (item) => `${item}_`)).toStrictEqual({ a: "a_" });
 });
 
 it("uses the last value", () => {
@@ -22,23 +22,23 @@ it("uses the last value", () => {
       counter += 1;
       return counter;
     }),
-  ).toEqual({ a: 2 });
+  ).toStrictEqual({ a: 2 });
 });
 
 it("works with number keys", () => {
-  expect(fromKeys([123], add(1))).toEqual({ 123: 124 });
+  expect(fromKeys([123], add(1))).toStrictEqual({ 123: 124 });
 });
 
 it("works with symbols", () => {
   const symbol = Symbol("a");
 
-  expect(fromKeys([symbol], () => 1)).toEqual({ [symbol]: 1 });
+  expect(fromKeys([symbol], () => 1)).toStrictEqual({ [symbol]: 1 });
 });
 
 it("works with a mix of key types", () => {
   const symbol = Symbol("a");
 
-  expect(fromKeys(["a", 123, symbol], (item) => typeof item)).toEqual({
+  expect(fromKeys(["a", 123, symbol], (item) => typeof item)).toStrictEqual({
     a: "string",
     123: "number",
     [symbol]: "symbol",
@@ -52,7 +52,7 @@ describe("dataLast", () => {
         [] as Array<string>,
         fromKeys((item) => `${item}_`),
       ),
-    ).toEqual({});
+    ).toStrictEqual({});
   });
 
   it("works on regular arrays", () => {
@@ -61,7 +61,7 @@ describe("dataLast", () => {
         ["a"],
         fromKeys((item) => `${item}_`),
       ),
-    ).toEqual({ a: "a_" });
+    ).toStrictEqual({ a: "a_" });
   });
 
   it("works with duplicates", () => {
@@ -70,7 +70,7 @@ describe("dataLast", () => {
         ["a", "a"],
         fromKeys((item) => `${item}_`),
       ),
-    ).toEqual({ a: "a_" });
+    ).toStrictEqual({ a: "a_" });
   });
 
   it("uses the last value", () => {
@@ -84,11 +84,11 @@ describe("dataLast", () => {
           return counter;
         }),
       ),
-    ).toEqual({ a: 2 });
+    ).toStrictEqual({ a: 2 });
   });
 
   it("works with number keys", () => {
-    expect(pipe([123], fromKeys(add(1)))).toEqual({ 123: 124 });
+    expect(pipe([123], fromKeys(add(1)))).toStrictEqual({ 123: 124 });
   });
 
   it("works with symbols", () => {
@@ -99,7 +99,7 @@ describe("dataLast", () => {
         [symbol],
         fromKeys(() => 1),
       ),
-    ).toEqual({ [symbol]: 1 });
+    ).toStrictEqual({ [symbol]: 1 });
   });
 
   it("works with a mix of key types", () => {
@@ -110,7 +110,7 @@ describe("dataLast", () => {
         ["a", 123, symbol],
         fromKeys((item) => typeof item),
       ),
-    ).toEqual({
+    ).toStrictEqual({
       a: "string",
       123: "number",
       [symbol]: "symbol",

--- a/src/groupBy.test-d.ts
+++ b/src/groupBy.test-d.ts
@@ -2,7 +2,7 @@ import { groupBy } from "./groupBy";
 import type { NonEmptyArray } from "./internal/types";
 import { prop } from "./prop";
 
-test("Union of string literals", () => {
+test("union of string literals", () => {
   const data = groupBy(
     [
       { a: "cat", b: 123 },
@@ -24,7 +24,7 @@ test("Union of string literals", () => {
   >();
 });
 
-test("Union of number literals", () => {
+test("union of number literals", () => {
   const data = groupBy(
     [
       { a: "cat", b: 123 },
@@ -102,7 +102,7 @@ test("string | number", () => {
   >();
 });
 
-describe("Filtering on undefined grouper result", () => {
+describe("filtering on undefined grouper result", () => {
   test("regular", () => {
     const { even, ...rest } = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
       x % 2 === 0 ? "even" : undefined,

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -14,7 +14,7 @@ describe("data first", () => {
         ],
         prop("a"),
       ),
-    ).toEqual({
+    ).toStrictEqual({
       1: [
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -37,7 +37,7 @@ describe("data last", () => {
         ],
         groupBy(prop("a")),
       ),
-    ).toEqual({
+    ).toStrictEqual({
       1: [
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -60,7 +60,7 @@ describe("filtering on undefined grouper result", () => {
     );
 
     expect(Object.values(result)).toHaveLength(1);
-    expect(result.even).toEqual([0, 2, 4, 6, 8]);
+    expect(result.even).toStrictEqual([0, 2, 4, 6, 8]);
   });
 
   test("regular indexed", () => {
@@ -70,6 +70,6 @@ describe("filtering on undefined grouper result", () => {
     );
 
     expect(Object.values(result)).toHaveLength(1);
-    expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
+    expect(result.even).toStrictEqual(["a", "c", "e", "g", "i"]);
   });
 });

--- a/src/groupBy.test.ts
+++ b/src/groupBy.test.ts
@@ -48,7 +48,7 @@ describe("data last", () => {
   });
 });
 
-describe("Filtering on undefined grouper result", () => {
+describe("filtering on undefined grouper result", () => {
   // These tests use a contrived example that is basically a simple filter. The
   // goal of these tests is to make sure that all flavours of the function
   // accept an undefined return value for the grouper function, and that it
@@ -58,6 +58,7 @@ describe("Filtering on undefined grouper result", () => {
     const result = groupBy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], (x) =>
       x % 2 === 0 ? "even" : undefined,
     );
+
     expect(Object.values(result)).toHaveLength(1);
     expect(result.even).toEqual([0, 2, 4, 6, 8]);
   });
@@ -67,6 +68,7 @@ describe("Filtering on undefined grouper result", () => {
       ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
       (_, index) => (index % 2 === 0 ? "even" : undefined),
     );
+
     expect(Object.values(result)).toHaveLength(1);
     expect(result.even).toEqual(["a", "c", "e", "g", "i"]);
   });

--- a/src/hasAtLeast.test.ts
+++ b/src/hasAtLeast.test.ts
@@ -14,6 +14,7 @@ describe("dataFirst", () => {
 
   it("works on large arrays", () => {
     const array = Array.from({ length: 1000 }, (_, i) => i);
+
     expect(hasAtLeast(array, 0)).toBe(true);
     expect(hasAtLeast(array, 1)).toBe(true);
     expect(hasAtLeast(array, 1000)).toBe(true);
@@ -22,6 +23,7 @@ describe("dataFirst", () => {
 
   it("works on sparse arrays", () => {
     const array = Array.from({ length: 1000 });
+
     expect(hasAtLeast(array, 0)).toBe(true);
     expect(hasAtLeast(array, 1)).toBe(true);
     expect(hasAtLeast(array, 1000)).toBe(true);
@@ -43,6 +45,7 @@ describe("dataLast", () => {
 
   it("works on large arrays", () => {
     const array = Array.from({ length: 1000 }, (_, i) => i);
+
     expect(hasAtLeast(0)(array)).toBe(true);
     expect(hasAtLeast(1)(array)).toBe(true);
     expect(hasAtLeast(1000)(array)).toBe(true);
@@ -51,6 +54,7 @@ describe("dataLast", () => {
 
   it("works on sparse arrays", () => {
     const array = Array.from({ length: 1000 });
+
     expect(hasAtLeast(0)(array)).toBe(true);
     expect(hasAtLeast(1)(array)).toBe(true);
     expect(hasAtLeast(1000)(array)).toBe(true);

--- a/src/hasSubObject.test.ts
+++ b/src/hasSubObject.test.ts
@@ -24,6 +24,7 @@ describe("data first", () => {
 
   it("checks for matching key", () => {
     const data = {} as { a?: undefined };
+
     expect(hasSubObject(data, { a: undefined })).toBe(false);
   });
 });

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -27,9 +27,9 @@ test("works with variadic arguments", () => {
 });
 
 test("can be put in a pipe", () => {
-  expect(pipe([1, 2, 3], identity(), map(add(1)))).toEqual([2, 3, 4]);
+  expect(pipe([1, 2, 3], identity(), map(add(1)))).toStrictEqual([2, 3, 4]);
 });
 
 test("can be used as a fill function (with times)", () => {
-  expect(times(10, identity())).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  expect(times(10, identity())).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 });

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -6,11 +6,13 @@ import { times } from "./times";
 
 test("works", () => {
   const id = identity();
+
   expect(id("hello")).toBe("hello");
 });
 
 test("works with more than one argument", () => {
   const id = identity();
+
   expect(id(1)).toBe(1);
   expect(id(1, 2)).toBe(1);
   expect(id(1, "a")).toBe(1);
@@ -20,6 +22,7 @@ test("works with more than one argument", () => {
 test("works with variadic arguments", () => {
   const data = [1, 2, 3] as const;
   const id = identity();
+
   expect(id(...data)).toBe(data[0]);
 });
 

--- a/src/indexBy.test-d.ts
+++ b/src/indexBy.test-d.ts
@@ -2,28 +2,70 @@ import { indexBy } from "./indexBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
 
-test("dataFirst", () => {
-  const result = indexBy(
-    [
-      { dir: "left", code: 97 },
-      { dir: "right", code: 100 },
-    ],
-    prop("code"),
-  );
-  expectTypeOf<
-    Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>
-  >(result);
+describe("data-first", () => {
+  test("simple array of objects", () => {
+    const result = indexBy(
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ],
+      prop("code"),
+    );
+    expectTypeOf(result).toEqualTypeOf<
+      Record<number, { dir: string; code: number }>
+    >();
+  });
+
+  test("tuple of readonly objects", () => {
+    const result = indexBy(
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ] as const,
+      prop("code"),
+    );
+    expectTypeOf(result).toEqualTypeOf<
+      Partial<
+        Record<
+          97 | 100,
+          | { readonly dir: "left"; readonly code: 97 }
+          | { readonly dir: "right"; readonly code: 100 }
+        >
+      >
+    >();
+  });
 });
 
-test("dataLast", () => {
-  const result = pipe(
-    [
-      { dir: "left", code: 97 },
-      { dir: "right", code: 100 },
-    ],
-    indexBy(prop("code")),
-  );
-  expectTypeOf<
-    Partial<Record<97 | 100, { dir: "left" | "right"; code: 97 | 100 }>>
-  >(result);
+describe("data-last", () => {
+  test("simple array of objects", () => {
+    const result = pipe(
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ],
+      indexBy(prop("code")),
+    );
+    expectTypeOf(result).toEqualTypeOf<
+      Record<number, { dir: string; code: number }>
+    >();
+  });
+
+  test("tuple of readonly objects", () => {
+    const result = pipe(
+      [
+        { dir: "left", code: 97 },
+        { dir: "right", code: 100 },
+      ] as const,
+      indexBy(prop("code")),
+    );
+    expectTypeOf(result).toEqualTypeOf<
+      Partial<
+        Record<
+          97 | 100,
+          | { readonly dir: "left"; readonly code: 97 }
+          | { readonly dir: "right"; readonly code: 100 }
+        >
+      >
+    >();
+  });
 });

--- a/src/internal/binarySearchCutoffIndex.test.ts
+++ b/src/internal/binarySearchCutoffIndex.test.ts
@@ -55,7 +55,7 @@ describe("binary search correctness via the index", () => {
         ],
         (_, index) => index < 0,
       ),
-    ).toEqual([8, 4, 2, 1, 0]);
+    ).toStrictEqual([8, 4, 2, 1, 0]);
   });
 
   test("after 4 items", () => {
@@ -81,7 +81,7 @@ describe("binary search correctness via the index", () => {
         ],
         (_, index) => index < 4,
       ),
-    ).toEqual([8, 4, 2, 3]);
+    ).toStrictEqual([8, 4, 2, 3]);
   });
 
   test("after 8 items", () => {
@@ -107,7 +107,7 @@ describe("binary search correctness via the index", () => {
         ],
         (_, index) => index < 8,
       ),
-    ).toEqual([8, 4, 6, 7]);
+    ).toStrictEqual([8, 4, 6, 7]);
   });
 
   test("after 12 items", () => {
@@ -133,7 +133,7 @@ describe("binary search correctness via the index", () => {
         ],
         (_, index) => index < 12,
       ),
-    ).toEqual([8, 12, 10, 11]);
+    ).toStrictEqual([8, 12, 10, 11]);
   });
 
   test("after 20 items", () => {
@@ -159,7 +159,7 @@ describe("binary search correctness via the index", () => {
         ],
         (_, index) => index < 20,
       ),
-    ).toEqual([8, 12, 14, 15]);
+    ).toStrictEqual([8, 12, 14, 15]);
   });
 });
 

--- a/src/internal/heap.test.ts
+++ b/src/internal/heap.test.ts
@@ -8,6 +8,7 @@ import { heapMaybeInsert } from "./heap";
 describe("heapMaybeInsert", () => {
   test("it works trivially on an empty heap", () => {
     const heap = [] as Array<number>;
+
     expect(heapMaybeInsert(heap, (a, b) => a - b, 1)).toBeUndefined();
   });
 });

--- a/src/internal/purryFromLazy.test.ts
+++ b/src/internal/purryFromLazy.test.ts
@@ -17,7 +17,7 @@ test("throws on wrong number of arguments", () => {
       // throw.
       "world",
     ),
-  ).toThrowError("Wrong number of arguments");
+  ).toThrow("Wrong number of arguments");
 });
 
 const zeroArgsPurried = (...args: ReadonlyArray<unknown>) =>

--- a/src/internal/splitWords.test.ts
+++ b/src/internal/splitWords.test.ts
@@ -66,7 +66,7 @@ describe("copied from the type-fest tests", () => {
     { input: "BBBBa", output: ["BBB", "Ba"] },
     { input: "BBBBB", output: ["BBBBB"] },
   ])("case changes: $input", ({ input, output }) => {
-    expect(splitWords(input)).toEqual(output);
+    expect(splitWords(input)).toStrictEqual(output);
   });
 
   test.each([
@@ -92,7 +92,7 @@ describe("copied from the type-fest tests", () => {
     { input: "hello WORLD-lowercase", output: ["hello", "WORLD", "lowercase"] },
     { input: "hello WORLD Uppercase", output: ["hello", "WORLD", "Uppercase"] },
   ])("white spaces: $input", ({ input, output }) => {
-    expect(splitWords(input)).toEqual(output);
+    expect(splitWords(input)).toStrictEqual(output);
   });
 
   test.each([
@@ -109,6 +109,6 @@ describe("copied from the type-fest tests", () => {
       output: ["item", "0", "item", "1", "item", "2"],
     },
   ])("digits: $input", ({ input, output }) => {
-    expect(splitWords(input)).toEqual(output);
+    expect(splitWords(input)).toStrictEqual(output);
   });
 });

--- a/src/internal/types.test-d.ts
+++ b/src/internal/types.test-d.ts
@@ -13,7 +13,7 @@ declare const SymbolFoo: unique symbol;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare const SymbolBar: unique symbol;
 
-describe("IfBoundedRecord", () => {
+describe("ifBoundedRecord", () => {
   test("string", () => {
     expectTypeOf<
       IfBoundedRecord<Record<string, unknown>>
@@ -167,7 +167,7 @@ describe("IfBoundedRecord", () => {
   });
 });
 
-describe("EnumerableStringKeyOf", () => {
+describe("enumerableStringKeyOf", () => {
   test("string keys", () => {
     expectTypeOf<
       EnumerableStringKeyOf<Record<string, unknown>>
@@ -221,7 +221,7 @@ describe("EnumerableStringKeyOf", () => {
   });
 });
 
-describe("EnumerableStringKeyedValueOf", () => {
+describe("enumerableStringKeyedValueOf", () => {
   test("string values", () => {
     expectTypeOf<
       EnumerableStringKeyedValueOf<Record<PropertyKey, string>>
@@ -311,7 +311,7 @@ describe("EnumerableStringKeyedValueOf", () => {
   });
 });
 
-describe("NTuple", () => {
+describe("nTuple", () => {
   test("size 0", () => {
     const result = nTuple("foo", 0);
     expectTypeOf(result).toEqualTypeOf<[]>();
@@ -323,7 +323,7 @@ describe("NTuple", () => {
   });
 });
 
-describe("TupleParts", () => {
+describe("tupleParts", () => {
   describe("mutable", () => {
     test("empty array", () => {
       const data = [] as [];
@@ -469,7 +469,7 @@ describe("TupleParts", () => {
   });
 });
 
-describe("DeDupped", () => {
+describe("deDupped", () => {
   describe("mutable", () => {
     test("empty array", () => {
       const result = deduped([] as []);

--- a/src/internal/types.test-d.ts
+++ b/src/internal/types.test-d.ts
@@ -13,7 +13,7 @@ declare const SymbolFoo: unique symbol;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare const SymbolBar: unique symbol;
 
-describe("ifBoundedRecord", () => {
+describe("IfBoundedRecord", () => {
   test("string", () => {
     expectTypeOf<
       IfBoundedRecord<Record<string, unknown>>
@@ -167,7 +167,7 @@ describe("ifBoundedRecord", () => {
   });
 });
 
-describe("enumerableStringKeyOf", () => {
+describe("EnumerableStringKeyOf", () => {
   test("string keys", () => {
     expectTypeOf<
       EnumerableStringKeyOf<Record<string, unknown>>
@@ -221,7 +221,7 @@ describe("enumerableStringKeyOf", () => {
   });
 });
 
-describe("enumerableStringKeyedValueOf", () => {
+describe("EnumerableStringKeyedValueOf", () => {
   test("string values", () => {
     expectTypeOf<
       EnumerableStringKeyedValueOf<Record<PropertyKey, string>>
@@ -311,7 +311,7 @@ describe("enumerableStringKeyedValueOf", () => {
   });
 });
 
-describe("nTuple", () => {
+describe("NTuple", () => {
   test("size 0", () => {
     const result = nTuple("foo", 0);
     expectTypeOf(result).toEqualTypeOf<[]>();
@@ -323,7 +323,7 @@ describe("nTuple", () => {
   });
 });
 
-describe("tupleParts", () => {
+describe("TupleParts", () => {
   describe("mutable", () => {
     test("empty array", () => {
       const data = [] as [];
@@ -469,7 +469,7 @@ describe("tupleParts", () => {
   });
 });
 
-describe("deDupped", () => {
+describe("DeDupped", () => {
   describe("mutable", () => {
     test("empty array", () => {
       const result = deduped([] as []);

--- a/src/intersection.test.ts
+++ b/src/intersection.test.ts
@@ -43,6 +43,7 @@ it("maintains order for multiple copies", () => {
 it("returns a shallow copy even when all items match", () => {
   const data = [1, 2, 3];
   const result = intersection(data, [1, 2, 3]);
+
   expect(result).toStrictEqual(data);
   expect(result).not.toBe(data);
 });
@@ -51,6 +52,7 @@ describe("piping", () => {
   test("lazy", () => {
     const mock = vi.fn(identity());
     const result = pipe([1, 2, 3, 4, 5, 6], map(mock), intersection([4, 2]));
+
     expect(mock).toHaveBeenCalledTimes(4);
     expect(result).toStrictEqual([2, 4]);
   });

--- a/src/intersectionWith.test.ts
+++ b/src/intersectionWith.test.ts
@@ -24,6 +24,7 @@ describe("intersectionWith", () => {
       );
     });
   });
+
   describe("data last", () => {
     it("returns the new array of intersecting values based on a custom comparator", () => {
       expect(
@@ -35,6 +36,7 @@ describe("intersectionWith", () => {
         )(source),
       ).toEqual(expected);
     });
+
     it("checks if items are equal based on remeda's imported util function as a comparator", () => {
       expect(
         pipe(
@@ -61,6 +63,7 @@ describe("intersectionWith", () => {
         intersectionWith([{ a: 2 }, { a: 3 }, { a: 4 }], isDeepEqual),
         take(2),
       );
+
       expect(counter.count).toHaveBeenCalledTimes(3);
       expect(result).toEqual([{ a: 2 }, { a: 3 }]);
     });

--- a/src/intersectionWith.test.ts
+++ b/src/intersectionWith.test.ts
@@ -19,9 +19,9 @@ const expected = [
 describe("intersectionWith", () => {
   describe("data first", () => {
     test("returns the new array of intersecting values based on a custom comparator", () => {
-      expect(intersectionWith(source, other, (a, b) => a.id === b)).toEqual(
-        expected,
-      );
+      expect(
+        intersectionWith(source, other, (a, b) => a.id === b),
+      ).toStrictEqual(expected);
     });
   });
 
@@ -34,7 +34,7 @@ describe("intersectionWith", () => {
           // parameter in data last variant
           (a, b) => (a as (typeof source)[0]).id === b,
         )(source),
-      ).toEqual(expected);
+      ).toStrictEqual(expected);
     });
 
     it("checks if items are equal based on remeda's imported util function as a comparator", () => {
@@ -52,7 +52,7 @@ describe("intersectionWith", () => {
             isDeepEqual,
           ),
         ),
-      ).toEqual([{ x: 1, y: 2 }]);
+      ).toStrictEqual([{ x: 1, y: 2 }]);
     });
 
     it("evaluates lazily", () => {
@@ -65,7 +65,7 @@ describe("intersectionWith", () => {
       );
 
       expect(counter.count).toHaveBeenCalledTimes(3);
-      expect(result).toEqual([{ a: 2 }, { a: 3 }]);
+      expect(result).toStrictEqual([{ a: 2 }, { a: 3 }]);
     });
   });
 });

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -3,11 +3,11 @@ import { pipe } from "./pipe";
 
 describe("data first", () => {
   test("empty object", () => {
-    expect(invert({})).toEqual({});
+    expect(invert({})).toStrictEqual({});
   });
 
   test("no duplicate values", () => {
-    expect(invert({ a: "d", b: "e", c: "f" })).toEqual({
+    expect(invert({ a: "d", b: "e", c: "f" })).toStrictEqual({
       d: "a",
       e: "b",
       f: "c",
@@ -15,50 +15,55 @@ describe("data first", () => {
   });
 
   test("duplicate values", () => {
-    expect(invert({ a: "d", b: "e", c: "d" })).toEqual({ e: "b", d: "c" });
-  });
-
-  test("numeric values", () => {
-    expect(invert(["a", "b", "c"])).toEqual({ a: "0", b: "1", c: "2" });
-  });
-
-  test("symbol keys are filtered out", () => {
-    expect(invert({ [Symbol("a")]: 4, a: "hello" })).toEqual({ hello: "a" });
-  });
-
-  test("number keys are converted to strings", () => {
-    expect(invert({ 1: "a", 2: "b" })).toEqual({ a: "1", b: "2" });
-  });
-
-  test("symbol values are fine", () => {
-    const mySymbol = Symbol("my");
-
-    expect(invert({ a: mySymbol })).toEqual({ [mySymbol]: "a" });
-  });
-});
-
-describe("data last", () => {
-  test("empty object", () => {
-    expect(pipe({}, invert())).toEqual({});
-  });
-
-  test("no duplicate values", () => {
-    expect(pipe({ a: "d", b: "e", c: "f" }, invert())).toEqual({
-      d: "a",
-      e: "b",
-      f: "c",
-    });
-  });
-
-  test("duplicate values", () => {
-    expect(pipe({ a: "d", b: "e", c: "d" }, invert())).toEqual({
+    expect(invert({ a: "d", b: "e", c: "d" })).toStrictEqual({
       e: "b",
       d: "c",
     });
   });
 
   test("numeric values", () => {
-    expect(pipe(["a", "b", "c"], invert())).toEqual({
+    expect(invert(["a", "b", "c"])).toStrictEqual({ a: "0", b: "1", c: "2" });
+  });
+
+  test("symbol keys are filtered out", () => {
+    expect(invert({ [Symbol("a")]: 4, a: "hello" })).toStrictEqual({
+      hello: "a",
+    });
+  });
+
+  test("number keys are converted to strings", () => {
+    expect(invert({ 1: "a", 2: "b" })).toStrictEqual({ a: "1", b: "2" });
+  });
+
+  test("symbol values are fine", () => {
+    const mySymbol = Symbol("my");
+
+    expect(invert({ a: mySymbol })).toStrictEqual({ [mySymbol]: "a" });
+  });
+});
+
+describe("data last", () => {
+  test("empty object", () => {
+    expect(pipe({}, invert())).toStrictEqual({});
+  });
+
+  test("no duplicate values", () => {
+    expect(pipe({ a: "d", b: "e", c: "f" }, invert())).toStrictEqual({
+      d: "a",
+      e: "b",
+      f: "c",
+    });
+  });
+
+  test("duplicate values", () => {
+    expect(pipe({ a: "d", b: "e", c: "d" }, invert())).toStrictEqual({
+      e: "b",
+      d: "c",
+    });
+  });
+
+  test("numeric values", () => {
+    expect(pipe(["a", "b", "c"], invert())).toStrictEqual({
       a: "0",
       b: "1",
       c: "2",

--- a/src/invert.test.ts
+++ b/src/invert.test.ts
@@ -32,6 +32,7 @@ describe("data first", () => {
 
   test("symbol values are fine", () => {
     const mySymbol = Symbol("my");
+
     expect(invert({ a: mySymbol })).toEqual({ [mySymbol]: "a" });
   });
 });

--- a/src/isArray.test.ts
+++ b/src/isArray.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isArray } from "./isArray";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.array as AllTypesDataProviderTypes;
-  if (isArray(data)) {
-    expect(Array.isArray(data)).toEqual(true);
-  }
+  expect(isArray(TYPES_DATA_PROVIDER.array)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isArray);
-  expect(data.every((c) => Array.isArray(c))).toEqual(true);
+
+  expect(data.every((c) => Array.isArray(c))).toBe(true);
 });

--- a/src/isBigInt.test.ts
+++ b/src/isBigInt.test.ts
@@ -1,34 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isBigInt } from "./isBigInt";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.bigint as AllTypesDataProviderTypes;
-  if (isBigInt(data)) {
-    expect(typeof data).toEqual("bigint");
-  }
+  expect(isBigInt(TYPES_DATA_PROVIDER.bigint)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBigInt);
-  expect(data.every((c) => typeof c === "bigint")).toEqual(true);
-});
 
-it("should work even if data type is unknown", () => {
-  const data = TYPES_DATA_PROVIDER.bigint as unknown;
-  if (isBigInt(data)) {
-    expect(typeof data).toEqual("bigint");
-  }
+  expect(data.every((c) => typeof c === "bigint")).toBe(true);
 });
-
-it("should work with literal types", () => {
-  const x = dataFunction();
-  if (isBigInt(x)) {
-    expect(typeof x).toEqual("bigint");
-  }
-});
-
-const dataFunction = (): string | 1n | 2n | 3n => 1n;

--- a/src/isBoolean.test.ts
+++ b/src/isBoolean.test.ts
@@ -1,33 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isBoolean } from "./isBoolean";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.boolean as AllTypesDataProviderTypes;
-  if (isBoolean(data)) {
-    expect(typeof data).toEqual("boolean");
-  }
-});
-
-it("should narrow `unknown`", () => {
-  const data = TYPES_DATA_PROVIDER.boolean as unknown;
-  if (isBoolean(data)) {
-    expect(typeof data).toEqual("boolean");
-  }
-});
-
-it("should narrow `any`", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
-  const data = TYPES_DATA_PROVIDER.boolean as any;
-  if (isBoolean(data)) {
-    expect(typeof data).toEqual("boolean");
-  }
+  expect(isBoolean(TYPES_DATA_PROVIDER.boolean)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBoolean);
-  expect(data.every((c) => typeof c === "boolean")).toEqual(true);
+
+  expect(data.every((c) => typeof c === "boolean")).toBe(true);
 });

--- a/src/isDate.test.ts
+++ b/src/isDate.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isDate } from "./isDate";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
-  if (isDate(data)) {
-    expect(data instanceof Date).toEqual(true);
-  }
+  expect(isDate(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDate);
-  expect(data.every((c) => c instanceof Date)).toEqual(true);
+
+  expect(data.every((c) => c instanceof Date)).toBe(true);
 });

--- a/src/isDeepEqual.test.ts
+++ b/src/isDeepEqual.test.ts
@@ -74,7 +74,7 @@ describe("scalars", () => {
   });
 });
 
-describe("objects", () => {
+describe("Objects", () => {
   test("empty objects are equal", () => {
     expect(isDeepEqual({}, {})).toBe(true);
   });
@@ -152,7 +152,7 @@ describe("objects", () => {
   });
 });
 
-describe("sets", () => {
+describe("Sets", () => {
   test("two empty sets should be equal", () => {
     expect(isDeepEqual(new Set(), new Set())).toBe(true);
   });
@@ -199,7 +199,7 @@ describe("sets", () => {
   });
 });
 
-describe("arrays", () => {
+describe("Arrays", () => {
   test("two empty arrays are equal", () => {
     expect(isDeepEqual([], [])).toBe(true);
   });
@@ -233,7 +233,7 @@ describe("arrays", () => {
   });
 });
 
-describe("maps", () => {
+describe("Maps", () => {
   it("works on shallow equal maps", () => {
     expect(isDeepEqual(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(true);
   });
@@ -296,7 +296,7 @@ describe("maps", () => {
   });
 });
 
-describe("date objects", () => {
+describe("Dates", () => {
   test("equal date objects", () => {
     expect(
       isDeepEqual(
@@ -331,7 +331,7 @@ describe("date objects", () => {
   });
 });
 
-describe("regExp objects", () => {
+describe("RegExp", () => {
   test("equal RegExp objects", () => {
     expect(isDeepEqual(/foo/u, /foo/u)).toBe(true);
   });

--- a/src/isDeepEqual.test.ts
+++ b/src/isDeepEqual.test.ts
@@ -4,54 +4,70 @@ describe("scalars", () => {
   test("equal numbers", () => {
     expect(isDeepEqual(1, 1)).toBe(true);
   });
+
   test("not equal numbers", () => {
     expect(isDeepEqual(1, 2)).toBe(false);
   });
+
   test("number and array are not equal", () => {
     expect(isDeepEqual(1 as unknown, [])).toBe(false);
   });
+
   test("0 and null are not equal", () => {
     expect(isDeepEqual(0 as unknown, null)).toBe(false);
   });
+
   test("equal strings", () => {
     expect(isDeepEqual("a", "a")).toBe(true);
   });
+
   test("not equal strings", () => {
     expect(isDeepEqual("a", "b")).toBe(false);
   });
+
   test("empty string and null are not equal", () => {
     expect(isDeepEqual("" as unknown, null)).toBe(false);
   });
+
   test("null is equal to null", () => {
     expect(isDeepEqual(null, null)).toBe(true);
   });
+
   test("equal booleans (true)", () => {
     expect(isDeepEqual(true, true)).toBe(true);
   });
+
   test("equal booleans (false)", () => {
     expect(isDeepEqual(false, false)).toBe(true);
   });
+
   test("not equal booleans", () => {
     expect(isDeepEqual(true, false)).toBe(false);
   });
+
   test("1 and true are not equal", () => {
     expect(isDeepEqual(1 as unknown, true)).toBe(false);
   });
+
   test("0 and false are not equal", () => {
     expect(isDeepEqual(0 as unknown, false)).toBe(false);
   });
-  test("NaN and NaN are equal", () => {
+
+  test("naN and NaN are equal", () => {
     expect(isDeepEqual(Number.NaN, Number.NaN)).toBe(true);
   });
+
   test("0 and -0 are equal", () => {
     expect(isDeepEqual(0, -0)).toBe(true);
   });
-  test("Infinity and Infinity are equal", () => {
+
+  test("infinity and Infinity are equal", () => {
     expect(
       isDeepEqual(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
     ).toBe(true);
   });
-  test("Infinity and -Infinity are not equal", () => {
+
+  test("infinity and -Infinity are not equal", () => {
     expect(
       isDeepEqual(Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY),
     ).toBe(false);
@@ -62,65 +78,81 @@ describe("objects", () => {
   test("empty objects are equal", () => {
     expect(isDeepEqual({}, {})).toBe(true);
   });
+
   test('equal objects (same properties "order")', () => {
     expect(isDeepEqual({ a: 1, b: "2" }, { a: 1, b: "2" })).toBe(true);
   });
+
   test('equal objects (different properties "order")', () => {
     expect(isDeepEqual({ a: 1, b: "2" }, { b: "2", a: 1 })).toBe(true);
   });
+
   test("not equal objects (extra property)", () => {
     expect(isDeepEqual({ a: 1, b: "2" }, { a: 1, b: "2", c: [] })).toBe(false);
   });
+
   test("not equal objects (different properties) #1", () => {
     expect(
       isDeepEqual({ a: 1, b: "2", c: 3 } as unknown, { a: 1, b: "2", d: 3 }),
     ).toBe(false);
   });
+
   test("not equal objects (different properties) #2", () => {
     expect(
       isDeepEqual({ a: 1, b: "2", c: 3 } as unknown, { a: 1, b: "2", d: 3 }),
     ).toBe(false);
   });
+
   test("equal objects (same sub-properties)", () => {
     expect(isDeepEqual({ a: [{ b: "c" }] }, { a: [{ b: "c" }] })).toBe(true);
   });
+
   test("not equal objects (different sub-property value)", () => {
     expect(isDeepEqual({ a: [{ b: "c" }] }, { a: [{ b: "d" }] })).toBe(false);
   });
+
   test("not equal objects (different sub-property)", () => {
     expect(
       isDeepEqual({ a: [{ b: "c" }] } as unknown, { a: [{ c: "c" }] }),
     ).toBe(false);
   });
+
   test("empty array and empty object are not equal", () => {
     expect(isDeepEqual({}, [])).toBe(false);
   });
+
   test("object with extra undefined properties are not equal #1", () => {
     expect(isDeepEqual({}, { foo: undefined })).toBe(false);
   });
+
   test("object with extra undefined properties are not equal #2", () => {
     expect(isDeepEqual({ foo: undefined } as unknown, {})).toBe(false);
   });
+
   test("object with extra undefined properties are not equal #3", () => {
     expect(isDeepEqual({ foo: undefined } as unknown, { bar: undefined })).toBe(
       false,
     );
   });
+
   test("nulls are equal", () => {
     expect(isDeepEqual(null, null)).toBe(true);
   });
+
   test("null and undefined are not equal", () => {
     expect(isDeepEqual(null as unknown, undefined)).toBe(false);
   });
+
   test("null and empty object are not equal", () => {
     expect(isDeepEqual(null as unknown, {})).toBe(false);
   });
+
   test("undefined and empty object are not equal", () => {
     expect(isDeepEqual(undefined as unknown, {})).toBe(false);
   });
 });
 
-describe("Sets", () => {
+describe("sets", () => {
   test("two empty sets should be equal", () => {
     expect(isDeepEqual(new Set(), new Set())).toBe(true);
   });
@@ -171,31 +203,37 @@ describe("arrays", () => {
   test("two empty arrays are equal", () => {
     expect(isDeepEqual([], [])).toBe(true);
   });
+
   test("equal arrays", () => {
     expect(isDeepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
   });
+
   test("not equal arrays (different item)", () => {
     expect(isDeepEqual([1, 2, 3], [1, 2, 4])).toBe(false);
   });
+
   test("not equal arrays (different length)", () => {
     expect(isDeepEqual([1, 2, 3], [1, 2])).toBe(false);
   });
+
   test("equal arrays of objects", () => {
     expect(
       isDeepEqual([{ a: "a" }, { b: "b" }], [{ a: "a" }, { b: "b" }]),
     ).toBe(true);
   });
+
   test("not equal arrays of objects", () => {
     expect(
       isDeepEqual([{ a: "a" }, { b: "b" }], [{ a: "a" }, { b: "c" }]),
     ).toBe(false);
   });
+
   test("pseudo array and equivalent array are not equal", () => {
     expect(isDeepEqual({ "0": 0, "1": 1, length: 2 }, [0, 1])).toBe(false);
   });
 });
 
-describe("Maps", () => {
+describe("maps", () => {
   it("works on shallow equal maps", () => {
     expect(isDeepEqual(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(true);
   });
@@ -258,7 +296,7 @@ describe("Maps", () => {
   });
 });
 
-describe("Date objects", () => {
+describe("date objects", () => {
   test("equal date objects", () => {
     expect(
       isDeepEqual(
@@ -267,6 +305,7 @@ describe("Date objects", () => {
       ),
     ).toBe(true);
   });
+
   test("not equal date objects", () => {
     expect(
       isDeepEqual(
@@ -275,6 +314,7 @@ describe("Date objects", () => {
       ),
     ).toBe(false);
   });
+
   test("date and string are not equal", () => {
     expect(
       isDeepEqual(
@@ -283,6 +323,7 @@ describe("Date objects", () => {
       ),
     ).toBe(false);
   });
+
   test("date and object are not equal", () => {
     expect(
       isDeepEqual(new Date("2017-06-16T21:36:48.362Z") as unknown, {}),
@@ -290,20 +331,24 @@ describe("Date objects", () => {
   });
 });
 
-describe("RegExp objects", () => {
+describe("regExp objects", () => {
   test("equal RegExp objects", () => {
     expect(isDeepEqual(/foo/u, /foo/u)).toBe(true);
   });
+
   test("not equal RegExp objects (different pattern)", () => {
     expect(isDeepEqual(/foo/u, /bar/u)).toBe(false);
   });
+
   test("not equal RegExp objects (different flags)", () => {
     expect(isDeepEqual(/foo/u, /foo/iu)).toBe(false);
   });
-  test("RegExp and string are not equal", () => {
+
+  test("regExp and string are not equal", () => {
     expect(isDeepEqual(/foo/u as unknown, "foo")).toBe(false);
   });
-  test("RegExp and object are not equal", () => {
+
+  test("regExp and object are not equal", () => {
     expect(isDeepEqual(/foo/u as unknown, {})).toBe(false);
   });
 });
@@ -312,6 +357,7 @@ describe("functions", () => {
   test("same function is equal", () => {
     expect(isDeepEqual(func1, func1)).toBe(true);
   });
+
   test("different functions are not equal", () => {
     expect(isDeepEqual(func1, func2)).toBe(false);
   });

--- a/src/isDefined.test.ts
+++ b/src/isDefined.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isDefined } from "./isDefined";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
-  if (isDefined(data)) {
-    expect(data instanceof Date).toBe(true);
-  }
+  expect(isDefined(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDefined);
+
   expect(data).toHaveLength(18);
 });

--- a/src/isEmpty.test.ts
+++ b/src/isEmpty.test.ts
@@ -3,6 +3,7 @@ import { isEmpty } from "./isEmpty";
 test("returns true for an empty array", () => {
   expect(isEmpty([])).toBe(true);
 });
+
 test("returns false for a non-empty array", () => {
   expect(isEmpty([1, 2, 3])).toBe(false);
 });

--- a/src/isError.test.ts
+++ b/src/isError.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isError } from "./isError";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.error as AllTypesDataProviderTypes;
-  if (isError(data)) {
-    expect(data instanceof Error).toEqual(true);
-  }
+  expect(isError(TYPES_DATA_PROVIDER.error)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isError);
-  expect(data.every((c) => c instanceof Error)).toEqual(true);
+
+  expect(data.every((c) => c instanceof Error)).toBe(true);
 });

--- a/src/isFunction.test.ts
+++ b/src/isFunction.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isFunction } from "./isFunction";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.function as AllTypesDataProviderTypes;
-  if (isFunction(data)) {
-    expect(typeof data).toEqual("function");
-  }
+  expect(isFunction(TYPES_DATA_PROVIDER.function)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isFunction);
-  expect(data.every((c) => typeof c === "function")).toEqual(true);
+
+  expect(data.every((c) => typeof c === "function")).toBe(true);
 });

--- a/src/isIncludedIn.test.ts
+++ b/src/isIncludedIn.test.ts
@@ -111,17 +111,17 @@ describe("legacy v1 replacements", () => {
   describe("difference", () => {
     describe("data_first", () => {
       test("should return difference", () => {
-        expect(filter([1, 2, 3, 4], isNot(isIncludedIn([2, 5, 3])))).toEqual([
-          1, 4,
-        ]);
+        expect(
+          filter([1, 2, 3, 4], isNot(isIncludedIn([2, 5, 3]))),
+        ).toStrictEqual([1, 4]);
       });
     });
 
     describe("data_last", () => {
       test("should return difference", () => {
-        expect(filter(isNot(isIncludedIn([2, 5, 3])))([1, 2, 3, 4])).toEqual([
-          1, 4,
-        ]);
+        expect(
+          filter(isNot(isIncludedIn([2, 5, 3])))([1, 2, 3, 4]),
+        ).toStrictEqual([1, 4]);
       });
 
       test("lazy", () => {
@@ -137,7 +137,7 @@ describe("legacy v1 replacements", () => {
         );
 
         expect(count).toHaveBeenCalledTimes(4);
-        expect(result).toEqual([1, 4]);
+        expect(result).toStrictEqual([1, 4]);
       });
     });
   });
@@ -145,13 +145,17 @@ describe("legacy v1 replacements", () => {
   describe("intersection", () => {
     describe("data_first", () => {
       test("intersection", () => {
-        expect(filter([1, 2, 3], isIncludedIn([2, 3, 5]))).toEqual([2, 3]);
+        expect(filter([1, 2, 3], isIncludedIn([2, 3, 5]))).toStrictEqual([
+          2, 3,
+        ]);
       });
     });
 
     describe("data_last", () => {
       test("intersection", () => {
-        expect(filter(isIncludedIn([2, 3, 5]))([1, 2, 3])).toEqual([2, 3]);
+        expect(filter(isIncludedIn([2, 3, 5]))([1, 2, 3])).toStrictEqual([
+          2, 3,
+        ]);
       });
     });
   });

--- a/src/isIncludedIn.test.ts
+++ b/src/isIncludedIn.test.ts
@@ -24,12 +24,14 @@ describe("dataFirst", () => {
 
   it("only tests reference equality: (arrays)", () => {
     const arr = [1];
+
     expect(isIncludedIn([1], [arr])).toBe(false);
     expect(isIncludedIn(arr, [arr])).toBe(true);
   });
 
   it("only tests reference equality: (objects)", () => {
     const obj = { a: 1 };
+
     expect(isIncludedIn({ a: 1 }, [obj])).toBe(false);
     expect(isIncludedIn(obj, [obj])).toBe(true);
   });
@@ -54,12 +56,14 @@ describe("dataLast", () => {
 
   it("only tests reference equality: (arrays)", () => {
     const arr = [1];
+
     expect(pipe([1], isIncludedIn([arr]))).toBe(false);
     expect(pipe(arr, isIncludedIn([arr]))).toBe(true);
   });
 
   it("only tests reference equality: (objects)", () => {
     const obj = { a: 1 };
+
     expect(pipe({ a: 1 }, isIncludedIn([obj]))).toBe(false);
     expect(pipe(obj, isIncludedIn([obj]))).toBe(true);
   });
@@ -67,6 +71,7 @@ describe("dataLast", () => {
   describe("dataLast memoization", () => {
     it("returns correct result when called multiple times with the same container", () => {
       const isIncludedInContainer = isIncludedIn([1, 2, 3]);
+
       expect(isIncludedInContainer(2)).toBe(true);
       expect(isIncludedInContainer(4)).toBe(false);
     });
@@ -74,6 +79,7 @@ describe("dataLast", () => {
     it("returns correct result when called with different containers", () => {
       const isIncludedInContainer1 = isIncludedIn([1, 2, 3]);
       const isIncludedInContainer2 = isIncludedIn([4, 5, 6]);
+
       expect(isIncludedInContainer1(2)).toBe(true);
       expect(isIncludedInContainer2(2)).toBe(false);
       expect(isIncludedInContainer1(4)).toBe(false);
@@ -129,6 +135,7 @@ describe("legacy v1 replacements", () => {
           filter(isNot(isIncludedIn([2, 3]))),
           take(2),
         );
+
         expect(count).toHaveBeenCalledTimes(4);
         expect(result).toEqual([1, 4]);
       });

--- a/src/isNonNull.test.ts
+++ b/src/isNonNull.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isNonNull } from "./isNonNull";
 
 test("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
-  if (isNonNull(data)) {
-    expect(data instanceof Date).toBe(true);
-  }
+  expect(isNonNull(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
 test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNonNull);
+
   expect(data).toHaveLength(18);
 });

--- a/src/isNonNullish.test.ts
+++ b/src/isNonNullish.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isNonNullish } from "./isNonNullish";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
-  if (isNonNullish(data)) {
-    expect(data instanceof Date).toBe(true);
-  }
+  expect(isNonNullish(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNonNullish);
+
   expect(data).toHaveLength(17);
 });

--- a/src/isNot.test.ts
+++ b/src/isNot.test.ts
@@ -1,20 +1,17 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
-  if (isNot(isString)(data)) {
-    expect(data instanceof Promise).toBe(true);
-  }
+  expect(isNot(isString)(TYPES_DATA_PROVIDER.promise)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNot(isPromise));
+
   expect(data.some((c) => c instanceof Promise)).toBe(false);
 });

--- a/src/isNullish.test.ts
+++ b/src/isNullish.test.ts
@@ -14,6 +14,7 @@ it("rejects anything else", () => {
     if (data === null || data === undefined) {
       continue;
     }
+
     expect(isNullish(data)).toBe(false);
   }
 });

--- a/src/isNumber.test.ts
+++ b/src/isNumber.test.ts
@@ -1,34 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isNumber } from "./isNumber";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.number as AllTypesDataProviderTypes;
-  if (isNumber(data)) {
-    expect(typeof data).toEqual("number");
-  }
+  expect(isNumber(TYPES_DATA_PROVIDER.number)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNumber);
-  expect(data.every((c) => typeof c === "number")).toEqual(true);
-});
 
-it("should work even if data type is unknown", () => {
-  const data = TYPES_DATA_PROVIDER.number as unknown;
-  if (isNumber(data)) {
-    expect(typeof data).toEqual("number");
-  }
+  expect(data.every((c) => typeof c === "number")).toBe(true);
 });
-
-it("should work with literal types", () => {
-  const x = dataFunction();
-  if (isNumber(x)) {
-    expect(typeof x).toEqual("number");
-  }
-});
-
-const dataFunction = (): string | 1 | 2 | 3 => 1;

--- a/src/isObjectType.test-d.ts
+++ b/src/isObjectType.test-d.ts
@@ -60,7 +60,7 @@ test("should work as type guard in filter", () => {
   >();
 });
 
-test("Can narrow down `any`", () => {
+test("can narrow down `any`", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
   const data = { hello: "world" } as any;
   if (isObjectType(data)) {

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -2,34 +2,34 @@ import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isObjectType } from "./isObjectType";
 
 it("accepts simple objects", () => {
-  expect(isObjectType({ a: 123 })).toEqual(true);
+  expect(isObjectType({ a: 123 })).toBe(true);
 });
 
 it("accepts trivial empty objects", () => {
-  expect(isObjectType({})).toEqual(true);
+  expect(isObjectType({})).toBe(true);
 });
 
 it("rejects strings", () => {
-  expect(isObjectType("asd")).toEqual(false);
+  expect(isObjectType("asd")).toBe(false);
 });
 
 it("rejects null", () => {
-  expect(isObjectType(null)).toEqual(false);
+  expect(isObjectType(null)).toBe(false);
 });
 
 it("accepts arrays", () => {
-  expect(isObjectType([1, 2, 3])).toEqual(true);
+  expect(isObjectType([1, 2, 3])).toBe(true);
 });
 
 it("accepts classes", () => {
-  expect(isObjectType(new TestClass())).toEqual(true);
+  expect(isObjectType(new TestClass())).toBe(true);
 });
 
 it("accepts null prototypes", () => {
-  expect(isObjectType(Object.create(null))).toEqual(true);
+  expect(isObjectType(Object.create(null))).toBe(true);
 });
 
-test("ALL_TYPES_DATA_PROVIDER", () => {
+test("aLL_TYPES_DATA_PROVIDER", () => {
   expect(ALL_TYPES_DATA_PROVIDER.filter(isObjectType)).toMatchInlineSnapshot(`
       [
         [

--- a/src/isObjectType.test.ts
+++ b/src/isObjectType.test.ts
@@ -29,7 +29,7 @@ it("accepts null prototypes", () => {
   expect(isObjectType(Object.create(null))).toBe(true);
 });
 
-test("aLL_TYPES_DATA_PROVIDER", () => {
+test("everything from ALL_TYPES_DATA_PROVIDER", () => {
   expect(ALL_TYPES_DATA_PROVIDER.filter(isObjectType)).toMatchInlineSnapshot(`
       [
         [

--- a/src/isPlainObject.test-d.ts
+++ b/src/isPlainObject.test-d.ts
@@ -38,7 +38,7 @@ test("should work as type guard in filter", () => {
   expectTypeOf(data).toEqualTypeOf<Array<{ readonly a: "asd" }>>();
 });
 
-test("Can narrow down `any`", () => {
+test("can narrow down `any`", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
   const data = { hello: "world" } as any;
   if (isPlainObject(data)) {

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -2,30 +2,30 @@ import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isPlainObject } from "./isPlainObject";
 
 it("accepts simple objects", () => {
-  expect(isPlainObject({ a: 123 })).toEqual(true);
+  expect(isPlainObject({ a: 123 })).toBe(true);
 });
 
 it("accepts trivial empty objects", () => {
-  expect(isPlainObject({})).toEqual(true);
+  expect(isPlainObject({})).toBe(true);
 });
 
 it("rejects strings", () => {
-  expect(isPlainObject("asd")).toEqual(false);
+  expect(isPlainObject("asd")).toBe(false);
 });
 
 it("rejects arrays", () => {
-  expect(isPlainObject([1, 2, 3])).toEqual(false);
+  expect(isPlainObject([1, 2, 3])).toBe(false);
 });
 
 it("rejects classes", () => {
-  expect(isPlainObject(new TestClass())).toEqual(false);
+  expect(isPlainObject(new TestClass())).toBe(false);
 });
 
 it("accepts null prototypes", () => {
-  expect(isPlainObject(Object.create(null))).toEqual(true);
+  expect(isPlainObject(Object.create(null))).toBe(true);
 });
 
-test("ALL_TYPES_DATA_PROVIDER", () => {
+test("aLL_TYPES_DATA_PROVIDER", () => {
   expect(ALL_TYPES_DATA_PROVIDER.filter(isPlainObject)).toMatchInlineSnapshot(`
         [
           {

--- a/src/isPlainObject.test.ts
+++ b/src/isPlainObject.test.ts
@@ -25,7 +25,7 @@ it("accepts null prototypes", () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
 });
 
-test("aLL_TYPES_DATA_PROVIDER", () => {
+test("everything from ALL_TYPES_DATA_PROVIDER", () => {
   expect(ALL_TYPES_DATA_PROVIDER.filter(isPlainObject)).toMatchInlineSnapshot(`
         [
           {

--- a/src/isPromise.test.ts
+++ b/src/isPromise.test.ts
@@ -1,18 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isPromise } from "./isPromise";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
-  if (isPromise(data)) {
-    expect(data instanceof Promise).toEqual(true);
-  }
+  expect(isPromise(TYPES_DATA_PROVIDER.promise)).toBe(true);
 });
 
 it("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isPromise);
-  expect(data.every((c) => c instanceof Promise)).toEqual(true);
+
+  expect(data.every((c) => c instanceof Promise)).toBe(true);
 });

--- a/src/isShallowEqual.test.ts
+++ b/src/isShallowEqual.test.ts
@@ -33,6 +33,7 @@ describe("primitives", () => {
 describe("objects", () => {
   test("arrays", () => {
     const data = [1, 2, 3];
+
     expect(isShallowEqual(data, [1, 2, 3])).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -41,6 +42,7 @@ describe("objects", () => {
 
   test("objects", () => {
     const data = { a: 1, b: 2 } as Record<string, number>;
+
     expect(isShallowEqual(data, { a: 1, b: 2 })).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -50,6 +52,7 @@ describe("objects", () => {
 
   test("uint arrays", () => {
     const data = new Uint8Array([1, 2, 3]);
+
     expect(isShallowEqual(data, new Uint8Array([1, 2, 3]))).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -58,6 +61,7 @@ describe("objects", () => {
 
   test("maps", () => {
     const data = new Map([["a", 1]]);
+
     expect(isShallowEqual(data, new Map([["a", 1]]))).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -75,6 +79,7 @@ describe("objects", () => {
 
   test("sets", () => {
     const data = new Set([1, 2, 3]);
+
     expect(isShallowEqual(data, new Set([1, 2, 3]))).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -86,6 +91,7 @@ describe("objects", () => {
 describe("built-ins", () => {
   test("regex", () => {
     const data = /a/u;
+
     expect(isShallowEqual(data, /a/u)).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -94,6 +100,7 @@ describe("built-ins", () => {
 
   test("dates", () => {
     const data = new Date();
+
     expect(isShallowEqual(data, new Date())).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -102,6 +109,7 @@ describe("built-ins", () => {
 
   test("promises", () => {
     const data = Promise.resolve(1);
+
     expect(isShallowEqual(data, Promise.resolve(1))).toBe(true);
     expect(isShallowEqual(data, data)).toBe(true);
 
@@ -112,24 +120,28 @@ describe("built-ins", () => {
 describe("shallow inequality", () => {
   test("arrays of objects", () => {
     const a = { a: 1 };
+
     expect(isShallowEqual([a], [a])).toBe(true);
     expect(isShallowEqual([a], [{ a: 1 }])).toBe(false);
   });
 
   test("arrays of arrays", () => {
     const a = [1];
+
     expect(isShallowEqual([a], [a])).toBe(true);
     expect(isShallowEqual([a], [[1]])).toBe(false);
   });
 
   test("objects of arrays", () => {
     const a = [1];
+
     expect(isShallowEqual({ a }, { a })).toBe(true);
     expect(isShallowEqual({ a }, { a: [1] })).toBe(false);
   });
 
   test("objects of objects", () => {
     const a = { b: 1 };
+
     expect(isShallowEqual({ a }, { a })).toBe(true);
     expect(isShallowEqual({ a }, { a: { b: 1 } })).toBe(false);
   });

--- a/src/isStrictEqual.test.ts
+++ b/src/isStrictEqual.test.ts
@@ -91,7 +91,7 @@ describe("built-ins", () => {
 });
 
 describe("special cases", () => {
-  test("naN", () => {
+  test("literal NaN", () => {
     // eslint-disable-next-line unicorn/prefer-number-properties
     expect(isStrictEqual(NaN, NaN)).toBe(true);
     expect(isStrictEqual(Number.NaN, Number.NaN)).toBe(true);

--- a/src/isStrictEqual.test.ts
+++ b/src/isStrictEqual.test.ts
@@ -33,30 +33,35 @@ describe("primitives", () => {
 describe("objects", () => {
   test("arrays", () => {
     const data = [1, 2, 3];
+
     expect(isStrictEqual(data, [1, 2, 3])).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("objects", () => {
     const data = { a: 1, b: 2 };
+
     expect(isStrictEqual(data, { a: 1, b: 2 })).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("uint arrays", () => {
     const data = new Uint8Array([1, 2, 3]);
+
     expect(isStrictEqual(data, new Uint8Array([1, 2, 3]))).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("maps", () => {
     const data = new Map([["a", 1]]);
+
     expect(isStrictEqual(data, new Map([["a", 1]]))).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("sets", () => {
     const data = new Set([1, 2, 3]);
+
     expect(isStrictEqual(data, new Set([1, 2, 3]))).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
@@ -65,25 +70,28 @@ describe("objects", () => {
 describe("built-ins", () => {
   test("regex", () => {
     const data = /a/u;
+
     expect(isStrictEqual(data, /a/u)).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("dates", () => {
     const data = new Date();
+
     expect(isStrictEqual(data, new Date())).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 
   test("promises", () => {
     const data = Promise.resolve(1);
+
     expect(isStrictEqual(data, Promise.resolve(1))).toBe(false);
     expect(isStrictEqual(data, data)).toBe(true);
   });
 });
 
 describe("special cases", () => {
-  test("NaN", () => {
+  test("naN", () => {
     // eslint-disable-next-line unicorn/prefer-number-properties
     expect(isStrictEqual(NaN, NaN)).toBe(true);
     expect(isStrictEqual(Number.NaN, Number.NaN)).toBe(true);

--- a/src/isString.test.ts
+++ b/src/isString.test.ts
@@ -1,34 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isString } from "./isString";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.string as AllTypesDataProviderTypes;
-  if (isString(data)) {
-    expect(typeof data).toEqual("string");
-  }
-});
-
-it("should work even if data type is unknown", () => {
-  const data = TYPES_DATA_PROVIDER.string as unknown;
-  if (isString(data)) {
-    expect(typeof data).toEqual("string");
-  }
-});
-
-it("should work with literal types", () => {
-  const x = dataFunction();
-  if (isString(x)) {
-    expect(typeof x).toEqual("string");
-  }
+  expect(isString(TYPES_DATA_PROVIDER.string)).toBe(true);
 });
 
 it("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isString);
-  expect(data.every((c) => typeof c === "string")).toEqual(true);
-});
 
-const dataFunction = (): number | "a" | "b" | "c" => "a";
+  expect(data.every((c) => typeof c === "string")).toBe(true);
+});

--- a/src/isSymbol.test.ts
+++ b/src/isSymbol.test.ts
@@ -1,33 +1,15 @@
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
-  type AllTypesDataProviderTypes,
 } from "../test/typesDataProvider";
 import { isSymbol } from "./isSymbol";
 
 it("should work as type guard", () => {
-  const data = TYPES_DATA_PROVIDER.symbol as AllTypesDataProviderTypes;
-  if (isSymbol(data)) {
-    expect(typeof data).toEqual("symbol");
-  }
-});
-
-it("should work even if data type is `unknown`", () => {
-  const data = TYPES_DATA_PROVIDER.symbol as unknown;
-  if (isSymbol(data)) {
-    expect(typeof data).toEqual("symbol");
-  }
-});
-
-it("should work even if data type is `any`", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly checking any
-  const data = TYPES_DATA_PROVIDER.symbol as any;
-  if (isSymbol(data)) {
-    expect(typeof data).toEqual("symbol");
-  }
+  expect(isSymbol(TYPES_DATA_PROVIDER.symbol)).toBe(true);
 });
 
 it("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isSymbol);
-  expect(data.every((c) => typeof c === "symbol")).toEqual(true);
+
+  expect(data.every((c) => typeof c === "symbol")).toBe(true);
 });

--- a/src/isTruthy.test.ts
+++ b/src/isTruthy.test.ts
@@ -1,8 +1,5 @@
 import { isTruthy } from "./isTruthy";
 
 test("isTruthy", () => {
-  const data: "" | 0 | false | { a: string } = { a: "asd" };
-  if (isTruthy(data)) {
-    expect(data).toEqual({ a: "asd" });
-  }
+  expect(isTruthy({ a: "asd" })).toBe(true);
 });

--- a/src/join.test.ts
+++ b/src/join.test.ts
@@ -4,62 +4,72 @@ describe("joins same-typed items", () => {
   it("number", () => {
     const array = [1, 2, 3, 4, 5];
     const result = join(array, ",");
-    expect(result).toEqual("1,2,3,4,5");
+
+    expect(result).toBe("1,2,3,4,5");
   });
 
   it("string", () => {
     const array = ["a", "b", "c", "d", "e"];
     const result = join(array, ",");
-    expect(result).toEqual("a,b,c,d,e");
+
+    expect(result).toBe("a,b,c,d,e");
   });
 
   it("bigint", () => {
     const array = [1n, 2n, 3n, 4n, 5n];
     const result = join(array, ",");
-    expect(result).toEqual("1,2,3,4,5");
+
+    expect(result).toBe("1,2,3,4,5");
   });
 
   it("boolean", () => {
     const array = [true, false, true, false, true];
     const result = join(array, ",");
-    expect(result).toEqual("true,false,true,false,true");
+
+    expect(result).toBe("true,false,true,false,true");
   });
 
   it("null", () => {
     const array = [null, null, null, null, null];
     const result = join(array, ",");
-    expect(result).toEqual(",,,,");
+
+    expect(result).toBe(",,,,");
   });
 
   it("undefined", () => {
     const array = [undefined, undefined, undefined, undefined, undefined];
     const result = join(array, ",");
-    expect(result).toEqual(",,,,");
+
+    expect(result).toBe(",,,,");
   });
 });
 
 it("joins different-typed items", () => {
   const array = [1, "2", 3n, true, null, undefined];
   const result = join(array, ",");
-  expect(result).toEqual("1,2,3,true,,");
+
+  expect(result).toBe("1,2,3,true,,");
 });
 
 describe("edge-cases", () => {
   it("empty glue", () => {
     const array = [1, 2, 3, 4, 5];
     const result = join(array, "");
-    expect(result).toEqual("12345");
+
+    expect(result).toBe("12345");
   });
 
   it("empty array", () => {
     const array: Array<number> = [];
     const result = join(array, ",");
-    expect(result).toEqual("");
+
+    expect(result).toBe("");
   });
 
   it("doesnt add glue on single item", () => {
     const array = [1];
     const result = join(array, ",");
-    expect(result).toEqual("1");
+
+    expect(result).toBe("1");
   });
 });

--- a/src/keys.test-d.ts
+++ b/src/keys.test-d.ts
@@ -119,12 +119,12 @@ describe("object types", () => {
     expectTypeOf(result).toEqualTypeOf<Array<string>>();
   });
 
-  test("Record with literal union", () => {
+  test("record with literal union", () => {
     const result = keys({ a: 1, b: 2 } as Record<"a" | "b", number>);
     expectTypeOf(result).toEqualTypeOf<Array<"a" | "b">>();
   });
 
-  test("Record with template string literal", () => {
+  test("record with template string literal", () => {
     const result = keys({ param_123: "hello", param_456: "world" } as Record<
       `param_${number}`,
       string

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -2,15 +2,15 @@ import { keys } from "./keys";
 
 describe("dataFirst", () => {
   it("work with arrays", () => {
-    expect(keys(["x", "y", "z"])).toEqual(["0", "1", "2"]);
+    expect(keys(["x", "y", "z"])).toStrictEqual(["0", "1", "2"]);
   });
 
   it("work with objects", () => {
-    expect(keys({ a: "x", b: "y", c: "z" })).toEqual(["a", "b", "c"]);
+    expect(keys({ a: "x", b: "y", c: "z" })).toStrictEqual(["a", "b", "c"]);
   });
 
   it("should return strict types", () => {
-    expect(keys({ 5: "x", b: "y", c: "z" })).toEqual(["5", "b", "c"]);
+    expect(keys({ 5: "x", b: "y", c: "z" })).toStrictEqual(["5", "b", "c"]);
   });
 
   it("should ignore symbol keys", () => {

--- a/src/length.test.ts
+++ b/src/length.test.ts
@@ -3,7 +3,7 @@ import { pipe } from "./pipe";
 
 describe("data first", () => {
   test("array", () => {
-    expect(length([0, 1, 2, 3, 4])).toEqual(5);
+    expect(length([0, 1, 2, 3, 4])).toBe(5);
   });
 
   test("iterable", () => {
@@ -16,13 +16,13 @@ describe("data first", () => {
           yield 3;
         },
       }),
-    ).toEqual(4);
+    ).toBe(4);
   });
 });
 
 describe("curried", () => {
   test("array", () => {
-    expect(pipe([0, 1, 2, 3, 4], length())).toEqual(5);
+    expect(pipe([0, 1, 2, 3, 4], length())).toBe(5);
   });
 
   test("iterable", () => {
@@ -38,6 +38,6 @@ describe("curried", () => {
         },
         length(),
       ),
-    ).toEqual(4);
+    ).toBe(4);
   });
 });

--- a/src/map.test-d.ts
+++ b/src/map.test-d.ts
@@ -67,7 +67,7 @@ it("nonempty readonly (head) number array", () => {
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
-describe("Indexed", () => {
+describe("indexed", () => {
   it("number array", () => {
     const result = map([1, 2, 3] as Array<number>, (x, index) => x + index);
     expectTypeOf(result).toEqualTypeOf<Array<number>>();

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -17,16 +17,16 @@ describe("data_first", () => {
   });
 });
 
-describe("data_last", () => {
-  it("map", () => {
+describe("data-last", () => {
+  it("passes the value to the mapper as its first argument", () => {
     expect(pipe([1, 2, 3], map(multiply(2)))).toEqual([2, 4, 6]);
   });
 
-  it("map", () => {
+  it("passes the index to the mapper as its second argument", () => {
     expect(
       pipe(
         [0, 0, 0],
-        map((_, i) => i),
+        map((_, index) => index),
       ),
     ).toEqual([0, 1, 2]);
   });

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -9,17 +9,17 @@ import { take } from "./take";
 
 describe("data_first", () => {
   it("map", () => {
-    expect(map([1, 2, 3], multiply(2))).toEqual([2, 4, 6]);
+    expect(map([1, 2, 3], multiply(2))).toStrictEqual([2, 4, 6]);
   });
 
   it("map indexed", () => {
-    expect(map([0, 0, 0], (_, i) => i)).toEqual([0, 1, 2]);
+    expect(map([0, 0, 0], (_, i) => i)).toStrictEqual([0, 1, 2]);
   });
 });
 
 describe("data-last", () => {
   it("passes the value to the mapper as its first argument", () => {
-    expect(pipe([1, 2, 3], map(multiply(2)))).toEqual([2, 4, 6]);
+    expect(pipe([1, 2, 3], map(multiply(2)))).toStrictEqual([2, 4, 6]);
   });
 
   it("passes the index to the mapper as its second argument", () => {
@@ -28,7 +28,7 @@ describe("data-last", () => {
         [0, 0, 0],
         map((_, index) => index),
       ),
-    ).toEqual([0, 1, 2]);
+    ).toStrictEqual([0, 1, 2]);
   });
 });
 
@@ -36,7 +36,7 @@ describe("pipe", () => {
   it("invoked lazily", () => {
     const count = vi.fn(multiply(10));
 
-    expect(pipe([1, 2, 3], map(count), take(2))).toEqual([10, 20]);
+    expect(pipe([1, 2, 3], map(count), take(2))).toStrictEqual([10, 20]);
 
     expect(count).toHaveBeenCalledTimes(2);
   });
@@ -44,7 +44,7 @@ describe("pipe", () => {
   it("invoked lazily (indexed)", () => {
     const count = vi.fn((_: unknown, index: number) => index);
 
-    expect(pipe([0, 0, 0], map(count), take(2))).toEqual([0, 1]);
+    expect(pipe([0, 0, 0], map(count), take(2))).toStrictEqual([0, 1]);
 
     expect(count).toHaveBeenCalledTimes(2);
   });
@@ -70,27 +70,27 @@ describe("pipe", () => {
           return x;
         }),
       ),
-    ).toEqual([1, 3, 5]);
+    ).toStrictEqual([1, 3, 5]);
 
-    expect(indexes1).toEqual([0, 1, 2, 3, 4]);
-    expect(indexes2).toEqual([0, 1, 2]);
-    expect(anyItems1).toEqual([
+    expect(indexes1).toStrictEqual([0, 1, 2, 3, 4]);
+    expect(indexes2).toStrictEqual([0, 1, 2]);
+    expect(anyItems1).toStrictEqual([
       [1],
       [1, 2],
       [1, 2, 3],
       [1, 2, 3, 4],
       [1, 2, 3, 4, 5],
     ]);
-    expect(anyItems2).toEqual([[1], [1, 3], [1, 3, 5]]);
+    expect(anyItems2).toStrictEqual([[1], [1, 3], [1, 3, 5]]);
   });
 });
 
 it("number array", () => {
-  expect(map([1, 2, 3], add(1))).toEqual([2, 3, 4]);
+  expect(map([1, 2, 3], add(1))).toStrictEqual([2, 3, 4]);
 });
 
 it("mixed type tuple", () => {
-  expect(map([1, "2", true], constant(1))).toEqual([1, 1, 1]);
+  expect(map([1, "2", true], constant(1))).toStrictEqual([1, 1, 1]);
 });
 
 it("complex variadic number array", () => {
@@ -105,15 +105,15 @@ it("complex variadic number array", () => {
     true,
   ];
 
-  expect(map(input, identity())).toEqual(input);
+  expect(map(input, identity())).toStrictEqual(input);
 });
 
 describe("indexed", () => {
   it("number array", () => {
-    expect(map([1, 2, 3], (x, index) => x + index)).toEqual([1, 3, 5]);
+    expect(map([1, 2, 3], (x, index) => x + index)).toStrictEqual([1, 3, 5]);
   });
 
   it("mixed type tuple", () => {
-    expect(map([1, "2", true], (_, index) => index)).toEqual([0, 1, 2]);
+    expect(map([1, "2", true], (_, index) => index)).toStrictEqual([0, 1, 2]);
   });
 });

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -104,10 +104,11 @@ it("complex variadic number array", () => {
     123,
     true,
   ];
+
   expect(map(input, identity())).toEqual(input);
 });
 
-describe("Indexed", () => {
+describe("indexed", () => {
   it("number array", () => {
     expect(map([1, 2, 3], (x, index) => x + index)).toEqual([1, 3, 5]);
   });

--- a/src/mapKeys.test.ts
+++ b/src/mapKeys.test.ts
@@ -25,12 +25,14 @@ test("symbols are not passed to the mapper", () => {
   mapKeys({ [Symbol("mySymbol")]: 1, a: "hello" }, (key, value) => {
     expect(key).toBe("a");
     expect(value).toBe("hello");
+
     return key;
   });
 });
 
 test("symbols returned from the mapper are not ignored", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(mapKeys({ a: 1 }, constant(mySymbol))).toStrictEqual({
     [mySymbol]: 1,
   });
@@ -40,6 +42,7 @@ test("number keys are converted to strings", () => {
   mapKeys({ 123: 456 }, (key, value) => {
     expect(key).toBe("123");
     expect(value).toBe(456);
+
     return key;
   });
 });

--- a/src/mapKeys.test.ts
+++ b/src/mapKeys.test.ts
@@ -48,5 +48,5 @@ test("number keys are converted to strings", () => {
 });
 
 test("numbers returned from the mapper are used as-is", () => {
-  expect(mapKeys({ a: "b" }, constant(123))).toEqual({ 123: "b" });
+  expect(mapKeys({ a: "b" }, constant(123))).toStrictEqual({ 123: "b" });
 });

--- a/src/mapToObj.test.ts
+++ b/src/mapToObj.test.ts
@@ -5,13 +5,13 @@ describe("data_first", () => {
   it("mapToObj", () => {
     const result = mapToObj([1, 2, 3], (x) => [String(x), x * 2]);
 
-    expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
+    expect(result).toStrictEqual({ 1: 2, 2: 4, 3: 6 });
   });
 
   it("indexed", () => {
     const result = mapToObj([0, 0, 0], (_, i) => [i, i]);
 
-    expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
+    expect(result).toStrictEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });
 
@@ -22,7 +22,7 @@ describe("data_last", () => {
       mapToObj((x) => [String(x), x * 2]),
     );
 
-    expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
+    expect(result).toStrictEqual({ 1: 2, 2: 4, 3: 6 });
   });
 
   it("indexed", () => {
@@ -31,6 +31,6 @@ describe("data_last", () => {
       mapToObj((_, i) => [i, i]),
     );
 
-    expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
+    expect(result).toStrictEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });

--- a/src/mapToObj.test.ts
+++ b/src/mapToObj.test.ts
@@ -4,10 +4,13 @@ import { pipe } from "./pipe";
 describe("data_first", () => {
   it("mapToObj", () => {
     const result = mapToObj([1, 2, 3], (x) => [String(x), x * 2]);
+
     expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
   });
+
   it("indexed", () => {
     const result = mapToObj([0, 0, 0], (_, i) => [i, i]);
+
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });
@@ -18,13 +21,16 @@ describe("data_last", () => {
       [1, 2, 3],
       mapToObj((x) => [String(x), x * 2]),
     );
+
     expect(result).toEqual({ 1: 2, 2: 4, 3: 6 });
   });
+
   it("indexed", () => {
     const result = pipe(
       [0, 0, 0],
       mapToObj((_, i) => [i, i]),
     );
+
     expect(result).toEqual({ 0: 0, 1: 1, 2: 2 });
   });
 });

--- a/src/mapValues.test-d.ts
+++ b/src/mapValues.test-d.ts
@@ -25,16 +25,19 @@ describe("mapped type", () => {
       expectTypeOf(key).toEqualTypeOf<string>();
     });
   });
+
   test("should work with number keys", () => {
     mapValues({} as { [K in number]: unknown }, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<`${number}`>();
     });
   });
+
   test("should work with template literal string keys", () => {
     mapValues({} as { [K in `prefix${string}`]: unknown }, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<`prefix${string}`>();
     });
   });
+
   test("should not work with symbol keys", () => {
     mapValues({} as { [K in symbol]: unknown }, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<never>();
@@ -48,16 +51,19 @@ describe("indexed signature", () => {
       expectTypeOf(key).toEqualTypeOf<string>();
     });
   });
+
   test("should work with number keys", () => {
     mapValues({} as Record<number, unknown>, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<`${number}`>();
     });
   });
+
   test("should work with template literal string keys", () => {
     mapValues({} as Record<`prefix${string}`, unknown>, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<`prefix${string}`>();
     });
   });
+
   test("should not work with symbol keys", () => {
     mapValues({} as Record<symbol, unknown>, (_, key) => {
       expectTypeOf(key).toEqualTypeOf<never>();

--- a/src/mapValues.test.ts
+++ b/src/mapValues.test.ts
@@ -27,6 +27,7 @@ test("symbols are not passed to the mapper", () => {
   mapValues({ [Symbol("mySymbol")]: 1, a: "hello" }, (value, key) => {
     expect(value).toBe("hello");
     expect(key).toBe("a");
+
     return "world";
   });
 });
@@ -35,6 +36,7 @@ test("number keys are converted to string in the mapper", () => {
   mapValues({ 123: 456 }, (value, key) => {
     expect(value).toBe(456);
     expect(key).toBe("123");
+
     return "world";
   });
 });

--- a/src/mapWithFeedback.test-d.ts
+++ b/src/mapWithFeedback.test-d.ts
@@ -8,6 +8,16 @@ it("should return a mutable tuple type whose length matches input container's le
   >();
 });
 
+it("should maintain the input shape via a pipe", () => {
+  const result = pipe(
+    [1, 2, 3, 4, 5] as const,
+    mapWithFeedback((acc, x) => acc + x, 100),
+  );
+  expectTypeOf(result).toEqualTypeOf<
+    [number, number, number, number, number]
+  >();
+});
+
 it("should return a tuple consisting of the initial value type even if the initial iterable contains a different type", () => {
   const result = mapWithFeedback(
     ["1", "2", "3", "4", "5"],
@@ -26,16 +36,6 @@ it("should correctly infer type with a non-literal array type", () => {
     100,
   );
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
-});
-
-it("should return a tuple consisting of the initial value type even if the initial iterable contains a different type", () => {
-  const result = pipe(
-    [1, 2, 3, 4, 5] as const,
-    mapWithFeedback((acc, x) => acc + x, 100),
-  );
-  expectTypeOf(result).toEqualTypeOf<
-    [number, number, number, number, number]
-  >();
 });
 
 it("the items array passed to the callback should be an array type containing the union type of all of the members in the original array", () => {

--- a/src/mapWithFeedback.test.ts
+++ b/src/mapWithFeedback.test.ts
@@ -21,7 +21,9 @@ describe("data first", () => {
     );
 
     const [item] = results;
+
     expect(item).toStrictEqual({ "1": 1, "2": 2, "3": 3, "4": 4, "5": 5 });
+
     for (const result of results) {
       expect(result).toBe(item);
     }
@@ -30,6 +32,7 @@ describe("data first", () => {
   it("if an empty array is provided, it should never iterate, returning a new empty array.", () => {
     const data: Array<unknown> = [];
     const result = mapWithFeedback(data, (acc) => acc, "value");
+
     expect(result).toStrictEqual([]);
     expect(result).not.toBe(data);
   });
@@ -67,6 +70,7 @@ describe("data last", () => {
       mapWithFeedback((acc, x) => acc + x, 100),
       take(2),
     );
+
     expect(counter).toHaveBeenCalledTimes(2);
   });
 
@@ -81,6 +85,7 @@ describe("data last", () => {
         return acc + x;
       }, 100),
     );
+
     expect(indices).toStrictEqual([0, 1, 2, 3, 4]);
     expect(lazyItems).toStrictEqual([
       [1],

--- a/src/meanBy.test.ts
+++ b/src/meanBy.test.ts
@@ -7,7 +7,7 @@ describe("data first", () => {
   test("meanBy", () => {
     expect(
       meanBy([{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }], prop("a")),
-    ).toEqual(3);
+    ).toBe(3);
   });
 
   test("indexed", () => {
@@ -16,7 +16,7 @@ describe("data first", () => {
         [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
         ({ a }, idx) => a + idx,
       ),
-    ).toEqual(5);
+    ).toBe(5);
   });
 
   test("should handle empty array", () => {
@@ -31,7 +31,7 @@ describe("data last", () => {
         [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
         meanBy(prop("a")),
       ),
-    ).toEqual(3);
+    ).toBe(3);
   });
 
   test("indexed", () => {
@@ -40,7 +40,7 @@ describe("data last", () => {
         [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
         meanBy(({ a }, idx) => a + idx),
       ),
-    ).toEqual(5);
+    ).toBe(5);
   });
 
   test("should handle empty array", () => {

--- a/src/merge.test-d.ts
+++ b/src/merge.test-d.ts
@@ -128,7 +128,7 @@ test("source with any", () => {
   /* eslint-enable @typescript-eslint/no-explicit-any */
 });
 
-test("Type-fest issue #601?", () => {
+test("type-fest issue #601?", () => {
   // Test for issue https://github.com/sindresorhus/type-fest/issues/601
   expectTypeOf(
     merge(

--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -2,7 +2,7 @@ import { merge } from "./merge";
 
 describe("data first", () => {
   test("should merge", () => {
-    expect(merge({ x: 1, y: 2 }, { y: 10, z: 2 })).toEqual({
+    expect(merge({ x: 1, y: 2 }, { y: 10, z: 2 })).toStrictEqual({
       x: 1,
       y: 10,
       z: 2,
@@ -12,7 +12,7 @@ describe("data first", () => {
 
 describe("data last", () => {
   test("should merge", () => {
-    expect(merge({ y: 10, z: 2 })({ x: 1, y: 2 })).toEqual({
+    expect(merge({ y: 10, z: 2 })({ x: 1, y: 2 })).toStrictEqual({
       x: 1,
       y: 10,
       z: 2,

--- a/src/mergeAll.test.ts
+++ b/src/mergeAll.test.ts
@@ -3,7 +3,7 @@ import { mergeAll } from "./mergeAll";
 test("merge objects", () => {
   expect(
     mergeAll([{ a: 1, b: 1 }, { b: 2, c: 3 }, { d: 10 }] as const),
-  ).toEqual({
+  ).toStrictEqual({
     a: 1,
     b: 2,
     c: 3,

--- a/src/mergeDeep.test.ts
+++ b/src/mergeDeep.test.ts
@@ -6,80 +6,80 @@ describe("runtime (dataFirst)", () => {
     const a = { foo: "baz", x: 1 };
     const b = { foo: "bar", y: 2 };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: "bar", x: 1, y: 2 });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: "bar", x: 1, y: 2 });
   });
 
   test("should merge nested objects", () => {
     const a = { foo: { bar: "baz" } };
     const b = { foo: { qux: "quux" } };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: { bar: "baz", qux: "quux" } });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: { bar: "baz", qux: "quux" } });
   });
 
   test("should not merge object and array", () => {
     const a = { foo: ["qux"] };
     const b = { foo: { bar: "baz" } };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: { bar: "baz" } });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: { bar: "baz" } });
   });
 
   test("should not merge array and object", () => {
     const a = { foo: { bar: "baz" } };
     const b = { foo: ["qux"] };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: ["qux"] });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: ["qux"] });
   });
 
   it("should not merge arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: ["baz"] });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: ["baz"] });
   });
 
   it("should merge different types", () => {
     const a = { foo: "bar" };
     const b = { foo: 123 };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: 123 });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: 123 });
   });
 
   it("should work with weird object types, null", () => {
     const a = { foo: null };
     const b = { foo: 123 };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: 123 });
-    expect(mergeDeep(b, a)).toEqual({ foo: null });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: 123 });
+    expect(mergeDeep(b, a)).toStrictEqual({ foo: null });
   });
 
   it("should work with weird object types, functions", () => {
     const a = { foo: doNothing() };
     const b = { foo: 123 };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: 123 });
-    expect(mergeDeep(b, a)).toEqual({ foo: doNothing() });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: 123 });
+    expect(mergeDeep(b, a)).toStrictEqual({ foo: doNothing() });
   });
 
   it("should work with weird object types, date", () => {
     const a = { foo: new Date(1337) };
     const b = { foo: 123 };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: 123 });
-    expect(mergeDeep(b, a)).toEqual({ foo: new Date(1337) });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: 123 });
+    expect(mergeDeep(b, a)).toStrictEqual({ foo: new Date(1337) });
   });
 
   it("doesn't spread arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: ["baz"] });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: ["baz"] });
   });
 
   it("doesn't recurse into arrays", () => {
     const a = { foo: [{ bar: "baz" }] };
     const b = { foo: [{ bar: "hello, world" }] };
 
-    expect(mergeDeep(a, b)).toEqual({ foo: [{ bar: "hello, world" }] });
+    expect(mergeDeep(a, b)).toStrictEqual({ foo: [{ bar: "hello, world" }] });
   });
 });
 
@@ -88,6 +88,6 @@ describe("runtime (dataLast)", () => {
     const a = { foo: "baz", x: 1 };
     const b = { foo: "bar", y: 2 };
 
-    expect(mergeDeep(b)(a)).toEqual({ foo: "bar", x: 1, y: 2 });
+    expect(mergeDeep(b)(a)).toStrictEqual({ foo: "bar", x: 1, y: 2 });
   });
 });

--- a/src/mergeDeep.test.ts
+++ b/src/mergeDeep.test.ts
@@ -5,42 +5,49 @@ describe("runtime (dataFirst)", () => {
   test("should merge objects", () => {
     const a = { foo: "baz", x: 1 };
     const b = { foo: "bar", y: 2 };
+
     expect(mergeDeep(a, b)).toEqual({ foo: "bar", x: 1, y: 2 });
   });
 
   test("should merge nested objects", () => {
     const a = { foo: { bar: "baz" } };
     const b = { foo: { qux: "quux" } };
+
     expect(mergeDeep(a, b)).toEqual({ foo: { bar: "baz", qux: "quux" } });
   });
 
   test("should not merge object and array", () => {
     const a = { foo: ["qux"] };
     const b = { foo: { bar: "baz" } };
+
     expect(mergeDeep(a, b)).toEqual({ foo: { bar: "baz" } });
   });
 
   test("should not merge array and object", () => {
     const a = { foo: { bar: "baz" } };
     const b = { foo: ["qux"] };
+
     expect(mergeDeep(a, b)).toEqual({ foo: ["qux"] });
   });
 
   it("should not merge arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
+
     expect(mergeDeep(a, b)).toEqual({ foo: ["baz"] });
   });
 
   it("should merge different types", () => {
     const a = { foo: "bar" };
     const b = { foo: 123 };
+
     expect(mergeDeep(a, b)).toEqual({ foo: 123 });
   });
 
   it("should work with weird object types, null", () => {
     const a = { foo: null };
     const b = { foo: 123 };
+
     expect(mergeDeep(a, b)).toEqual({ foo: 123 });
     expect(mergeDeep(b, a)).toEqual({ foo: null });
   });
@@ -48,6 +55,7 @@ describe("runtime (dataFirst)", () => {
   it("should work with weird object types, functions", () => {
     const a = { foo: doNothing() };
     const b = { foo: 123 };
+
     expect(mergeDeep(a, b)).toEqual({ foo: 123 });
     expect(mergeDeep(b, a)).toEqual({ foo: doNothing() });
   });
@@ -55,6 +63,7 @@ describe("runtime (dataFirst)", () => {
   it("should work with weird object types, date", () => {
     const a = { foo: new Date(1337) };
     const b = { foo: 123 };
+
     expect(mergeDeep(a, b)).toEqual({ foo: 123 });
     expect(mergeDeep(b, a)).toEqual({ foo: new Date(1337) });
   });
@@ -62,12 +71,14 @@ describe("runtime (dataFirst)", () => {
   it("doesn't spread arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
+
     expect(mergeDeep(a, b)).toEqual({ foo: ["baz"] });
   });
 
   it("doesn't recurse into arrays", () => {
     const a = { foo: [{ bar: "baz" }] };
     const b = { foo: [{ bar: "hello, world" }] };
+
     expect(mergeDeep(a, b)).toEqual({ foo: [{ bar: "hello, world" }] });
   });
 });
@@ -76,6 +87,7 @@ describe("runtime (dataLast)", () => {
   test("should merge objects", () => {
     const a = { foo: "baz", x: 1 };
     const b = { foo: "bar", y: 2 };
+
     expect(mergeDeep(b)(a)).toEqual({ foo: "bar", x: 1, y: 2 });
   });
 });

--- a/src/multiply.test.ts
+++ b/src/multiply.test.ts
@@ -1,9 +1,9 @@
 import { multiply } from "./multiply";
 
 test("data-first", () => {
-  expect(multiply(3, 4)).toEqual(12);
+  expect(multiply(3, 4)).toBe(12);
 });
 
 test("data-last", () => {
-  expect(multiply(4)(3)).toEqual(12);
+  expect(multiply(4)(3)).toBe(12);
 });

--- a/src/nthBy.test.ts
+++ b/src/nthBy.test.ts
@@ -5,16 +5,18 @@ import { pipe } from "./pipe";
 describe("runtime (dataFirst)", () => {
   it("works", () => {
     const data = [2, 1, 3];
-    expect(nthBy(data, 0, identity())).toEqual(1);
-    expect(nthBy(data, 1, identity())).toEqual(2);
-    expect(nthBy(data, 2, identity())).toEqual(3);
+
+    expect(nthBy(data, 0, identity())).toBe(1);
+    expect(nthBy(data, 1, identity())).toBe(2);
+    expect(nthBy(data, 2, identity())).toBe(3);
   });
 
   it("handles negative indexes", () => {
     const data = [2, 1, 3];
-    expect(nthBy(data, -1, identity())).toEqual(3);
-    expect(nthBy(data, -2, identity())).toEqual(2);
-    expect(nthBy(data, -3, identity())).toEqual(1);
+
+    expect(nthBy(data, -1, identity())).toBe(3);
+    expect(nthBy(data, -2, identity())).toBe(2);
+    expect(nthBy(data, -3, identity())).toBe(1);
   });
 
   it("handles overflows gracefully", () => {
@@ -24,30 +26,33 @@ describe("runtime (dataFirst)", () => {
 
   it("works with complex order rules", () => {
     const data = ["aaaa", "b", "bb", "a", "aaa", "bbbb", "aa", "bbb"] as const;
-    expect(nthBy(data, 0, (a) => a.length, identity())).toEqual("a");
-    expect(nthBy(data, 1, (a) => a.length, identity())).toEqual("b");
-    expect(nthBy(data, 2, (a) => a.length, identity())).toEqual("aa");
-    expect(nthBy(data, 3, (a) => a.length, identity())).toEqual("bb");
-    expect(nthBy(data, 4, (a) => a.length, identity())).toEqual("aaa");
-    expect(nthBy(data, 5, (a) => a.length, identity())).toEqual("bbb");
-    expect(nthBy(data, 6, (a) => a.length, identity())).toEqual("aaaa");
-    expect(nthBy(data, 7, (a) => a.length, identity())).toEqual("bbbb");
+
+    expect(nthBy(data, 0, (a) => a.length, identity())).toBe("a");
+    expect(nthBy(data, 1, (a) => a.length, identity())).toBe("b");
+    expect(nthBy(data, 2, (a) => a.length, identity())).toBe("aa");
+    expect(nthBy(data, 3, (a) => a.length, identity())).toBe("bb");
+    expect(nthBy(data, 4, (a) => a.length, identity())).toBe("aaa");
+    expect(nthBy(data, 5, (a) => a.length, identity())).toBe("bbb");
+    expect(nthBy(data, 6, (a) => a.length, identity())).toBe("aaaa");
+    expect(nthBy(data, 7, (a) => a.length, identity())).toBe("bbbb");
   });
 });
 
 describe("runtime (dataLast)", () => {
   it("works", () => {
     const data = [2, 1, 3];
-    expect(pipe(data, nthBy(0, identity()))).toEqual(1);
-    expect(pipe(data, nthBy(1, identity()))).toEqual(2);
-    expect(pipe(data, nthBy(2, identity()))).toEqual(3);
+
+    expect(pipe(data, nthBy(0, identity()))).toBe(1);
+    expect(pipe(data, nthBy(1, identity()))).toBe(2);
+    expect(pipe(data, nthBy(2, identity()))).toBe(3);
   });
 
   it("handles negative indexes", () => {
     const data = [2, 1, 3];
-    expect(pipe(data, nthBy(-1, identity()))).toEqual(3);
-    expect(pipe(data, nthBy(-2, identity()))).toEqual(2);
-    expect(pipe(data, nthBy(-3, identity()))).toEqual(1);
+
+    expect(pipe(data, nthBy(-1, identity()))).toBe(3);
+    expect(pipe(data, nthBy(-2, identity()))).toBe(2);
+    expect(pipe(data, nthBy(-3, identity()))).toBe(1);
   });
 
   it("handles overflows gracefully", () => {
@@ -57,53 +62,54 @@ describe("runtime (dataLast)", () => {
 
   it("works with complex order rules", () => {
     const data = ["aaaa", "b", "bb", "a", "aaa", "bbbb", "aa", "bbb"] as const;
+
     expect(
       pipe(
         data,
         nthBy(0, (a) => a.length, identity()),
       ),
-    ).toEqual("a");
+    ).toBe("a");
     expect(
       pipe(
         data,
         nthBy(1, (a) => a.length, identity()),
       ),
-    ).toEqual("b");
+    ).toBe("b");
     expect(
       pipe(
         data,
         nthBy(2, (a) => a.length, identity()),
       ),
-    ).toEqual("aa");
+    ).toBe("aa");
     expect(
       pipe(
         data,
         nthBy(3, (a) => a.length, identity()),
       ),
-    ).toEqual("bb");
+    ).toBe("bb");
     expect(
       pipe(
         data,
         nthBy(4, (a) => a.length, identity()),
       ),
-    ).toEqual("aaa");
+    ).toBe("aaa");
     expect(
       pipe(
         data,
         nthBy(5, (a) => a.length, identity()),
       ),
-    ).toEqual("bbb");
+    ).toBe("bbb");
     expect(
       pipe(
         data,
         nthBy(6, (a) => a.length, identity()),
       ),
-    ).toEqual("aaaa");
+    ).toBe("aaaa");
     expect(
       pipe(
         data,
         nthBy(7, (a) => a.length, identity()),
       ),
-    ).toEqual("bbbb");
+    ).toBe("bbbb");
   });
 });

--- a/src/objOf.test.ts
+++ b/src/objOf.test.ts
@@ -5,7 +5,7 @@ describe("data first", () => {
     const actual = objOf(10, "a");
 
     expect(actual.a).toBe(10);
-    expect(actual).toEqual({ a: 10 });
+    expect(actual).toStrictEqual({ a: 10 });
   });
 });
 
@@ -14,6 +14,6 @@ describe("data last", () => {
     const actual = objOf("a")(10);
 
     expect(actual.a).toBe(10);
-    expect(actual).toEqual({ a: 10 });
+    expect(actual).toStrictEqual({ a: 10 });
   });
 });

--- a/src/objOf.test.ts
+++ b/src/objOf.test.ts
@@ -3,7 +3,8 @@ import { objOf } from "./objOf";
 describe("data first", () => {
   test("wrap value", () => {
     const actual = objOf(10, "a");
-    expect(actual.a).toEqual(10);
+
+    expect(actual.a).toBe(10);
     expect(actual).toEqual({ a: 10 });
   });
 });
@@ -11,7 +12,8 @@ describe("data first", () => {
 describe("data last", () => {
   test("wrap value", () => {
     const actual = objOf("a")(10);
-    expect(actual.a).toEqual(10);
+
+    expect(actual.a).toBe(10);
     expect(actual).toEqual({ a: 10 });
   });
 });

--- a/src/omit.test.ts
+++ b/src/omit.test.ts
@@ -3,28 +3,33 @@ import { pipe } from "./pipe";
 
 test("dataFirst", () => {
   const result = omit({ a: 1, b: 2, c: 3, d: 4 }, ["a", "d"] as const);
+
   expect(result).toEqual({ b: 2, c: 3 });
 });
 
 test("single removed prop works", () => {
   const obj: { a: number } = { a: 1 };
   const result = omit(obj, ["a"]);
+
   expect(result).toEqual({});
 });
 
 test("dataLast", () => {
   const result = pipe({ a: 1, b: 2, c: 3, d: 4 }, omit(["a", "d"] as const));
+
   expect(result).toEqual({ b: 2, c: 3 });
 });
 
 test("can omit symbol keys", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(omit({ [mySymbol]: 3 }, [mySymbol])).toStrictEqual({});
 });
 
 test("shallow clone the array when there's nothing to omit", () => {
   const obj = { a: 1, b: 2, c: 3, d: 4 };
   const result = omit(obj, []);
+
   expect(result).toStrictEqual(obj);
   expect(result).not.toBe(obj);
 });

--- a/src/omit.test.ts
+++ b/src/omit.test.ts
@@ -4,20 +4,20 @@ import { pipe } from "./pipe";
 test("dataFirst", () => {
   const result = omit({ a: 1, b: 2, c: 3, d: 4 }, ["a", "d"] as const);
 
-  expect(result).toEqual({ b: 2, c: 3 });
+  expect(result).toStrictEqual({ b: 2, c: 3 });
 });
 
 test("single removed prop works", () => {
   const obj: { a: number } = { a: 1 };
   const result = omit(obj, ["a"]);
 
-  expect(result).toEqual({});
+  expect(result).toStrictEqual({});
 });
 
 test("dataLast", () => {
   const result = pipe({ a: 1, b: 2, c: 3, d: 4 }, omit(["a", "d"] as const));
 
-  expect(result).toEqual({ b: 2, c: 3 });
+  expect(result).toStrictEqual({ b: 2, c: 3 });
 });
 
 test("can omit symbol keys", () => {

--- a/src/omitBy.test-d.ts
+++ b/src/omitBy.test-d.ts
@@ -87,7 +87,7 @@ test("handles type-predicates", () => {
   }>();
 });
 
-test("Makes wide types partial", () => {
+test("makes wide types partial", () => {
   const wide = omitBy({ a: 0 } as { a: number }, isDeepEqual(1 as const));
   expectTypeOf(wide).toEqualTypeOf<{ a?: number }>();
 
@@ -96,7 +96,7 @@ test("Makes wide types partial", () => {
   expectTypeOf(narrow).toEqualTypeOf<{}>();
 });
 
-test("Works well with nullish type-guards", () => {
+test("works well with nullish type-guards", () => {
   const data = {} as {
     required: string;
     optional?: string;
@@ -146,7 +146,7 @@ test("Works well with nullish type-guards", () => {
 });
 
 // @see https://github.com/remeda/remeda/issues/696
-describe("Records with non-narrowing predicates (Issue #696)", () => {
+describe("records with non-narrowing predicates (Issue #696)", () => {
   test("string keys", () => {
     const data = {} as Record<string, string>;
     const result = omitBy(data, constant(true));

--- a/src/omitBy.test.ts
+++ b/src/omitBy.test.ts
@@ -20,12 +20,14 @@ test("dataLast", () => {
 test("number keys are converted to strings in the mapper", () => {
   omitBy({ 123: "hello" }, (_, key) => {
     expect(key).toBe("123");
+
     return true;
   });
 });
 
 test("symbols are passed through", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(omitBy({ [mySymbol]: 1 }, constant(true))).toStrictEqual({
     [mySymbol]: 1,
   });
@@ -35,6 +37,7 @@ test("symbols are not passed to the predicate", () => {
   const mock = vi.fn();
   const data = { [Symbol("mySymbol")]: 1, a: "hello" };
   omitBy(data, mock);
-  expect(mock).toBeCalledTimes(1);
-  expect(mock).toBeCalledWith("hello", "a", data);
+
+  expect(mock).toHaveBeenCalledTimes(1);
+  expect(mock).toHaveBeenCalledWith("hello", "a", data);
 });

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -4,8 +4,11 @@ test("should call only once", () => {
   const mock = vi.fn(() => ({}));
   const wrapped = once(mock as () => object);
   const ret1 = wrapped();
+
   expect(mock).toHaveBeenCalledTimes(1);
+
   const ret2 = wrapped();
+
   expect(mock).toHaveBeenCalledTimes(1);
   expect(ret1).toBe(ret2);
 });

--- a/src/only.test.ts
+++ b/src/only.test.ts
@@ -7,7 +7,7 @@ describe("dataFirst", () => {
   });
 
   test("length 1 array", () => {
-    expect(only([1])).toEqual(1);
+    expect(only([1])).toBe(1);
   });
 
   test("length 2 array", () => {
@@ -21,7 +21,7 @@ describe("data last", () => {
   });
 
   test("length 1 array", () => {
-    expect(pipe([1], only())).toEqual(1);
+    expect(pipe([1], only())).toBe(1);
   });
 
   test("length 2 array", () => {

--- a/src/partition.test.ts
+++ b/src/partition.test.ts
@@ -14,7 +14,7 @@ describe("data first", () => {
         ],
         ({ a }) => a === 1,
       ),
-    ).toEqual([
+    ).toStrictEqual([
       [
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -25,7 +25,7 @@ describe("data first", () => {
   });
 
   test("partition with type guard", () => {
-    expect(partition([1, "a", 2, "b"], isNumber)).toEqual([
+    expect(partition([1, "a", 2, "b"], isNumber)).toStrictEqual([
       [1, 2],
       ["a", "b"],
     ]);
@@ -37,7 +37,7 @@ describe("data first", () => {
         [1, "a", 2, "b"],
         partition((value): value is number => typeof value === "number"),
       ),
-    ).toEqual([
+    ).toStrictEqual([
       [1, 2],
       ["a", "b"],
     ]);
@@ -54,7 +54,7 @@ describe("data first", () => {
         ],
         (_, index) => index !== 2,
       ),
-    ).toEqual([
+    ).toStrictEqual([
       [
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -77,7 +77,7 @@ describe("data last", () => {
         ],
         partition(({ a }) => a === 1),
       ),
-    ).toEqual([
+    ).toStrictEqual([
       [
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -98,7 +98,7 @@ describe("data last", () => {
         ],
         partition((_, index) => index !== 2),
       ),
-    ).toEqual([
+    ).toStrictEqual([
       [
         { a: 1, b: 1 },
         { a: 1, b: 2 },

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -38,7 +38,7 @@ describe("data first", () => {
   });
 
   test("should return value (2 level deep)", () => {
-    expect(pathOr(obj, ["a", "b"] as const, { c: 0 })).toEqual({ c: 1 });
+    expect(pathOr(obj, ["a", "b"] as const, { c: 0 })).toStrictEqual({ c: 1 });
   });
 
   test("should return default value (2 level deep)", () => {

--- a/src/pathOr.test.ts
+++ b/src/pathOr.test.ts
@@ -25,15 +25,16 @@ const obj: SampleType = {
 describe("data first", () => {
   test("should return default value (input undefined)", () => {
     type MaybeSampleType = SampleType | undefined;
-    expect(pathOr(undefined as MaybeSampleType, ["x"], 2)).toEqual(2);
+
+    expect(pathOr(undefined as MaybeSampleType, ["x"], 2)).toBe(2);
   });
 
   test("should return value", () => {
-    expect(pathOr(obj, ["y"] as const, 2)).toEqual(10);
+    expect(pathOr(obj, ["y"] as const, 2)).toBe(10);
   });
 
   test("should return default value", () => {
-    expect(pathOr(obj, ["x"] as const, 2)).toEqual(2);
+    expect(pathOr(obj, ["x"] as const, 2)).toBe(2);
   });
 
   test("should return value (2 level deep)", () => {
@@ -41,22 +42,24 @@ describe("data first", () => {
   });
 
   test("should return default value (2 level deep)", () => {
-    expect(pathOr(obj, ["a", "z"] as const, 3)).toEqual(3);
+    expect(pathOr(obj, ["a", "z"] as const, 3)).toBe(3);
   });
 
   test("should return value (3 level deep)", () => {
-    expect(pathOr(obj, ["a", "b", "c"] as const, 0)).toEqual(1);
+    expect(pathOr(obj, ["a", "b", "c"] as const, 0)).toBe(1);
   });
 });
 
 describe("data last", () => {
   test("1 level", () => {
-    expect(pipe(obj, pathOr(["x"], 1))).toEqual(1);
+    expect(pipe(obj, pathOr(["x"], 1))).toBe(1);
   });
+
   test("2 level", () => {
-    expect(pipe(obj, pathOr(["a", "z"], 1))).toEqual(1);
+    expect(pipe(obj, pathOr(["a", "z"], 1))).toBe(1);
   });
+
   test("3 level", () => {
-    expect(pipe(obj, pathOr(["a", "b", "d"] as const, 1))).toEqual(1);
+    expect(pipe(obj, pathOr(["a", "b", "d"] as const, 1))).toBe(1);
   });
 });

--- a/src/pick.test-d.ts
+++ b/src/pick.test-d.ts
@@ -50,6 +50,7 @@ test("multiple keys", () => {
 
 test("support inherited properties", () => {
   class BaseClass {
+    // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- This is fine...
     public testProp(): string {
       return "abc";
     }

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -1,4 +1,3 @@
-import { concat } from "./concat";
 import { pick } from "./pick";
 import { pipe } from "./pipe";
 
@@ -10,16 +9,6 @@ test("dataFirst", () => {
 test("dataLast", () => {
   const result = pipe({ a: 1, b: 2, c: 3, d: 4 }, pick(["a", "d"]));
   expect(result).toEqual({ a: 1, d: 4 });
-});
-
-test("read only", () => {
-  concat([1, 2], [3, 4] as const);
-  // or similar:
-  // const props: ReadonlyArray<string> = ["prop1", "prop2"];
-  // const getProps = <T extends string>(props: readonly T[]) => props;
-  const someObject = { prop1: "a", prop2: 2, a: "b" };
-  const props = ["prop1", "prop2"] as const;
-  pick(someObject, props); // TS2345 compilation error
 });
 
 test("it can pick symbol keys", () => {

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -10,7 +10,7 @@ test("dataFirst", () => {
 test("dataLast", () => {
   const result = pipe({ a: 1, b: 2, c: 3, d: 4 }, pick(["a", "d"]));
 
-  expect(result).toEqual({ a: 1, d: 4 });
+  expect(result).toStrictEqual({ a: 1, d: 4 });
 });
 
 test("it can pick symbol keys", () => {

--- a/src/pick.test.ts
+++ b/src/pick.test.ts
@@ -3,16 +3,19 @@ import { pipe } from "./pipe";
 
 test("dataFirst", () => {
   const result = pick({ a: 1, b: 2, c: 3, d: 4 }, ["a", "d"]);
+
   expect(result).toStrictEqual({ a: 1, d: 4 });
 });
 
 test("dataLast", () => {
   const result = pipe({ a: 1, b: 2, c: 3, d: 4 }, pick(["a", "d"]));
+
   expect(result).toEqual({ a: 1, d: 4 });
 });
 
 test("it can pick symbol keys", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(pick({ [mySymbol]: 3, a: 4 }, [mySymbol])).toStrictEqual({
     [mySymbol]: 3,
   });

--- a/src/pickBy.test-d.ts
+++ b/src/pickBy.test-d.ts
@@ -50,7 +50,7 @@ test("symbols are not passed to the predicate", () => {
   });
 });
 
-test("Makes wide types partial", () => {
+test("makes wide types partial", () => {
   const wide = pickBy({ a: 0 } as { a: number }, isDeepEqual(1 as const));
   expectTypeOf(wide).toEqualTypeOf<{ a?: 1 }>();
 
@@ -84,7 +84,7 @@ test("works with type-guards", () => {
   }>();
 });
 
-test("Works well with nullish type-guards", () => {
+test("works well with nullish type-guards", () => {
   const data = {} as {
     required: string;
     optional?: string;
@@ -133,7 +133,7 @@ test("Works well with nullish type-guards", () => {
 });
 
 // @see https://github.com/remeda/remeda/issues/696
-describe("Records with non-narrowing predicates (Issue #696)", () => {
+describe("records with non-narrowing predicates (Issue #696)", () => {
   test("string keys", () => {
     const data = {} as Record<string, string>;
     const result = pickBy(data, constant(true));

--- a/src/pickBy.test.ts
+++ b/src/pickBy.test.ts
@@ -19,6 +19,7 @@ test("dataLast", () => {
 
 test("symbols are filtered out", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(pickBy({ [mySymbol]: 1 }, constant(true))).toStrictEqual({});
 });
 
@@ -26,6 +27,7 @@ test("symbols are not passed to the predicate", () => {
   const mock = vi.fn();
   const data = { [Symbol("mySymbol")]: 1, a: "hello" };
   pickBy(data, mock);
-  expect(mock).toBeCalledTimes(1);
-  expect(mock).toBeCalledWith("hello", "a", data);
+
+  expect(mock).toHaveBeenCalledTimes(1);
+  expect(mock).toHaveBeenCalledWith("hello", "a", data);
 });

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -8,7 +8,8 @@ import { take } from "./take";
 
 it("should pipe a single operation", () => {
   const result = pipe(1, (x) => x * 2);
-  expect(result).toEqual(2);
+
+  expect(result).toBe(2);
 });
 
 it("should pipe operations", () => {
@@ -17,7 +18,8 @@ it("should pipe operations", () => {
     (x) => x * 2,
     (x) => x * 3,
   );
-  expect(result).toEqual(6);
+
+  expect(result).toBe(6);
 });
 
 describe("lazy", () => {
@@ -31,6 +33,7 @@ describe("lazy", () => {
       }),
       take(2),
     );
+
     expect(count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([10, 20]);
   });
@@ -46,6 +49,7 @@ describe("lazy", () => {
       filter((x) => (x / 10) % 2 === 1),
       take(2),
     );
+
     expect(count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([10, 30]);
   });
@@ -61,6 +65,7 @@ describe("lazy", () => {
       }),
       take(2),
     );
+
     expect(count).toHaveBeenCalledTimes(2);
     expect(result).toEqual([10, 20]);
   });
@@ -76,6 +81,7 @@ describe("lazy", () => {
       (x) => x,
       take(2),
     );
+
     expect(count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([10, 20]);
   });
@@ -91,6 +97,7 @@ describe("lazy", () => {
       take(2),
       take(1),
     );
+
     expect(count).toHaveBeenCalledTimes(1);
     expect(result).toEqual([10]);
   });
@@ -112,6 +119,7 @@ describe("lazy", () => {
       }),
       take(2),
     );
+
     expect(count).toHaveBeenCalledTimes(4);
     expect(count2).toHaveBeenCalledTimes(2);
     expect(result).toEqual([100, 200]);
@@ -127,6 +135,7 @@ describe("lazy", () => {
       take(1),
       flat(),
     );
+
     expect(result).toEqual([1, 2]);
   });
 });

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -35,7 +35,7 @@ describe("lazy", () => {
     );
 
     expect(count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([10, 20]);
+    expect(result).toStrictEqual([10, 20]);
   });
 
   it("lazy map + filter + take", () => {
@@ -51,7 +51,7 @@ describe("lazy", () => {
     );
 
     expect(count).toHaveBeenCalledTimes(3);
-    expect(result).toEqual([10, 30]);
+    expect(result).toStrictEqual([10, 30]);
   });
 
   it("lazy after 1st op", () => {
@@ -67,7 +67,7 @@ describe("lazy", () => {
     );
 
     expect(count).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([10, 20]);
+    expect(result).toStrictEqual([10, 20]);
   });
 
   it("break lazy", () => {
@@ -83,7 +83,7 @@ describe("lazy", () => {
     );
 
     expect(count).toHaveBeenCalledTimes(3);
-    expect(result).toEqual([10, 20]);
+    expect(result).toStrictEqual([10, 20]);
   });
 
   it("multiple take", () => {
@@ -99,7 +99,7 @@ describe("lazy", () => {
     );
 
     expect(count).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([10]);
+    expect(result).toStrictEqual([10]);
   });
 
   it("multiple lazy", () => {
@@ -122,7 +122,7 @@ describe("lazy", () => {
 
     expect(count).toHaveBeenCalledTimes(4);
     expect(count2).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([100, 200]);
+    expect(result).toStrictEqual([100, 200]);
   });
 
   it("lazy early exit with hasMany", () => {
@@ -136,6 +136,6 @@ describe("lazy", () => {
       flat(),
     );
 
-    expect(result).toEqual([1, 2]);
+    expect(result).toStrictEqual([1, 2]);
   });
 });

--- a/src/piped.test.ts
+++ b/src/piped.test.ts
@@ -2,7 +2,8 @@ import { piped } from "./piped";
 
 it("should pipe a single operation", () => {
   const fn = piped((x: number) => x * 2);
-  expect(fn(1)).toEqual(2);
+
+  expect(fn(1)).toBe(2);
 });
 
 it("should pipe operations", () => {
@@ -10,5 +11,6 @@ it("should pipe operations", () => {
     (x: number) => x * 2,
     (x) => x * 3,
   );
-  expect(fn(1)).toEqual(6);
+
+  expect(fn(1)).toBe(6);
 });

--- a/src/product.test-d.ts
+++ b/src/product.test-d.ts
@@ -77,8 +77,8 @@ it("doesn't allow mixed arrays", () => {
   product([1, 2n]);
 });
 
-describe("KNOWN ISSUES", () => {
-  it("Returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
+describe("kNOWN ISSUES", () => {
+  it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
     expectTypeOf(result).toEqualTypeOf<bigint | 1>();
   });

--- a/src/product.test-d.ts
+++ b/src/product.test-d.ts
@@ -77,7 +77,7 @@ it("doesn't allow mixed arrays", () => {
   product([1, 2n]);
 });
 
-describe("kNOWN ISSUES", () => {
+describe("KNOWN ISSUES", () => {
   it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
     expectTypeOf(result).toEqualTypeOf<bigint | 1>();

--- a/src/product.test.ts
+++ b/src/product.test.ts
@@ -31,9 +31,10 @@ describe("dataLast", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
-  it("Returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
+describe("kNOWN ISSUES", () => {
+  it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
+
     expect(result).toBe(1);
   });
 });

--- a/src/product.test.ts
+++ b/src/product.test.ts
@@ -31,7 +31,7 @@ describe("dataLast", () => {
   });
 });
 
-describe("kNOWN ISSUES", () => {
+describe("KNOWN ISSUES", () => {
   it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
 

--- a/src/prop.test.ts
+++ b/src/prop.test.ts
@@ -3,5 +3,6 @@ import { prop } from "./prop";
 
 test("prop", () => {
   const result = pipe({ foo: "bar" }, prop("foo"));
-  expect(result).toEqual("bar");
+
+  expect(result).toBe("bar");
 });

--- a/src/pullObject.test.ts
+++ b/src/pullObject.test.ts
@@ -70,7 +70,7 @@ describe("dataFirst", () => {
     ).toStrictEqual({ a: "world" });
   });
 
-  test("Guaranteed to run on each item", () => {
+  test("guaranteed to run on each item", () => {
     const data = ["a", "a", "a", "a", "a", "a"];
 
     const keyFn = vi.fn(identity());
@@ -152,7 +152,7 @@ describe("dataLast", () => {
     ).toStrictEqual({ a: "world" });
   });
 
-  test("Guaranteed to run on each item", () => {
+  test("guaranteed to run on each item", () => {
     const data = ["a", "a", "a", "a", "a", "a"];
 
     const keyFn = vi.fn(identity());

--- a/src/purry.test.ts
+++ b/src/purry.test.ts
@@ -9,14 +9,15 @@ function fn(...args: ReadonlyArray<unknown>): unknown {
 }
 
 test("all arguments", () => {
-  expect(fn(10, 5)).toEqual(5);
+  expect(fn(10, 5)).toBe(5);
 });
 
 test("1 missing", () => {
   const purried = fn(5) as (...args: ReadonlyArray<unknown>) => unknown;
-  expect(purried(10)).toEqual(5);
+
+  expect(purried(10)).toBe(5);
 });
 
 test("wrong number of arguments", () => {
-  expect(() => fn(5, 10, 40)).toThrowError("Wrong number of arguments");
+  expect(() => fn(5, 10, 40)).toThrow("Wrong number of arguments");
 });

--- a/src/randomBigInt.test-d.ts
+++ b/src/randomBigInt.test-d.ts
@@ -1,6 +1,6 @@
 import { randomBigInt } from "./randomBigInt";
 
-test("KNOWN LIMITATION: doesn't return never on invalid range", () => {
+test("kNOWN LIMITATION: doesn't return never on invalid range", () => {
   // @ts-expect-error [ts2554] - We can't detect these cases with TypeScript.
   expectTypeOf(randomBigInt(10n, 0n)).toEqualTypeOf<never>();
 });

--- a/src/randomBigInt.test-d.ts
+++ b/src/randomBigInt.test-d.ts
@@ -1,6 +1,8 @@
 import { randomBigInt } from "./randomBigInt";
 
-test("kNOWN LIMITATION: doesn't return never on invalid range", () => {
-  // @ts-expect-error [ts2554] - We can't detect these cases with TypeScript.
-  expectTypeOf(randomBigInt(10n, 0n)).toEqualTypeOf<never>();
+describe("KNOWN LIMITATIONS", () => {
+  it("doesn't return never on invalid range", () => {
+    // @ts-expect-error [ts2554] - We can't detect these cases with TypeScript.
+    expectTypeOf(randomBigInt(10n, 0n)).toEqualTypeOf<never>();
+  });
 });

--- a/src/randomBigInt.test.ts
+++ b/src/randomBigInt.test.ts
@@ -53,6 +53,7 @@ test("results are varied", () => {
   for (const v of randomBigInts(1n, 10n)) {
     results.add(v);
   }
+
   expect(results).toHaveLength(10);
 });
 
@@ -108,6 +109,7 @@ describe("crypto module polyfill", () => {
     for (const v of randomBigInts(1n, 10n)) {
       results.add(v);
     }
+
     expect(results).toHaveLength(10);
   });
 });

--- a/src/randomInteger.test-d.ts
+++ b/src/randomInteger.test-d.ts
@@ -25,39 +25,39 @@ test("returns the same value when to equals from and out of range", () => {
   expectTypeOf(randomInteger(10_000, 10_000)).toEqualTypeOf<10_000>();
 });
 
-test("Returns number for large max (to >= 1000)", () => {
+test("returns number for large max (to >= 1000)", () => {
   expectTypeOf(randomInteger(1, 1001)).toEqualTypeOf<number>();
 });
 
-test("Returns number when from is a negative integer", () => {
+test("returns number when from is a negative integer", () => {
   expectTypeOf(randomInteger(-1, 1)).toEqualTypeOf<number>();
 });
 
-test("Returns number when to is a negative integer", () => {
+test("returns number when to is a negative integer", () => {
   expectTypeOf(randomInteger(1, -1)).toEqualTypeOf<number>();
 });
 
-test("Returns number when from is a negative decimal", () => {
+test("returns number when from is a negative decimal", () => {
   expectTypeOf(randomInteger(-1.5, 1)).toEqualTypeOf<number>();
 });
 
-test("Returns number when to is a negative decimal", () => {
+test("returns number when to is a negative decimal", () => {
   expectTypeOf(randomInteger(1, -1.5)).toEqualTypeOf<number>();
 });
 
-test("Returns number when from is number", () => {
+test("returns number when from is number", () => {
   expectTypeOf(randomInteger(1 as number, 5)).toEqualTypeOf<number>();
 });
 
-test("Returns number when to is number", () => {
+test("returns number when to is number", () => {
   expectTypeOf(randomInteger(1, 5 as number)).toEqualTypeOf<number>();
 });
 
-test("Returns number when from and to are number", () => {
+test("returns number when from and to are number", () => {
   expectTypeOf(randomInteger(1 as number, 5 as number)).toEqualTypeOf<number>();
 });
 
-test("Returns number when from and to are very big numbers", () => {
+test("returns number when from and to are very big numbers", () => {
   expectTypeOf(
     randomInteger(10_000_000_000, 10_000_000_001),
   ).toEqualTypeOf<number>();

--- a/src/randomInteger.test.ts
+++ b/src/randomInteger.test.ts
@@ -9,7 +9,7 @@ test("from is greater than to", () => {
 });
 
 test("from and to are decimals with same whole number", () => {
-  expect(() => expect(randomInteger(1.5, 1.6))).toThrow(
+  expect(() => randomInteger(1.5, 1.6)).toThrow(
     new RangeError("randomInteger: The range [1.5,1.6] contains no integer"),
   );
 });

--- a/src/randomString.test.ts
+++ b/src/randomString.test.ts
@@ -1,5 +1,5 @@
 import { randomString } from "./randomString";
 
 test("randomString", () => {
-  expect(randomString(10).length).toBe(10);
+  expect(randomString(10)).toHaveLength(10);
 });

--- a/src/range.test.ts
+++ b/src/range.test.ts
@@ -2,12 +2,12 @@ import { range } from "./range";
 
 describe("data first", () => {
   test("range", () => {
-    expect(range(1, 5)).toEqual([1, 2, 3, 4]);
+    expect(range(1, 5)).toStrictEqual([1, 2, 3, 4]);
   });
 });
 
 describe("data last", () => {
   test("range", () => {
-    expect(range(5)(1)).toEqual([1, 2, 3, 4]);
+    expect(range(5)(1)).toStrictEqual([1, 2, 3, 4]);
   });
 });

--- a/src/rankBy.test.ts
+++ b/src/rankBy.test.ts
@@ -16,6 +16,7 @@ describe("runtime (dataFirst)", () => {
 
   it("can rank items not in the array", () => {
     const data = [5, 1, 3] as const;
+
     expect(rankBy(data, 0, identity())).toBe(0);
     expect(rankBy(data, 2, identity())).toBe(1);
     expect(rankBy(data, 4, identity())).toBe(2);
@@ -23,6 +24,7 @@ describe("runtime (dataFirst)", () => {
 
   it("finds items ranked at the end of the array", () => {
     const data = [5, 1, 3] as const;
+
     expect(rankBy(data, 6, identity())).toBe(3);
   });
 });

--- a/src/reduce.test.ts
+++ b/src/reduce.test.ts
@@ -3,7 +3,7 @@ import { reduce } from "./reduce";
 
 describe("data first", () => {
   test("reduce", () => {
-    expect(reduce([1, 2, 3, 4, 5], (acc, x) => acc + x, 100)).toEqual(115);
+    expect(reduce([1, 2, 3, 4, 5], (acc, x) => acc + x, 100)).toBe(115);
   });
 
   test("indexed", () => {
@@ -16,12 +16,13 @@ describe("data first", () => {
         (acc, x, index, items) => {
           expect(index).toBe(i);
           expect(items).toBe(data);
+
           i += 1;
           return acc + x;
         },
         100,
       ),
-    ).toEqual(115);
+    ).toBe(115);
   });
 });
 
@@ -32,6 +33,6 @@ describe("data last", () => {
         [1, 2, 3, 4, 5],
         reduce((acc, x) => acc + x, 100),
       ),
-    ).toEqual(115);
+    ).toBe(115);
   });
 });

--- a/src/reverse.test-d.ts
+++ b/src/reverse.test-d.ts
@@ -6,6 +6,7 @@ describe("data first", () => {
     const actual = reverse([1, 2, 3]);
     expectTypeOf(actual).toEqualTypeOf<Array<number>>();
   });
+
   test("tuples", () => {
     const actual = reverse([1, 2, [true], "a"] as const);
     expectTypeOf(actual).toEqualTypeOf<["a", readonly [true], 2, 1]>();
@@ -23,6 +24,7 @@ describe("data last", () => {
     const actual = pipe([1, 2, 3], reverse());
     expectTypeOf(actual).toEqualTypeOf<Array<number>>();
   });
+
   test("tuples", () => {
     const actual = pipe([1, 2, [true], "a"] as const, reverse());
     expectTypeOf(actual).toEqualTypeOf<["a", readonly [true], 2, 1]>();

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -5,7 +5,7 @@ describe("data first", () => {
   test("reverse", () => {
     const actual = reverse([1, 2, 3]);
 
-    expect(actual).toEqual([3, 2, 1]);
+    expect(actual).toStrictEqual([3, 2, 1]);
   });
 });
 
@@ -13,6 +13,6 @@ describe("data last", () => {
   test("reverse", () => {
     const actual = pipe([1, 2, 3], reverse());
 
-    expect(actual).toEqual([3, 2, 1]);
+    expect(actual).toStrictEqual([3, 2, 1]);
   });
 });

--- a/src/reverse.test.ts
+++ b/src/reverse.test.ts
@@ -4,6 +4,7 @@ import { pipe } from "./pipe";
 describe("data first", () => {
   test("reverse", () => {
     const actual = reverse([1, 2, 3]);
+
     expect(actual).toEqual([3, 2, 1]);
   });
 });
@@ -11,6 +12,7 @@ describe("data first", () => {
 describe("data last", () => {
   test("reverse", () => {
     const actual = pipe([1, 2, 3], reverse());
+
     expect(actual).toEqual([3, 2, 1]);
   });
 });

--- a/src/round.test.ts
+++ b/src/round.test.ts
@@ -8,36 +8,32 @@ describe("data-first", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(round(8123.4317, -2)).toEqual(8100);
-    expect(round(8123.4317, -4)).toEqual(10_000);
+    expect(round(8123.4317, -2)).toBe(8100);
+    expect(round(8123.4317, -4)).toBe(10_000);
   });
 
   test("should work with precision = 0", () => {
-    expect(round(8123.4317, 0)).toEqual(8123);
+    expect(round(8123.4317, 0)).toBe(8123);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => round(1, val)).toThrowError(
+      expect(() => round(1, val)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => round(1, 21.37)).toThrowError(
+    expect(() => round(1, 21.37)).toThrow(
       "precision must be an integer: 21.37",
     );
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => round(1, 16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => round(1, -16)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => round(1, 16)).toThrow("precision must be between -15 and 15");
+    expect(() => round(1, -16)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
@@ -58,36 +54,32 @@ describe("data-last", () => {
   });
 
   test("should work with negative precision", () => {
-    expect(round(-2)(8123.4317)).toEqual(8100);
-    expect(round(-4)(8123.4317)).toEqual(10_000);
+    expect(round(-2)(8123.4317)).toBe(8100);
+    expect(round(-4)(8123.4317)).toBe(10_000);
   });
 
   test("should work with precision = 0", () => {
-    expect(round(0)(8123.4317)).toEqual(8123);
+    expect(round(0)(8123.4317)).toBe(8123);
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY])(
     "should throw for %d precision",
     (val) => {
-      expect(() => round(val)(1)).toThrowError(
+      expect(() => round(val)(1)).toThrow(
         `precision must be an integer: ${val}`,
       );
     },
   );
 
   test("should throw for non integer precision", () => {
-    expect(() => round(21.37)(1)).toThrowError(
+    expect(() => round(21.37)(1)).toThrow(
       "precision must be an integer: 21.37",
     );
   });
 
   test("should throw for precision higher than 15 and lower than -15", () => {
-    expect(() => round(16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
-    expect(() => round(-16)(1)).toThrowError(
-      "precision must be between -15 and 15",
-    );
+    expect(() => round(16)(1)).toThrow("precision must be between -15 and 15");
+    expect(() => round(-16)(1)).toThrow("precision must be between -15 and 15");
   });
 
   test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(

--- a/src/round.test.ts
+++ b/src/round.test.ts
@@ -2,9 +2,9 @@ import { round } from "./round";
 
 describe("data-first", () => {
   test("should work with positive precision", () => {
-    expect(round(8123.4317, 3)).toEqual(8123.432);
-    expect(round(483.222_43, 1)).toEqual(483.2);
-    expect(round(123.4317, 5)).toEqual(123.4317);
+    expect(round(8123.4317, 3)).toBe(8123.432);
+    expect(round(483.222_43, 1)).toBe(483.2);
+    expect(round(123.4317, 5)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -40,7 +40,7 @@ describe("data-first", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(round(val, precision)).toStrictEqual(val);
+        expect(round(val, precision)).toBe(val);
       }
     },
   );
@@ -48,9 +48,9 @@ describe("data-first", () => {
 
 describe("data-last", () => {
   test("should work with positive precision", () => {
-    expect(round(3)(8123.4317)).toEqual(8123.432);
-    expect(round(1)(483.222_43)).toEqual(483.2);
-    expect(round(5)(123.4317)).toEqual(123.4317);
+    expect(round(3)(8123.4317)).toBe(8123.432);
+    expect(round(1)(483.222_43)).toBe(483.2);
+    expect(round(5)(123.4317)).toBe(123.4317);
   });
 
   test("should work with negative precision", () => {
@@ -86,7 +86,7 @@ describe("data-last", () => {
     "should return %d when passed as value regardless of precision",
     (val) => {
       for (const precision of [-1, 0, 1]) {
-        expect(round(precision)(val)).toStrictEqual(val);
+        expect(round(precision)(val)).toBe(val);
       }
     },
   );

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -8,6 +8,7 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
     "returns the right number of items",
     (sampleSize) => {
       const result = sample(array, sampleSize);
+
       expect(result).toHaveLength(sampleSize);
     },
   );
@@ -35,11 +36,13 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
       const [item] = sample(array, 1);
       collector.add(item);
     }
+
     expect(collector.size).toBeGreaterThan(1);
   });
 
   it.each(allIndices(array))("doesn't return repetitions", (sampleSize) => {
     const result = sample(array, sampleSize);
+
     expect(result).toHaveLength(new Set(result).size);
   });
 
@@ -52,7 +55,9 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
       // in the input array.
 
       const currentInputIndex = array.indexOf(item);
+
       expect(currentInputIndex).toBeGreaterThan(lastInputIndex);
+
       lastInputIndex = currentInputIndex;
     }
   });
@@ -62,6 +67,7 @@ describe("identity", () => {
   it("for full (=== n) sample size", () => {
     const array = [1, 2, 3];
     const result = sample(array, 3);
+
     expect(result).toStrictEqual(array);
     expect(result).not.toBe(array);
   });
@@ -69,6 +75,7 @@ describe("identity", () => {
   it("for large (> n) sample sizes", () => {
     const array = [1, 2, 3];
     const result = sample(array, 10);
+
     expect(result).toStrictEqual(array);
     expect(result).not.toBe(array);
   });
@@ -76,6 +83,7 @@ describe("identity", () => {
   it("on empty arrays", () => {
     const array: Array<number> = [];
     const result = sample(array, 1);
+
     expect(result).toStrictEqual(array);
     expect(result).not.toBe(array);
   });
@@ -83,6 +91,7 @@ describe("identity", () => {
   it("on empty arrays and sample size 0", () => {
     const array: Array<number> = [];
     const result = sample(array, 0);
+
     expect(result).toStrictEqual(array);
     expect(result).not.toBe(array);
   });
@@ -91,10 +100,11 @@ describe("identity", () => {
 describe("edge cases", () => {
   it("works on empty arrays", () => {
     const result = sample([], 1);
+
     expect(result).toStrictEqual([]);
   });
 
-  it("Treats negative sample sizes as 0", () => {
+  it("treats negative sample sizes as 0", () => {
     expect(sample([1, 2, 3], -1 as number)).toStrictEqual([]);
   });
 
@@ -107,12 +117,14 @@ describe("sampleSize === n", () => {
   it("empty array", () => {
     const array: [] = [];
     const result = sample(array, 0);
+
     expect(result).toStrictEqual([]);
   });
 
   it("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 0);
+
     expect(result).toStrictEqual([]);
   });
 });
@@ -121,12 +133,14 @@ describe("sampleSize > n", () => {
   it("empty array", () => {
     const array: [] = [];
     const result = sample(array, 10);
+
     expect(result).toStrictEqual([]);
   });
 
   it("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 10);
+
     expect(result).toStrictEqual([]);
   });
 });
@@ -135,12 +149,14 @@ describe("non-const sampleSize", () => {
   it("empty array", () => {
     const array: [] = [];
     const result = sample(array, 5 as number);
+
     expect(result).toStrictEqual([]);
   });
 
   it("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 5 as number);
+
     expect(result).toStrictEqual([]);
   });
 });

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -3,12 +3,12 @@ import { set } from "./set";
 
 describe("data first", () => {
   test("simple", () => {
-    expect(set({ a: 1 }, "a", 2)).toEqual({ a: 2 });
+    expect(set({ a: 1 }, "a", 2)).toStrictEqual({ a: 2 });
   });
 });
 
 describe("data last", () => {
   test("simple", () => {
-    expect(pipe({ a: 1 }, set("a", 2))).toEqual({ a: 2 });
+    expect(pipe({ a: 1 }, set("a", 2))).toStrictEqual({ a: 2 });
   });
 });

--- a/src/sliceString.test.ts
+++ b/src/sliceString.test.ts
@@ -17,7 +17,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, 0 indexStart", () => {
-      expect(sliceString(ALPHABET, 0)).toEqual(ALPHABET);
+      expect(sliceString(ALPHABET, 0)).toStrictEqual(ALPHABET);
     });
 
     test("alphabet, >0 indexStart, <len", () => {
@@ -33,7 +33,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
-      expect(sliceString(ALPHABET, -100)).toEqual(ALPHABET);
+      expect(sliceString(ALPHABET, -100)).toStrictEqual(ALPHABET);
     });
   });
 
@@ -51,7 +51,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
-      expect(sliceString(ALPHABET, 0, 100)).toEqual(ALPHABET);
+      expect(sliceString(ALPHABET, 0, 100)).toStrictEqual(ALPHABET);
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {
@@ -107,7 +107,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, 0 indexStart", () => {
-      expect(sliceString(0)(ALPHABET)).toEqual(ALPHABET);
+      expect(sliceString(0)(ALPHABET)).toStrictEqual(ALPHABET);
     });
 
     test("alphabet, >0 indexStart, <len", () => {
@@ -123,7 +123,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
-      expect(sliceString(-100)(ALPHABET)).toEqual(ALPHABET);
+      expect(sliceString(-100)(ALPHABET)).toStrictEqual(ALPHABET);
     });
   });
 
@@ -141,7 +141,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
-      expect(sliceString(0, 100)(ALPHABET)).toEqual(ALPHABET);
+      expect(sliceString(0, 100)(ALPHABET)).toStrictEqual(ALPHABET);
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {

--- a/src/sliceString.test.ts
+++ b/src/sliceString.test.ts
@@ -5,15 +5,15 @@ const ALPHABET = "abcdefghijklmnopqrstuvwxyz";
 describe("dataFirst", () => {
   describe("indexStart", () => {
     test("empty string, 0 indexStart", () => {
-      expect(sliceString("", 0)).toEqual("");
+      expect(sliceString("", 0)).toBe("");
     });
 
     test("empty string, >0 indexStart", () => {
-      expect(sliceString("", 100)).toEqual("");
+      expect(sliceString("", 100)).toBe("");
     });
 
     test("empty string, <0 indexStart", () => {
-      expect(sliceString("", -100)).toEqual("");
+      expect(sliceString("", -100)).toBe("");
     });
 
     test("alphabet, 0 indexStart", () => {
@@ -21,15 +21,15 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, >0 indexStart, <len", () => {
-      expect(sliceString(ALPHABET, 10)).toEqual("klmnopqrstuvwxyz");
+      expect(sliceString(ALPHABET, 10)).toBe("klmnopqrstuvwxyz");
     });
 
     test("alphabet, <0 indexStart, >-len", () => {
-      expect(sliceString(ALPHABET, -10)).toEqual("qrstuvwxyz");
+      expect(sliceString(ALPHABET, -10)).toBe("qrstuvwxyz");
     });
 
     test("alphabet, >0 indexStart, >len", () => {
-      expect(sliceString(ALPHABET, 100)).toEqual("");
+      expect(sliceString(ALPHABET, 100)).toBe("");
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
@@ -39,15 +39,15 @@ describe("dataFirst", () => {
 
   describe("indexEnd", () => {
     test("empty string, 0 indexStart, 0 indexEnd", () => {
-      expect(sliceString("", 0, 0)).toEqual("");
+      expect(sliceString("", 0, 0)).toBe("");
     });
 
     test("alphabet, 0 indexStart, 0 indexEnd", () => {
-      expect(sliceString(ALPHABET, 0, 0)).toEqual("");
+      expect(sliceString(ALPHABET, 0, 0)).toBe("");
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd <len", () => {
-      expect(sliceString(ALPHABET, 0, 10)).toEqual("abcdefghij");
+      expect(sliceString(ALPHABET, 0, 10)).toBe("abcdefghij");
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
@@ -55,39 +55,39 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {
-      expect(sliceString(ALPHABET, 0, -10)).toEqual("abcdefghijklmnop");
+      expect(sliceString(ALPHABET, 0, -10)).toBe("abcdefghijklmnop");
     });
 
     test("alphabet, 0 indexStart <len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(ALPHABET, 0, -100)).toEqual("");
+      expect(sliceString(ALPHABET, 0, -100)).toBe("");
     });
 
     test("alphabet, >0 indexStart <len, >indexStart indexEnd <len", () => {
-      expect(sliceString(ALPHABET, 10, 20)).toEqual("klmnopqrst");
+      expect(sliceString(ALPHABET, 10, 20)).toBe("klmnopqrst");
     });
 
     test("alphabet, >0 indexStart <len, >indexStart indexEnd >len", () => {
-      expect(sliceString(ALPHABET, 10, 100)).toEqual("klmnopqrstuvwxyz");
+      expect(sliceString(ALPHABET, 10, 100)).toBe("klmnopqrstuvwxyz");
     });
 
     test("alphabet, >0 indexStart <len, <indexStart indexEnd >-len", () => {
-      expect(sliceString(ALPHABET, 10, 5)).toEqual("");
+      expect(sliceString(ALPHABET, 10, 5)).toBe("");
     });
 
     test("alphabet, >0 indexStart <len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(ALPHABET, 10, -100)).toEqual("");
+      expect(sliceString(ALPHABET, 10, -100)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, >indexStart indexEnd >len", () => {
-      expect(sliceString(ALPHABET, 100, 200)).toEqual("");
+      expect(sliceString(ALPHABET, 100, 200)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, <indexStart indexEnd >-len", () => {
-      expect(sliceString(ALPHABET, 100, 5)).toEqual("");
+      expect(sliceString(ALPHABET, 100, 5)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(ALPHABET, 100, -100)).toEqual("");
+      expect(sliceString(ALPHABET, 100, -100)).toBe("");
     });
   });
 });
@@ -95,15 +95,15 @@ describe("dataFirst", () => {
 describe("dataLast", () => {
   describe("indexStart", () => {
     test("empty string, 0 indexStart", () => {
-      expect(sliceString(0)("")).toEqual("");
+      expect(sliceString(0)("")).toBe("");
     });
 
     test("empty string, >0 indexStart", () => {
-      expect(sliceString(100)("")).toEqual("");
+      expect(sliceString(100)("")).toBe("");
     });
 
     test("empty string, <0 indexStart", () => {
-      expect(sliceString(-100)("")).toEqual("");
+      expect(sliceString(-100)("")).toBe("");
     });
 
     test("alphabet, 0 indexStart", () => {
@@ -111,15 +111,15 @@ describe("dataLast", () => {
     });
 
     test("alphabet, >0 indexStart, <len", () => {
-      expect(sliceString(10)(ALPHABET)).toEqual("klmnopqrstuvwxyz");
+      expect(sliceString(10)(ALPHABET)).toBe("klmnopqrstuvwxyz");
     });
 
     test("alphabet, <0 indexStart, >-len", () => {
-      expect(sliceString(-10)(ALPHABET)).toEqual("qrstuvwxyz");
+      expect(sliceString(-10)(ALPHABET)).toBe("qrstuvwxyz");
     });
 
     test("alphabet, >0 indexStart, >len", () => {
-      expect(sliceString(100)(ALPHABET)).toEqual("");
+      expect(sliceString(100)(ALPHABET)).toBe("");
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
@@ -129,15 +129,15 @@ describe("dataLast", () => {
 
   describe("indexEnd", () => {
     test("empty string, 0 indexStart, 0 indexEnd", () => {
-      expect(sliceString(0, 0)("")).toEqual("");
+      expect(sliceString(0, 0)("")).toBe("");
     });
 
     test("alphabet, 0 indexStart, 0 indexEnd", () => {
-      expect(sliceString(0, 0)(ALPHABET)).toEqual("");
+      expect(sliceString(0, 0)(ALPHABET)).toBe("");
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd <len", () => {
-      expect(sliceString(0, 10)(ALPHABET)).toEqual("abcdefghij");
+      expect(sliceString(0, 10)(ALPHABET)).toBe("abcdefghij");
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
@@ -145,39 +145,39 @@ describe("dataLast", () => {
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {
-      expect(sliceString(0, -10)(ALPHABET)).toEqual("abcdefghijklmnop");
+      expect(sliceString(0, -10)(ALPHABET)).toBe("abcdefghijklmnop");
     });
 
     test("alphabet, 0 indexStart <len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(0, -100)(ALPHABET)).toEqual("");
+      expect(sliceString(0, -100)(ALPHABET)).toBe("");
     });
 
     test("alphabet, >0 indexStart <len, >indexStart indexEnd <len", () => {
-      expect(sliceString(10, 20)(ALPHABET)).toEqual("klmnopqrst");
+      expect(sliceString(10, 20)(ALPHABET)).toBe("klmnopqrst");
     });
 
     test("alphabet, >0 indexStart <len, >indexStart indexEnd >len", () => {
-      expect(sliceString(10, 100)(ALPHABET)).toEqual("klmnopqrstuvwxyz");
+      expect(sliceString(10, 100)(ALPHABET)).toBe("klmnopqrstuvwxyz");
     });
 
     test("alphabet, >0 indexStart <len, <indexStart indexEnd >-len", () => {
-      expect(sliceString(10, 5)(ALPHABET)).toEqual("");
+      expect(sliceString(10, 5)(ALPHABET)).toBe("");
     });
 
     test("alphabet, >0 indexStart <len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(10, -100)(ALPHABET)).toEqual("");
+      expect(sliceString(10, -100)(ALPHABET)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, >indexStart indexEnd >len", () => {
-      expect(sliceString(100, 200)(ALPHABET)).toEqual("");
+      expect(sliceString(100, 200)(ALPHABET)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, <indexStart indexEnd >-len", () => {
-      expect(sliceString(100, 5)(ALPHABET)).toEqual("");
+      expect(sliceString(100, 5)(ALPHABET)).toBe("");
     });
 
     test("alphabet, >0 indexStart >len, <indexStart indexEnd <-len", () => {
-      expect(sliceString(100, -100)(ALPHABET)).toEqual("");
+      expect(sliceString(100, -100)(ALPHABET)).toBe("");
     });
   });
 });

--- a/src/sliceString.test.ts
+++ b/src/sliceString.test.ts
@@ -17,7 +17,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, 0 indexStart", () => {
-      expect(sliceString(ALPHABET, 0)).toStrictEqual(ALPHABET);
+      expect(sliceString(ALPHABET, 0)).toBe(ALPHABET);
     });
 
     test("alphabet, >0 indexStart, <len", () => {
@@ -33,7 +33,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
-      expect(sliceString(ALPHABET, -100)).toStrictEqual(ALPHABET);
+      expect(sliceString(ALPHABET, -100)).toBe(ALPHABET);
     });
   });
 
@@ -51,7 +51,7 @@ describe("dataFirst", () => {
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
-      expect(sliceString(ALPHABET, 0, 100)).toStrictEqual(ALPHABET);
+      expect(sliceString(ALPHABET, 0, 100)).toBe(ALPHABET);
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {
@@ -107,7 +107,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, 0 indexStart", () => {
-      expect(sliceString(0)(ALPHABET)).toStrictEqual(ALPHABET);
+      expect(sliceString(0)(ALPHABET)).toBe(ALPHABET);
     });
 
     test("alphabet, >0 indexStart, <len", () => {
@@ -123,7 +123,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, <0 indexStart, <-len", () => {
-      expect(sliceString(-100)(ALPHABET)).toStrictEqual(ALPHABET);
+      expect(sliceString(-100)(ALPHABET)).toBe(ALPHABET);
     });
   });
 
@@ -141,7 +141,7 @@ describe("dataLast", () => {
     });
 
     test("alphabet, 0 indexStart, >indexStart indexEnd >len", () => {
-      expect(sliceString(0, 100)(ALPHABET)).toStrictEqual(ALPHABET);
+      expect(sliceString(0, 100)(ALPHABET)).toBe(ALPHABET);
     });
 
     test("alphabet, 0 indexStart, <indexStart indexEnd >-len", () => {

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -3,7 +3,7 @@ import { sort } from "./sort";
 
 describe("data_first", () => {
   test("sort", () => {
-    expect(sort([4, 2, 7, 5], (a, b) => a - b)).toEqual([2, 4, 5, 7]);
+    expect(sort([4, 2, 7, 5], (a, b) => a - b)).toStrictEqual([2, 4, 5, 7]);
   });
 });
 
@@ -14,6 +14,6 @@ describe("data_last", () => {
         [4, 2, 7, 5],
         sort((a, b) => a - b),
       ),
-    ).toEqual([2, 4, 5, 7]);
+    ).toStrictEqual([2, 4, 5, 7]);
   });
 });

--- a/src/sortBy.test-d.ts
+++ b/src/sortBy.test-d.ts
@@ -30,26 +30,26 @@ const DATA = [
 ];
 
 describe("dataFirst", () => {
-  test("SortProjection", () => {
+  test("sortProjection", () => {
     const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
     const actual = sortBy(items, prop("a"));
     expectTypeOf(actual).toMatchTypeOf<Array<(typeof items)[number]>>();
   });
 
-  test("SortPair", () => {
+  test("sortPair", () => {
     const actual = sortBy(DATA, [(x) => x.active, "desc"]);
     expectTypeOf(actual).toEqualTypeOf<Array<(typeof DATA)[number]>>();
   });
 });
 
 describe("dataLast", () => {
-  test("SortProjection", () => {
+  test("sortProjection", () => {
     const items = [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }] as const;
     const actual = pipe(items, sortBy(prop("a")));
     expectTypeOf(actual).toMatchTypeOf<Array<(typeof items)[number]>>();
   });
 
-  test("SortPair", () => {
+  test("sortPair", () => {
     const actual = pipe(
       DATA,
       sortBy([prop("weight"), "asc"], [prop("color"), "desc"]),

--- a/src/sortBy.test.ts
+++ b/src/sortBy.test.ts
@@ -30,22 +30,19 @@ const DATA = [
 
 describe("data first", () => {
   test("sort correctly", () => {
-    expect(sortBy([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }], prop("a"))).toEqual(
-      [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }],
-    );
+    expect(
+      sortBy([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }], prop("a")),
+    ).toStrictEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]);
   });
 
   test("sort booleans correctly", () => {
-    expect(sortBy(DATA, [prop("active"), "desc"]).map(prop("active"))).toEqual([
-      true,
-      true,
-      false,
-      false,
-    ]);
+    expect(
+      sortBy(DATA, [prop("active"), "desc"]).map(prop("active")),
+    ).toStrictEqual([true, true, false, false]);
   });
 
   test("sort dates correctly", () => {
-    expect(sortBy(DATA, [prop("date"), "desc"]).map(prop("id"))).toEqual([
+    expect(sortBy(DATA, [prop("date"), "desc"]).map(prop("id"))).toStrictEqual([
       4, 3, 2, 1,
     ]);
   });
@@ -53,19 +50,19 @@ describe("data first", () => {
   test("sort objects correctly", () => {
     expect(
       sortBy(DATA, prop("weight"), prop("color")).map(prop("weight")),
-    ).toEqual([1, 1, 2, 3]);
+    ).toStrictEqual([1, 1, 2, 3]);
   });
 
   test("sort objects correctly mixing sort pair and sort projection", () => {
     expect(
       sortBy(DATA, prop("weight"), [prop("color"), "asc"]).map(prop("weight")),
-    ).toEqual([1, 1, 2, 3]);
+    ).toStrictEqual([1, 1, 2, 3]);
   });
 
   test("sort objects descending correctly", () => {
-    expect(sortBy(DATA, [prop("weight"), "desc"]).map(prop("weight"))).toEqual([
-      3, 2, 1, 1,
-    ]);
+    expect(
+      sortBy(DATA, [prop("weight"), "desc"]).map(prop("weight")),
+    ).toStrictEqual([3, 2, 1, 1]);
   });
 });
 
@@ -73,7 +70,7 @@ describe("data last", () => {
   test("sort correctly", () => {
     expect(
       pipe([{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }], sortBy(prop("a"))),
-    ).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]);
+    ).toStrictEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 7 }]);
   });
 
   test('sort correctly using pipe and "desc"', () => {
@@ -82,13 +79,13 @@ describe("data last", () => {
         [{ a: 1 }, { a: 3 }, { a: 7 }, { a: 2 }],
         sortBy([prop("a"), "desc"]),
       ),
-    ).toEqual([{ a: 7 }, { a: 3 }, { a: 2 }, { a: 1 }]);
+    ).toStrictEqual([{ a: 7 }, { a: 3 }, { a: 2 }, { a: 1 }]);
   });
 
   test("sort objects correctly", () => {
     expect(
       pipe(DATA, sortBy(prop("weight"), prop("color")), map(prop("color"))),
-    ).toEqual(["green", "purple", "red", "blue"]);
+    ).toStrictEqual(["green", "purple", "red", "blue"]);
   });
 
   test("sort objects correctly by weight asc then color desc", () => {
@@ -98,6 +95,6 @@ describe("data last", () => {
         sortBy([prop("weight"), "asc"], [prop("color"), "desc"]),
         map(prop("color")),
       ),
-    ).toEqual(["purple", "green", "red", "blue"]);
+    ).toStrictEqual(["purple", "green", "red", "blue"]);
   });
 });

--- a/src/sortedIndexBy.test.ts
+++ b/src/sortedIndexBy.test.ts
@@ -143,7 +143,9 @@ describe("runtime correctness", () => {
 describe("binary search correctness via indexed", () => {
   test("empty array", () => {
     // The value function always gets called for the item with index `undefined`
-    expect(indicesSeen([], { age: 21 }, ({ age }) => age)).toEqual([undefined]);
+    expect(indicesSeen([], { age: 21 }, ({ age }) => age)).toStrictEqual([
+      undefined,
+    ]);
   });
 
   test("before all", () => {
@@ -170,7 +172,7 @@ describe("binary search correctness via indexed", () => {
         { age: 20 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 2, 1, 0]);
+    ).toStrictEqual([undefined, 8, 4, 2, 1, 0]);
   });
 
   test("after all", () => {
@@ -197,7 +199,7 @@ describe("binary search correctness via indexed", () => {
         { age: 40 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 12, 14, 15]);
+    ).toStrictEqual([undefined, 8, 12, 14, 15]);
   });
 
   test("inside the array", () => {
@@ -224,7 +226,7 @@ describe("binary search correctness via indexed", () => {
         { age: 27 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 6, 5]);
+    ).toStrictEqual([undefined, 8, 4, 6, 5]);
   });
 
   test("with duplicates", () => {
@@ -251,7 +253,7 @@ describe("binary search correctness via indexed", () => {
         { age: 27 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 2, 1, 0]);
+    ).toStrictEqual([undefined, 8, 4, 2, 1, 0]);
   });
 });
 

--- a/src/sortedLastIndexBy.test.ts
+++ b/src/sortedLastIndexBy.test.ts
@@ -143,7 +143,9 @@ describe("runtime correctness", () => {
 describe("binary search correctness via indexed", () => {
   test("empty array", () => {
     // The value function always gets called for the item with index `undefined`
-    expect(indicesSeen([], { age: 21 }, ({ age }) => age)).toEqual([undefined]);
+    expect(indicesSeen([], { age: 21 }, ({ age }) => age)).toStrictEqual([
+      undefined,
+    ]);
   });
 
   test("before all", () => {
@@ -170,7 +172,7 @@ describe("binary search correctness via indexed", () => {
         { age: 20 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 2, 1, 0]);
+    ).toStrictEqual([undefined, 8, 4, 2, 1, 0]);
   });
 
   test("after all", () => {
@@ -197,7 +199,7 @@ describe("binary search correctness via indexed", () => {
         { age: 40 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 12, 14, 15]);
+    ).toStrictEqual([undefined, 8, 12, 14, 15]);
   });
 
   test("inside the array", () => {
@@ -224,7 +226,7 @@ describe("binary search correctness via indexed", () => {
         { age: 27 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 6, 7]);
+    ).toStrictEqual([undefined, 8, 4, 6, 7]);
   });
 
   test("with duplicates", () => {
@@ -251,7 +253,7 @@ describe("binary search correctness via indexed", () => {
         { age: 27 },
         ({ age }) => age,
       ),
-    ).toEqual([undefined, 8, 4, 6, 7]);
+    ).toStrictEqual([undefined, 8, 4, 6, 7]);
   });
 });
 

--- a/src/splice.test.ts
+++ b/src/splice.test.ts
@@ -18,6 +18,7 @@ describe("typical cases", (): void => {
 test("immutability", () => {
   const data = [1, 2, 3];
   const result = splice(data, 0, 0, []);
+
   expect(result).toEqual(data);
   expect(result).not.toBe(data);
 });

--- a/src/splice.test.ts
+++ b/src/splice.test.ts
@@ -3,15 +3,15 @@ import { splice } from "./splice";
 
 describe("typical cases", (): void => {
   test("removing a element", (): void => {
-    expect(splice([1, 2, 3], 0, 1, [])).toEqual([2, 3]);
+    expect(splice([1, 2, 3], 0, 1, [])).toStrictEqual([2, 3]);
   });
 
   test("inserting a element", (): void => {
-    expect(splice([1, 2, 3], 0, 0, [4])).toEqual([4, 1, 2, 3]);
+    expect(splice([1, 2, 3], 0, 0, [4])).toStrictEqual([4, 1, 2, 3]);
   });
 
   test("removing elements and inserting elements", (): void => {
-    expect(splice([1, 2, 3], 0, 2, [4, 5])).toEqual([4, 5, 3]);
+    expect(splice([1, 2, 3], 0, 2, [4, 5])).toStrictEqual([4, 5, 3]);
   });
 });
 
@@ -19,7 +19,7 @@ test("immutability", () => {
   const data = [1, 2, 3];
   const result = splice(data, 0, 0, []);
 
-  expect(result).toEqual(data);
+  expect(result).toStrictEqual(data);
   expect(result).not.toBe(data);
 });
 
@@ -104,13 +104,15 @@ describe("regression test including edge cases", () => {
   test.each(testCases)(
     "splice($items, $start, $deleteCount, $replacement) -> $expected",
     ({ items, start, deleteCount, replacement, expected }) => {
-      expect(splice(items, start, deleteCount, replacement)).toEqual(expected);
+      expect(splice(items, start, deleteCount, replacement)).toStrictEqual(
+        expected,
+      );
     },
   );
 });
 
 test("a purried data-last implementation", () => {
-  expect(pipe([1, 2, 3, 4, 5, 6, 7, 8], splice(2, 3, [9, 10]))).toEqual([
+  expect(pipe([1, 2, 3, 4, 5, 6, 7, 8], splice(2, 3, [9, 10]))).toStrictEqual([
     1, 2, 9, 10, 6, 7, 8,
   ]);
 });

--- a/src/split.test-d.ts
+++ b/src/split.test-d.ts
@@ -30,11 +30,6 @@ test("trivial literals", () => {
   expectTypeOf(result).toEqualTypeOf<["a"]>();
 });
 
-test("trivial literals", () => {
-  const result = split("a", ",");
-  expectTypeOf(result).toEqualTypeOf<["a"]>();
-});
-
 test("string contains separator", () => {
   const result = split(",", ",");
   expectTypeOf(result).toEqualTypeOf<["", ""]>();

--- a/src/split.test.ts
+++ b/src/split.test.ts
@@ -2,91 +2,91 @@ import { split } from "./split";
 import { pipe } from "./pipe";
 
 test("empty string, empty separator", () => {
-  expect(split("", "")).toEqual([]);
+  expect(split("", "")).toStrictEqual([]);
 });
 
 test("empty string, non-empty separator", () => {
-  expect(split("", ",")).toEqual([""]);
+  expect(split("", ",")).toStrictEqual([""]);
 });
 
 test("trivial split", () => {
-  expect(split("a", ",")).toEqual(["a"]);
+  expect(split("a", ",")).toStrictEqual(["a"]);
 });
 
 test("string contains separator", () => {
-  expect(split(",", ",")).toEqual(["", ""]);
+  expect(split(",", ",")).toStrictEqual(["", ""]);
 });
 
 test("useful split", () => {
-  expect(split("a,b,c", ",")).toEqual(["a", "b", "c"]);
+  expect(split("a,b,c", ",")).toStrictEqual(["a", "b", "c"]);
 });
 
 test("regex split", () => {
-  expect(split("a,b,c", /,/u)).toEqual(["a", "b", "c"]);
+  expect(split("a,b,c", /,/u)).toStrictEqual(["a", "b", "c"]);
 });
 
 test("multiple types of separators", () => {
-  expect(split("a,b;c", /[;,]/u)).toEqual(["a", "b", "c"]);
+  expect(split("a,b;c", /[;,]/u)).toStrictEqual(["a", "b", "c"]);
 });
 
 test("regex with limit", () => {
-  expect(split("a,b,c", /,/u, 2)).toEqual(["a", "b"]);
+  expect(split("a,b,c", /,/u, 2)).toStrictEqual(["a", "b"]);
 });
 
 test("limited split", () => {
-  expect(split("a,b,c", ",", 2)).toEqual(["a", "b"]);
+  expect(split("a,b,c", ",", 2)).toStrictEqual(["a", "b"]);
 });
 
 test("limit is higher than splits", () => {
-  expect(split("a,b,c", ",", 5)).toEqual(["a", "b", "c"]);
+  expect(split("a,b,c", ",", 5)).toStrictEqual(["a", "b", "c"]);
 });
 
 test("multiple consecutive separators", () => {
-  expect(split("a,,b", ",")).toEqual(["a", "", "b"]);
+  expect(split("a,,b", ",")).toStrictEqual(["a", "", "b"]);
 });
 
 test("separator at the start and end", () => {
-  expect(split(",a,b,", ",")).toEqual(["", "a", "b", ""]);
+  expect(split(",a,b,", ",")).toStrictEqual(["", "a", "b", ""]);
 });
 
 test("empty-string separator", () => {
-  expect(split("abcdef", "")).toEqual(["a", "b", "c", "d", "e", "f"]);
+  expect(split("abcdef", "")).toStrictEqual(["a", "b", "c", "d", "e", "f"]);
 });
 
 test("undefined limit", () => {
-  expect(split("a,b,c", ",", undefined)).toEqual(["a", "b", "c"]);
+  expect(split("a,b,c", ",", undefined)).toStrictEqual(["a", "b", "c"]);
 });
 
 test("negative limit", () => {
-  expect(split("a,b,c", ",", -1)).toEqual(["a", "b", "c"]);
+  expect(split("a,b,c", ",", -1)).toStrictEqual(["a", "b", "c"]);
 });
 
 test("fractional limits", () => {
-  expect(split("a,b,c", ",", 1.5)).toEqual(["a"]);
+  expect(split("a,b,c", ",", 1.5)).toStrictEqual(["a"]);
 });
 
 test("0 limit", () => {
-  expect(split("a,b,c", ",", 0)).toEqual([]);
+  expect(split("a,b,c", ",", 0)).toStrictEqual([]);
 });
 
 describe("dataLast", () => {
   test("useful split", () => {
-    expect(pipe("a,b,c", split(","))).toEqual(["a", "b", "c"]);
+    expect(pipe("a,b,c", split(","))).toStrictEqual(["a", "b", "c"]);
   });
 
   test("regex split", () => {
-    expect(pipe("a,b,c", split(/,/u))).toEqual(["a", "b", "c"]);
+    expect(pipe("a,b,c", split(/,/u))).toStrictEqual(["a", "b", "c"]);
   });
 
   test("limited split", () => {
-    expect(pipe("a,b,c", split(",", 2))).toEqual(["a", "b"]);
+    expect(pipe("a,b,c", split(",", 2))).toStrictEqual(["a", "b"]);
   });
 
   test("regex with limit", () => {
-    expect(pipe("a,b,c", split(/,/u, 2))).toEqual(["a", "b"]);
+    expect(pipe("a,b,c", split(/,/u, 2))).toStrictEqual(["a", "b"]);
   });
 
   test("undefined limit", () => {
-    expect(pipe("a,b,c", split(",", undefined))).toEqual(["a", "b", "c"]);
+    expect(pipe("a,b,c", split(",", undefined))).toStrictEqual(["a", "b", "c"]);
   });
 });

--- a/src/splitAt.test.ts
+++ b/src/splitAt.test.ts
@@ -2,20 +2,26 @@ import { splitAt } from "./splitAt";
 
 describe("data_first", () => {
   test("split", () => {
-    expect(splitAt([1, 2, 3] as const, 1)).toEqual([[1], [2, 3]]);
+    expect(splitAt([1, 2, 3] as const, 1)).toStrictEqual([[1], [2, 3]]);
   });
 
   test("split at -1", () => {
-    expect(splitAt([1, 2, 3, 4, 5] as const, -1)).toEqual([[1, 2, 3, 4], [5]]);
+    expect(splitAt([1, 2, 3, 4, 5] as const, -1)).toStrictEqual([
+      [1, 2, 3, 4],
+      [5],
+    ]);
   });
 });
 
 describe("data_last", () => {
   test("split", () => {
-    expect(splitAt(1)([1, 2, 3] as const)).toEqual([[1], [2, 3]]);
+    expect(splitAt(1)([1, 2, 3] as const)).toStrictEqual([[1], [2, 3]]);
   });
 
   test("split at -1", () => {
-    expect(splitAt(-1)([1, 2, 3, 4, 5] as const)).toEqual([[1, 2, 3, 4], [5]]);
+    expect(splitAt(-1)([1, 2, 3, 4, 5] as const)).toStrictEqual([
+      [1, 2, 3, 4],
+      [5],
+    ]);
   });
 });

--- a/src/splitWhen.test.ts
+++ b/src/splitWhen.test.ts
@@ -9,6 +9,7 @@ it("should split array", () => {
 
 it("should with no matches", () => {
   const n = 1232;
+
   expect(splitWhen([1, 2, 3, 1, 2, 3], (x) => x === n)).toEqual([
     [1, 2, 3, 1, 2, 3],
     [],

--- a/src/splitWhen.test.ts
+++ b/src/splitWhen.test.ts
@@ -1,7 +1,7 @@
 import { splitWhen } from "./splitWhen";
 
 it("should split array", () => {
-  expect(splitWhen([1, 2, 3, 1, 2, 3] as const, (x) => x === 2)).toEqual([
+  expect(splitWhen([1, 2, 3, 1, 2, 3] as const, (x) => x === 2)).toStrictEqual([
     [1],
     [2, 3, 1, 2, 3],
   ]);
@@ -10,7 +10,7 @@ it("should split array", () => {
 it("should with no matches", () => {
   const n = 1232;
 
-  expect(splitWhen([1, 2, 3, 1, 2, 3], (x) => x === n)).toEqual([
+  expect(splitWhen([1, 2, 3, 1, 2, 3], (x) => x === n)).toStrictEqual([
     [1, 2, 3, 1, 2, 3],
     [],
   ]);

--- a/src/startsWith.test-d.ts
+++ b/src/startsWith.test-d.ts
@@ -115,6 +115,7 @@ describe("data-last", () => {
       [] as Array<`foo_${number}`>,
       startsWith("foo"),
     );
+    // eslint-disable-next-line vitest/valid-expect -- the `branded` accessor isn't currently supported by the plugin. See https://github.com/vitest-dev/eslint-plugin-vitest/issues/539
     expectTypeOf(yes).branded.toEqualTypeOf<Array<`foo_${number}`>>();
     expectTypeOf(no).toEqualTypeOf<Array<never>>();
   });
@@ -143,6 +144,7 @@ describe("data-last", () => {
       [] as Array<`cat_${number}` | `dog_${boolean}`>,
       startsWith("c"),
     );
+    // eslint-disable-next-line vitest/valid-expect -- the `branded` accessor isn't currently supported by the plugin. See https://github.com/vitest-dev/eslint-plugin-vitest/issues/539
     expectTypeOf(yes).branded.toEqualTypeOf<Array<`cat_${number}`>>();
     expectTypeOf(no).toEqualTypeOf<Array<`dog_${boolean}`>>();
   });

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -18,6 +18,7 @@ test("should handle short path with only bracket access", () => {
 
 test("should handle bracket access at the end", () => {
   const res = stringToPath("foo.bar[3]");
+
   expect(res).toEqual(["foo", "bar", "3"]);
 });
 

--- a/src/stringToPath.test.ts
+++ b/src/stringToPath.test.ts
@@ -13,13 +13,13 @@ test("single index", () => {
 });
 
 test("should handle short path with only bracket access", () => {
-  expect(stringToPath("foo[bar]")).toEqual(["foo", "bar"]);
+  expect(stringToPath("foo[bar]")).toStrictEqual(["foo", "bar"]);
 });
 
 test("should handle bracket access at the end", () => {
   const res = stringToPath("foo.bar[3]");
 
-  expect(res).toEqual(["foo", "bar", "3"]);
+  expect(res).toStrictEqual(["foo", "bar", "3"]);
 });
 
 test("should convert a string to a deeply nested path", () => {

--- a/src/subtract.test.ts
+++ b/src/subtract.test.ts
@@ -1,11 +1,11 @@
 import { subtract } from "./subtract";
 
 test("data-first", () => {
-  expect(subtract(10, 5)).toEqual(5);
-  expect(subtract(10, -5)).toEqual(15);
+  expect(subtract(10, 5)).toBe(5);
+  expect(subtract(10, -5)).toBe(15);
 });
 
 test("data-last", () => {
-  expect(subtract(5)(10)).toEqual(5);
-  expect(subtract(-5)(10)).toEqual(15);
+  expect(subtract(5)(10)).toBe(5);
+  expect(subtract(-5)(10)).toBe(15);
 });

--- a/src/sum.test-d.ts
+++ b/src/sum.test-d.ts
@@ -77,7 +77,7 @@ it("doesn't allow mixed arrays", () => {
   sum([1, 2n]);
 });
 
-describe("kNOWN ISSUES", () => {
+describe("KNOWN ISSUES", () => {
   it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
     expectTypeOf(result).toEqualTypeOf<bigint | 0>();

--- a/src/sum.test-d.ts
+++ b/src/sum.test-d.ts
@@ -77,8 +77,8 @@ it("doesn't allow mixed arrays", () => {
   sum([1, 2n]);
 });
 
-describe("KNOWN ISSUES", () => {
-  it("Returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
+describe("kNOWN ISSUES", () => {
+  it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
     expectTypeOf(result).toEqualTypeOf<bigint | 0>();
   });

--- a/src/sum.test.ts
+++ b/src/sum.test.ts
@@ -29,7 +29,7 @@ describe("dataLast", () => {
   });
 });
 
-describe("kNOWN ISSUES", () => {
+describe("KNOWN ISSUES", () => {
   it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
 

--- a/src/sum.test.ts
+++ b/src/sum.test.ts
@@ -29,9 +29,10 @@ describe("dataLast", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
-  it("Returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
+describe("kNOWN ISSUES", () => {
+  it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
+
     expect(result).toBe(0);
   });
 });

--- a/src/sumBy.test.ts
+++ b/src/sumBy.test.ts
@@ -6,7 +6,7 @@ describe("data first", () => {
   test("sumBy", () => {
     expect(
       sumBy([{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }], prop("a")),
-    ).toEqual(15);
+    ).toBe(15);
   });
 
   test("indexed", () => {
@@ -15,13 +15,13 @@ describe("data first", () => {
         [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
         ({ a }, idx) => a + idx,
       ),
-    ).toEqual(25);
+    ).toBe(25);
   });
 
   test("works with bigint", () => {
     expect(
       sumBy([{ a: 1n }, { a: 2n }, { a: 4n }, { a: 5n }, { a: 3n }], prop("a")),
-    ).toEqual(15n);
+    ).toBe(15n);
   });
 
   it("should return 0 for an empty array", () => {
@@ -36,7 +36,7 @@ describe("data last", () => {
         [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
         sumBy(prop("a")),
       ),
-    ).toEqual(15);
+    ).toBe(15);
   });
 
   test("works with bigint", () => {
@@ -45,7 +45,7 @@ describe("data last", () => {
         [{ a: 1n }, { a: 2n }, { a: 4n }, { a: 5n }, { a: 3n }],
         sumBy(prop("a")),
       ),
-    ).toEqual(15n);
+    ).toBe(15n);
   });
 
   it("should return 0 for an empty array", () => {
@@ -57,6 +57,7 @@ describe("data last", () => {
       [{ a: 1 }, { a: 2 }, { a: 4 }, { a: 5 }, { a: 3 }],
       sumBy(({ a }, idx) => a + idx),
     );
-    expect(actual).toEqual(25);
+
+    expect(actual).toBe(25);
   });
 });

--- a/src/sumBy.ts
+++ b/src/sumBy.ts
@@ -1,5 +1,5 @@
 import { purry } from "./purry";
-import { type IterableContainer } from "./internal/types";
+import type { IterableContainer } from "./internal/types";
 
 type SumBy<
   T extends IterableContainer,

--- a/src/swapIndices.test.ts
+++ b/src/swapIndices.test.ts
@@ -6,19 +6,19 @@ describe("data_first", () => {
   });
 
   it("swap string", () => {
-    expect(swapIndices("apple", 0, 1)).toEqual("paple");
+    expect(swapIndices("apple", 0, 1)).toBe("paple");
   });
 
   it("fails gracefully on NaN indices", () => {
-    expect(swapIndices("apple", Number.NaN, 1)).toEqual("apple");
-    expect(swapIndices("apple", 1, Number.NaN)).toEqual("apple");
-    expect(swapIndices("apple", Number.NaN, Number.NaN)).toEqual("apple");
+    expect(swapIndices("apple", Number.NaN, 1)).toBe("apple");
+    expect(swapIndices("apple", 1, Number.NaN)).toBe("apple");
+    expect(swapIndices("apple", Number.NaN, Number.NaN)).toBe("apple");
   });
 
   it("fails gracefully on overflow indices", () => {
-    expect(swapIndices("apple", 100, 1)).toEqual("apple");
-    expect(swapIndices("apple", 1, 100)).toEqual("apple");
-    expect(swapIndices("apple", 200, 300)).toEqual("apple");
+    expect(swapIndices("apple", 100, 1)).toBe("apple");
+    expect(swapIndices("apple", 1, 100)).toBe("apple");
+    expect(swapIndices("apple", 200, 300)).toBe("apple");
   });
 });
 
@@ -26,7 +26,8 @@ describe("data_last", () => {
   it("swap array", () => {
     expect(swapIndices(-1, 4)([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]);
   });
+
   it("swap string", () => {
-    expect(swapIndices(0, -1)("apple")).toEqual("eppla");
+    expect(swapIndices(0, -1)("apple")).toBe("eppla");
   });
 });

--- a/src/swapIndices.test.ts
+++ b/src/swapIndices.test.ts
@@ -2,7 +2,7 @@ import { swapIndices } from "./swapIndices";
 
 describe("data_first", () => {
   it("swap array", () => {
-    expect(swapIndices([1, 2, 3, 4, 5], 0, -1)).toEqual([5, 2, 3, 4, 1]);
+    expect(swapIndices([1, 2, 3, 4, 5], 0, -1)).toStrictEqual([5, 2, 3, 4, 1]);
   });
 
   it("swap string", () => {
@@ -24,7 +24,7 @@ describe("data_first", () => {
 
 describe("data_last", () => {
   it("swap array", () => {
-    expect(swapIndices(-1, 4)([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]);
+    expect(swapIndices(-1, 4)([1, 2, 3, 4, 5])).toStrictEqual([1, 2, 3, 4, 5]);
   });
 
   it("swap string", () => {

--- a/src/swapProps.test.ts
+++ b/src/swapProps.test.ts
@@ -2,15 +2,18 @@ import { pipe } from "./pipe";
 import { swapProps } from "./swapProps";
 
 it("data-first", () => {
-  expect(swapProps({ a: 1, b: 2 }, "a", "b")).toEqual({ a: 2, b: 1 });
+  expect(swapProps({ a: 1, b: 2 }, "a", "b")).toStrictEqual({ a: 2, b: 1 });
 });
 
 it("data-last", () => {
-  expect(pipe({ a: 1, b: 2 }, swapProps("a", "b"))).toEqual({ a: 2, b: 1 });
+  expect(pipe({ a: 1, b: 2 }, swapProps("a", "b"))).toStrictEqual({
+    a: 2,
+    b: 1,
+  });
 });
 
 it("maintains the shape of the rest of the object", () => {
-  expect(swapProps({ a: true, b: "hello", c: 3 }, "a", "b")).toEqual({
+  expect(swapProps({ a: true, b: "hello", c: 3 }, "a", "b")).toStrictEqual({
     a: "hello",
     b: true,
     c: 3,

--- a/src/take.test.ts
+++ b/src/take.test.ts
@@ -23,6 +23,7 @@ describe("data first", () => {
   test("returns a shallow clone when all items are taken", () => {
     const data = [1, 2, 3, 4, 5];
     const result = take(data, 5);
+
     expect(result).toStrictEqual([1, 2, 3, 4, 5]);
     expect(result).not.toBe(data);
   });
@@ -48,6 +49,7 @@ describe("data last", () => {
   test("lazy implementation", () => {
     const mockFunc = vi.fn(identity());
     pipe([1, 2, 3, 4, 5], map(mockFunc), take(2));
+
     expect(mockFunc).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/takeFirstBy.test.ts
+++ b/src/takeFirstBy.test.ts
@@ -6,7 +6,7 @@ describe("runtime (dataFirst)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
-    expect(takeFirstBy(data, 2, identity())).toEqual([2, 1]);
+    expect(takeFirstBy(data, 2, identity())).toStrictEqual([2, 1]);
   });
 
   it("handles empty arrays gracefully", () => {
@@ -32,7 +32,7 @@ describe("runtime (dataFirst)", () => {
     const result = takeFirstBy(data, 100, identity());
 
     expect(result).not.toBe(data);
-    expect(result).toEqual(data);
+    expect(result).toStrictEqual(data);
   });
 
   it("works with complex compare rules", () => {
@@ -49,7 +49,7 @@ describe("runtime (dataFirst)", () => {
       "aaaaa",
     ];
 
-    expect(takeFirstBy(data, 3, (x) => x.length, identity())).toEqual([
+    expect(takeFirstBy(data, 3, (x) => x.length, identity())).toStrictEqual([
       "aa",
       "b",
       "a",
@@ -66,7 +66,7 @@ describe("runtime (dataLast)", () => {
         data,
         takeFirstBy(2, (x) => x),
       ),
-    ).toEqual([2, 1]);
+    ).toStrictEqual([2, 1]);
   });
 
   it("handles empty arrays gracefully", () => {
@@ -110,7 +110,7 @@ describe("runtime (dataLast)", () => {
     );
 
     expect(result).not.toBe(data);
-    expect(result).toEqual(data);
+    expect(result).toStrictEqual(data);
   });
 
   it("works with complex compare rules", () => {
@@ -136,6 +136,6 @@ describe("runtime (dataLast)", () => {
           (x) => x,
         ),
       ),
-    ).toEqual(["aa", "b", "a"]);
+    ).toStrictEqual(["aa", "b", "a"]);
   });
 });

--- a/src/takeFirstBy.test.ts
+++ b/src/takeFirstBy.test.ts
@@ -5,27 +5,32 @@ import { takeFirstBy } from "./takeFirstBy";
 describe("runtime (dataFirst)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(takeFirstBy(data, 2, identity())).toEqual([2, 1]);
   });
 
   it("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
+
     expect(takeFirstBy(data, 1, identity())).toHaveLength(0);
   });
 
   it("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(takeFirstBy(data, -3, identity())).toHaveLength(0);
   });
 
   it("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(takeFirstBy(data, 100, identity())).toHaveLength(data.length);
   });
 
   it("clones the array when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = takeFirstBy(data, 100, identity());
+
     expect(result).not.toBe(data);
     expect(result).toEqual(data);
   });
@@ -43,6 +48,7 @@ describe("runtime (dataFirst)", () => {
       "b",
       "aaaaa",
     ];
+
     expect(takeFirstBy(data, 3, (x) => x.length, identity())).toEqual([
       "aa",
       "b",
@@ -54,6 +60,7 @@ describe("runtime (dataFirst)", () => {
 describe("runtime (dataLast)", () => {
   it("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -64,6 +71,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
+
     expect(
       pipe(
         data,
@@ -74,6 +82,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -84,6 +93,7 @@ describe("runtime (dataLast)", () => {
 
   it("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
+
     expect(
       pipe(
         data,
@@ -98,6 +108,7 @@ describe("runtime (dataLast)", () => {
       data,
       takeFirstBy(100, (x) => x),
     );
+
     expect(result).not.toBe(data);
     expect(result).toEqual(data);
   });
@@ -115,6 +126,7 @@ describe("runtime (dataLast)", () => {
       "b",
       "aaaaa",
     ];
+
     expect(
       pipe(
         data,

--- a/src/takeLast.test.ts
+++ b/src/takeLast.test.ts
@@ -4,29 +4,30 @@ test("empty array", () => {
   expect(takeLast([], 2)).toStrictEqual([]);
 });
 
-test("N < 0", () => {
+test("n < 0", () => {
   expect(takeLast([1, 2, 3, 4, 5], -1)).toStrictEqual([]);
 });
 
-test("N === 0", () => {
+test("n === 0", () => {
   expect(takeLast([1, 2, 3, 4, 5], 0)).toStrictEqual([]);
 });
 
-test("N < length", () => {
+test("n < length", () => {
   expect(takeLast([1, 2, 3, 4, 5], 2)).toStrictEqual([4, 5]);
 });
 
-test("N === length", () => {
+test("n === length", () => {
   expect(takeLast([1, 2, 3, 4, 5], 5)).toStrictEqual([1, 2, 3, 4, 5]);
 });
 
-test("N > length", () => {
+test("n > length", () => {
   expect(takeLast([1, 2, 3, 4, 5], 10)).toStrictEqual([1, 2, 3, 4, 5]);
 });
 
 test("should return a new array even if everything was taken", () => {
   const data = [1, 2, 3, 4, 5];
   const result = takeLast(data, data.length);
+
   expect(result).not.toBe(data);
   expect(result).toStrictEqual(data);
 });

--- a/src/takeLastWhile.test.ts
+++ b/src/takeLastWhile.test.ts
@@ -23,6 +23,7 @@ describe("data first", () => {
   it("should return a copy of the original array when all items pass the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = takeLastWhile(data, (n) => n > 0);
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });
@@ -71,6 +72,7 @@ describe("data last", () => {
       data,
       takeLastWhile((n) => n > 0),
     );
+
     expect(result).toStrictEqual(data);
     expect(result).not.toBe(data);
   });

--- a/src/takeWhile.test.ts
+++ b/src/takeWhile.test.ts
@@ -3,9 +3,9 @@ import { takeWhile } from "./takeWhile";
 
 describe("data_first", () => {
   it("takeWhile", () => {
-    expect(takeWhile([1, 2, 3, 4, 3, 2, 1] as const, (x) => x !== 4)).toEqual([
-      1, 2, 3,
-    ]);
+    expect(
+      takeWhile([1, 2, 3, 4, 3, 2, 1] as const, (x) => x !== 4),
+    ).toStrictEqual([1, 2, 3]);
   });
 });
 
@@ -16,6 +16,6 @@ describe("data_last", () => {
         [1, 2, 3, 4, 3, 2, 1] as const,
         takeWhile((x) => x !== 4),
       ),
-    ).toEqual([1, 2, 3]);
+    ).toStrictEqual([1, 2, 3]);
   });
 });

--- a/src/tap.test.ts
+++ b/src/tap.test.ts
@@ -10,7 +10,8 @@ describe("data first", () => {
   it("should call function with input value", () => {
     const fn = vi.fn();
     tap(DATA, fn);
-    expect(fn).toBeCalledWith(DATA);
+
+    expect(fn).toHaveBeenCalledWith(DATA);
     expect(fn).toHaveBeenCalledOnce();
   });
 
@@ -23,7 +24,8 @@ describe("data last", () => {
   it("should call function with input value", () => {
     const fn = vi.fn();
     pipe(DATA, tap(fn));
-    expect(fn).toBeCalledWith(DATA);
+
+    expect(fn).toHaveBeenCalledWith(DATA);
     expect(fn).toHaveBeenCalledOnce();
   });
 

--- a/src/times.test.ts
+++ b/src/times.test.ts
@@ -7,9 +7,11 @@ import { times } from "./times";
 describe("data_first", () => {
   it("returns a trivial empty array for non-positive values", () => {
     const zeroResult = times(0, identity());
+
     expect(zeroResult).toStrictEqual([]);
 
     const negativeResult = times(-1000, identity());
+
     expect(negativeResult).toStrictEqual([]);
 
     // Make sure that the array returned is new, and not the same copy.
@@ -25,6 +27,7 @@ describe("data_first", () => {
   it("passes idx to fn", () => {
     const fn = vi.fn();
     times(5, fn);
+
     expect(fn).toHaveBeenCalledWith(0);
     expect(fn).toHaveBeenCalledWith(1);
     expect(fn).toHaveBeenCalledWith(2);
@@ -45,9 +48,11 @@ describe("data_first", () => {
 describe("data_last", () => {
   it("returns a trivial empty array for non-positive values", () => {
     const zeroResult = pipe(0, times(identity()));
+
     expect(zeroResult).toStrictEqual([]);
 
     const negativeResult = pipe(-1000, times(identity()));
+
     expect(negativeResult).toStrictEqual([]);
 
     // Make sure that the array returned is new, and not the same copy.
@@ -63,6 +68,7 @@ describe("data_last", () => {
   it("passes idx to fn", () => {
     const fn = vi.fn();
     pipe(5, times(fn));
+
     expect(fn).toHaveBeenCalledWith(0);
     expect(fn).toHaveBeenCalledWith(1);
     expect(fn).toHaveBeenCalledWith(2);

--- a/src/toCamelCase.test-d.ts
+++ b/src/toCamelCase.test-d.ts
@@ -106,7 +106,7 @@ describe("tests copied from type-fest's tests", () => {
     expectTypeOf(whenFalse).toEqualTypeOf<"fooBar">();
   });
 
-  test("preserveConsecutiveUppercase: fooBAR", () => {
+  test("preserveConsecutiveUppercase: fooBARBiz", () => {
     const data = "fooBARBiz";
     const whenTrue = toCamelCase(data, { preserveConsecutiveUppercase: true });
     expectTypeOf(whenTrue).toEqualTypeOf<"fooBARBiz">();
@@ -117,7 +117,7 @@ describe("tests copied from type-fest's tests", () => {
     expectTypeOf(whenFalse).toEqualTypeOf<"fooBarBiz">();
   });
 
-  test("preserveConsecutiveUppercase: fooBAR", () => {
+  test("preserveConsecutiveUppercase: foo BAR-Biz_BUZZ", () => {
     const data = "foo BAR-Biz_BUZZ";
     const whenTrue = toCamelCase(data, { preserveConsecutiveUppercase: true });
     expectTypeOf(whenTrue).toEqualTypeOf<"fooBARBizBUZZ">();
@@ -128,7 +128,7 @@ describe("tests copied from type-fest's tests", () => {
     expectTypeOf(whenFalse).toEqualTypeOf<"fooBarBizBuzz">();
   });
 
-  test("preserveConsecutiveUppercase: fooBAR", () => {
+  test("preserveConsecutiveUppercase: foo\tBAR-Biz_BUZZ", () => {
     const data = "foo\tBAR-Biz_BUZZ";
     const whenTrue = toCamelCase(data, { preserveConsecutiveUppercase: true });
     expectTypeOf(whenTrue).toEqualTypeOf<"fooBARBizBUZZ">();

--- a/src/unique.test.ts
+++ b/src/unique.test.ts
@@ -4,7 +4,7 @@ import { take } from "./take";
 import { unique } from "./unique";
 
 it("unique", () => {
-  expect(unique([1, 2, 2, 5, 1, 6, 7] as const)).toEqual([1, 2, 5, 6, 7]);
+  expect(unique([1, 2, 2, 5, 1, 6, 7] as const)).toStrictEqual([1, 2, 5, 6, 7]);
 });
 
 describe("pipe", () => {
@@ -18,7 +18,7 @@ describe("pipe", () => {
     );
 
     expect(counter.count).toHaveBeenCalledTimes(4);
-    expect(result).toEqual([1, 2, 5]);
+    expect(result).toStrictEqual([1, 2, 5]);
   });
 
   it("take before unique", () => {
@@ -32,6 +32,6 @@ describe("pipe", () => {
     );
 
     expect(counter.count).toHaveBeenCalledTimes(3);
-    expect(result).toEqual([1, 2]);
+    expect(result).toStrictEqual([1, 2]);
   });
 });

--- a/src/unique.test.ts
+++ b/src/unique.test.ts
@@ -16,6 +16,7 @@ describe("pipe", () => {
       unique(),
       take(3),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(4);
     expect(result).toEqual([1, 2, 5]);
   });
@@ -29,6 +30,7 @@ describe("pipe", () => {
       take(3),
       unique(),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([1, 2]);
   });

--- a/src/uniqueBy.test.ts
+++ b/src/uniqueBy.test.ts
@@ -16,13 +16,13 @@ describe("uniqueBy", () => {
   ] as const;
 
   it("handles uniq by identity", () => {
-    expect(uniqueBy([1, 2, 2, 5, 1, 6, 7], identity())).toEqual([
+    expect(uniqueBy([1, 2, 2, 5, 1, 6, 7], identity())).toStrictEqual([
       1, 2, 5, 6, 7,
     ]);
   });
 
   it("returns people with uniq names", () => {
-    expect(uniqueBy(people, (p) => p.name)).toEqual([
+    expect(uniqueBy(people, (p) => p.name)).toStrictEqual([
       { name: "John", age: 42 },
       { name: "Jörn", age: 30 },
       { name: "Sarah", age: 33 },
@@ -32,7 +32,7 @@ describe("uniqueBy", () => {
   });
 
   it("returns people with uniq ages", () => {
-    expect(uniqueBy(people, (p) => p.age)).toEqual([
+    expect(uniqueBy(people, (p) => p.age)).toStrictEqual([
       { name: "John", age: 42 },
       { name: "Jörn", age: 30 },
       { name: "Sarah", age: 33 },
@@ -42,7 +42,7 @@ describe("uniqueBy", () => {
   });
 
   it("returns people with uniq first letter of name", () => {
-    expect(uniqueBy(people, (p) => p.name.slice(0, 1))).toEqual([
+    expect(uniqueBy(people, (p) => p.name.slice(0, 1))).toStrictEqual([
       { name: "John", age: 42 },
       { name: "Sarah", age: 33 },
       { name: "Kim", age: 22 },
@@ -61,7 +61,7 @@ describe("uniqueBy", () => {
       );
 
       expect(counter.count).toHaveBeenCalledTimes(4);
-      expect(result).toEqual([1, 2, 5]);
+      expect(result).toStrictEqual([1, 2, 5]);
     });
 
     it("get executed 3 times when take before uniqueBy", () => {
@@ -74,7 +74,7 @@ describe("uniqueBy", () => {
       );
 
       expect(counter.count).toHaveBeenCalledTimes(3);
-      expect(result).toEqual([1, 2]);
+      expect(result).toStrictEqual([1, 2]);
     });
   });
 });

--- a/src/uniqueWith.test.ts
+++ b/src/uniqueWith.test.ts
@@ -34,6 +34,7 @@ describe("data_last", () => {
       uniqueWith(isDeepEqual),
       take(3),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(4);
     expect(result).toEqual([{ a: 1 }, { a: 2 }, { a: 5 }]);
   });
@@ -47,6 +48,7 @@ describe("data_last", () => {
       take(3),
       uniqueWith(isDeepEqual),
     );
+
     expect(counter.count).toHaveBeenCalledTimes(3);
     expect(result).toEqual([{ a: 1 }, { a: 2 }]);
   });

--- a/src/uniqueWith.test.ts
+++ b/src/uniqueWith.test.ts
@@ -17,13 +17,13 @@ const expected = [{ a: 1 }, { a: 2 }, { a: 5 }, { a: 6 }, { a: 7 }];
 
 describe("data_first", () => {
   test("should return uniq", () => {
-    expect(uniqueWith(source, isDeepEqual)).toEqual(expected);
+    expect(uniqueWith(source, isDeepEqual)).toStrictEqual(expected);
   });
 });
 
 describe("data_last", () => {
   test("should return uniq", () => {
-    expect(uniqueWith(isDeepEqual)(source)).toEqual(expected);
+    expect(uniqueWith(isDeepEqual)(source)).toStrictEqual(expected);
   });
 
   it("lazy", () => {
@@ -36,7 +36,7 @@ describe("data_last", () => {
     );
 
     expect(counter.count).toHaveBeenCalledTimes(4);
-    expect(result).toEqual([{ a: 1 }, { a: 2 }, { a: 5 }]);
+    expect(result).toStrictEqual([{ a: 1 }, { a: 2 }, { a: 5 }]);
   });
 
   it("take before uniq", () => {
@@ -50,6 +50,6 @@ describe("data_last", () => {
     );
 
     expect(counter.count).toHaveBeenCalledTimes(3);
-    expect(result).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(result).toStrictEqual([{ a: 1 }, { a: 2 }]);
   });
 });

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -14,5 +14,6 @@ it("should skip symbol keys", () => {
 
 it("shouldn't skip symbol values", () => {
   const mySymbol = Symbol("mySymbol");
+
   expect(values({ a: mySymbol })).toStrictEqual([mySymbol]);
 });

--- a/src/when.test-d.ts
+++ b/src/when.test-d.ts
@@ -353,17 +353,17 @@ describe("dataLast", () => {
 });
 
 describe("typing mismatches", () => {
-  test("Predicate enforces data param when explicitly stated", () => {
+  test("predicate enforces data param when explicitly stated", () => {
     // @ts-expect-error [ts2769] -- The predicate can't take an undefined value
     when(1 as number | undefined, (x: number) => x > 3, constant(3));
   });
 
-  test("Mappers enforce data param when explicitly stated", () => {
+  test("mappers enforce data param when explicitly stated", () => {
     // @ts-expect-error [ts2769] -- The mapper can't take an undefined value
     when(1 as number | undefined, constant(true), (x: number) => x + 1);
   });
 
-  test("Type of extra args enforced (data-first)", () => {
+  test("type of extra args enforced (data-first)", () => {
     when(
       1,
       constant(true),
@@ -374,7 +374,7 @@ describe("typing mismatches", () => {
     );
   });
 
-  test("Number of extra args enforced (data-first)", () => {
+  test("number of extra args enforced (data-first)", () => {
     when(
       1,
       constant(true),
@@ -386,7 +386,7 @@ describe("typing mismatches", () => {
     );
   });
 
-  test("Type of extra args enforced (data-last)", () => {
+  test("type of extra args enforced (data-last)", () => {
     map(
       [] as Array<string>,
       when(
@@ -397,7 +397,7 @@ describe("typing mismatches", () => {
     );
   });
 
-  test("Number of extra args enforced (data-last)", () => {
+  test("number of extra args enforced (data-last)", () => {
     map(
       [] as Array<string>,
       when(

--- a/src/when.test-d.ts
+++ b/src/when.test-d.ts
@@ -14,7 +14,7 @@ describe("dataFirst", () => {
         });
       });
 
-      it("return type is not narrowed ", () => {
+      it("return type is not narrowed", () => {
         const data = "hello" as number | string;
         const result = when(data, constant(true), constant({ a: 1 }));
         // The result contains both the input type, and the result of the
@@ -195,7 +195,7 @@ describe("dataLast", () => {
         );
       });
 
-      it("return type is not narrowed ", () => {
+      it("return type is not narrowed", () => {
         const data = "hello" as number | string;
         const result = pipe(data, when(constant(true), constant({ a: 1 })));
         // The result contains both the input type, and the result of the

--- a/src/zip.test-d.ts
+++ b/src/zip.test-d.ts
@@ -97,6 +97,7 @@ describe("dataLast", () => {
       [[number, string], [number, string], [number, string]]
     >();
   });
+
   test("tuples", () => {
     const actual = pipe(
       [1, 2, 3] as [1, 2, 3],
@@ -104,6 +105,7 @@ describe("dataLast", () => {
     );
     expectTypeOf(actual).toEqualTypeOf<[[1, "a"], [2, "b"], [3, "c"]]>();
   });
+
   test("variadic tuples", () => {
     const firstVariadic: [number, ...Array<string>] = [1, "b", "c"];
     const secondVariadic: [string, ...Array<number>] = ["a", 2, 3];

--- a/src/zip.test.ts
+++ b/src/zip.test.ts
@@ -54,6 +54,7 @@ describe("dataLast", () => {
   test("evaluates lazily", () => {
     const mockFn = vi.fn(identity());
     pipe([1, 2, 3], map(mockFn), zip([4, 5, 6]), first());
-    expect(mockFn).toBeCalledTimes(1);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/typesDataProvider.ts
+++ b/test/typesDataProvider.ts
@@ -1,5 +1,5 @@
 export class TestClass {
-  // eslint-disable-next-line @typescript-eslint/class-literal-property-style -- Maybe we can just accept the auto-fixer here...?
+  // eslint-disable-next-line @typescript-eslint/class-literal-property-style, @typescript-eslint/class-methods-use-this -- This is fine for a test (I hope...)
   public get foo(): string {
     return "a";
   }


### PR DESCRIPTION
This plugin helps enforce higher-quality tests.

Having it enabled allows us to skip some of the comments we find ourselves mentioning in code reviews often.

This PR changes a lot of files, mostly trivially via auto-fixes. The interesting changes are in:
* doNothing.test
* indexBy.test-d
* Guard runtime checks: isArray, isBigInt, isBoolean, isDate, isDefined, isError, isNonNull, isNonNullish, isNot, isNumber, isPromise, isString, isSymbol, isTruthy
* pick.test had a really weird test from 4 years ago removed.

Note: this PR adds a lot of whitespace newlines. If possible, it's best to review it with whitespaces ignored.