### PR TITLE
fix(pick): better inference of picked keys

### DIFF
--- a/src/pick.test-d.ts
+++ b/src/pick.test-d.ts
@@ -16,7 +16,8 @@ describe("data first", () => {
     >();
   });
 
-  it("infers the key types from the keys array (issue 886)", () => {
+  // @see https://github.com/remeda/remeda/issues/886
+  it("infers the key types from the keys array", () => {
     const data = { foo: "hello", bar: "world" };
 
     const raw = pick(data, ["foo"]);

--- a/src/pick.test-d.ts
+++ b/src/pick.test-d.ts
@@ -1,3 +1,5 @@
+import { identity } from "./identity";
+import { mapValues } from "./mapValues";
 import { pick } from "./pick";
 import { pipe } from "./pipe";
 
@@ -13,6 +15,19 @@ describe("data first", () => {
     expectTypeOf(result).toEqualTypeOf<
       Pick<{ a: number } | { a?: number; b: string }, "a">
     >();
+  });
+
+  it("infers the key types from the keys array (issue 886)", () => {
+    const data = { foo: "hello", bar: "world" };
+
+    const raw = pick(data, ["foo"]);
+    expectTypeOf(raw).toEqualTypeOf<{ foo: string }>();
+
+    const wrapped = mapValues(pick(data, ["foo"]), identity());
+    expectTypeOf(wrapped).toEqualTypeOf<{ foo: string }>();
+
+    const withConstKeys = mapValues(pick(data, ["foo"] as const), identity());
+    expectTypeOf(withConstKeys).toEqualTypeOf<{ foo: string }>();
   });
 });
 

--- a/src/pick.test-d.ts
+++ b/src/pick.test-d.ts
@@ -1,5 +1,4 @@
-import { identity } from "./identity";
-import { mapValues } from "./mapValues";
+import { keys } from "./keys";
 import { pick } from "./pick";
 import { pipe } from "./pipe";
 
@@ -23,11 +22,11 @@ describe("data first", () => {
     const raw = pick(data, ["foo"]);
     expectTypeOf(raw).toEqualTypeOf<{ foo: string }>();
 
-    const wrapped = mapValues(pick(data, ["foo"]), identity());
-    expectTypeOf(wrapped).toEqualTypeOf<{ foo: string }>();
+    const wrapped = keys(pick(data, ["foo"]));
+    expectTypeOf(wrapped).toEqualTypeOf<Array<"foo">>();
 
-    const withConstKeys = mapValues(pick(data, ["foo"] as const), identity());
-    expectTypeOf(withConstKeys).toEqualTypeOf<{ foo: string }>();
+    const withConstKeys = keys(pick(data, ["foo"] as const));
+    expectTypeOf(withConstKeys).toEqualTypeOf<Array<"foo">>();
   });
 });
 

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -1,34 +1,34 @@
 import { purry } from "./purry";
 
 /**
- * Creates an object composed of the picked `object` properties.
+ * Creates an object composed of the picked `data` properties.
  *
- * @param names - The properties names.
+ * @param keys - The property names.
  * @signature R.pick([prop1, prop2])(object)
  * @example
  *    R.pipe({ a: 1, b: 2, c: 3, d: 4 }, R.pick(['a', 'd'])) // => { a: 1, d: 4 }
  * @dataLast
  * @category Object
  */
-export function pick<T extends object, K extends keyof T>(
-  names: ReadonlyArray<K>,
-): (object: T) => Pick<T, K>;
+export function pick<T extends object, Keys extends ReadonlyArray<keyof T>>(
+  keys: Keys,
+): (data: T) => Pick<T, Keys[number]>;
 
 /**
- * Creates an object composed of the picked `object` properties.
+ * Creates an object composed of the picked `data` properties.
  *
- * @param object - The target object.
- * @param names - The properties names.
+ * @param data - The target object.
+ * @param keys - The property names.
  * @signature R.pick(object, [prop1, prop2])
  * @example
  *    R.pick({ a: 1, b: 2, c: 3, d: 4 }, ['a', 'd']) // => { a: 1, d: 4 }
  * @dataFirst
  * @category Object
  */
-export function pick<T extends object, K extends keyof T>(
-  object: T,
-  names: ReadonlyArray<K>,
-): Pick<T, K>;
+export function pick<T extends object, Keys extends ReadonlyArray<keyof T>>(
+  data: T,
+  keys: Keys,
+): Pick<T, Keys[number]>;
 
 export function pick(...args: ReadonlyArray<unknown>): unknown {
   return purry(pickImplementation, args);

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -34,14 +34,14 @@ export function pick(...args: ReadonlyArray<unknown>): unknown {
   return purry(pickImplementation, args);
 }
 
-function pickImplementation<T extends object, K extends keyof T>(
-  object: T,
-  names: ReadonlyArray<K>,
-): Pick<T, K> {
-  const out: Partial<Pick<T, K>> = {};
-  for (const name of names) {
-    if (name in object) {
-      out[name] = object[name];
+function pickImplementation<
+  T extends object,
+  Keys extends ReadonlyArray<keyof T>,
+>(object: T, keys: Keys): Pick<T, Keys[number]> {
+  const out: Partial<Pick<T, Keys[number]>> = {};
+  for (const key of keys) {
+    if (key in object) {
+      out[key] = object[key];
     }
   }
   // @ts-expect-error [ts2322] - We build the type incrementally, there's no way to make typescript infer that we "finished" building the object and to treat it as such.


### PR DESCRIPTION
Allows the array of keys to be inferred from its values instead of from a wrapping param type.

Fixes: #886