### PR TITLE
docs: add netlify attribution to main page

### DIFF
--- a/docs/src/components/netlify-attribution.astro
+++ b/docs/src/components/netlify-attribution.astro
@@ -1,0 +1,18 @@
+---
+const VARIANTS = {
+  accent: "https://www.netlify.com/v3/img/components/netlify-color-accent.svg",
+  bg: "https://www.netlify.com/v3/img/components/netlify-color-bg.svg",
+  light: "https://www.netlify.com/v3/img/components/netlify-light.svg",
+  dark: "https://www.netlify.com/v3/img/components/netlify-dark.svg",
+} as const;
+
+type Props = {
+  readonly variant?: keyof typeof VARIANTS;
+};
+
+const { variant = "accent" } = Astro.props;
+---
+
+<a href="https://www.netlify.com">
+  <img src={VARIANTS[variant]} alt="Deploys by Netlify" />
+</a>

--- a/docs/src/layouts/wiki.astro
+++ b/docs/src/layouts/wiki.astro
@@ -1,4 +1,5 @@
 ---
+import NetlifyAttribution from "@/components/netlify-attribution.astro";
 import Prose from "@/components/prose.astro";
 import BaseLayout from "./base.astro";
 ---
@@ -9,4 +10,7 @@ import BaseLayout from "./base.astro";
       <slot />
     </Prose>
   </main>
+  <footer class="flex justify-center py-5">
+    <NetlifyAttribution />
+  </footer>
 </BaseLayout>


### PR DESCRIPTION
Adds the netlify attribution badge to the main page.

Note that although this was added to the layout itself, this layout is only used on the main page atm. I felt this is a good place for it because it allowed me to separate the `footer` tag from the attribution itself, in case we want to add more stuff to the footer in the future.

This, together with #877 should satisfy the requirements for adding our docs site to the open-source plan.

Closes: #875