### PR TITLE
perf(isEmpty): Use better algorithm to determine object emptiness

### DIFF
--- a/src/isEmpty.ts
+++ b/src/isEmpty.ts
@@ -48,5 +48,10 @@ export function isEmpty(data: object | string | undefined): boolean {
     return data.length === 0;
   }
 
-  return Object.keys(data).length === 0;
+  for (const key in data) {
+    if (Object.hasOwn(data, key)) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
The prior implementation is O(n). This can be done in O(1).

You may also swap it for `Object.prototype.hasOwnProperty.call(data, key)` if `hasOwn` is not permitted for compatibility. 