### PR TITLE
refactor(mean): drop `bigint` support

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -45,8 +45,6 @@ export type BrandedReturn<F extends (...args: any) => any> = (
 
 export type NonEmptyArray<T> = [T, ...Array<T>];
 
-export type NonEmptyReadonlyArray<T> = readonly [T, ...ReadonlyArray<T>];
-
 export type Mapped<T extends IterableContainer, K> = {
   -readonly [P in keyof T]: K;
 };

--- a/src/mean.test-d.ts
+++ b/src/mean.test-d.ts
@@ -8,7 +8,7 @@ test("empty arrays", () => {
   expectTypeOf(result).toEqualTypeOf<undefined>();
 });
 
-describe("numbers", () => {
+describe("dataFirst", () => {
   test("arbitrary arrays", () => {
     const result = mean([] as Array<number>);
     expectTypeOf(result).toEqualTypeOf<number | undefined>();
@@ -35,42 +35,10 @@ describe("numbers", () => {
   });
 });
 
-describe("bigints", () => {
-  test("arbitrary arrays", () => {
-    const result = mean([] as Array<bigint>);
-    expectTypeOf(result).toEqualTypeOf<number | undefined>();
-  });
-
-  test("arbitrary readonly arrays", () => {
-    const result = mean([] as ReadonlyArray<bigint>);
-    expectTypeOf(result).toEqualTypeOf<number | undefined>();
-  });
-
-  test("arbitrary non-empty arrays", () => {
-    const result = mean([1n, 2n] as [bigint, ...Array<bigint>]);
-    expectTypeOf(result).toEqualTypeOf<bigint>();
-  });
-
-  test("consts", () => {
-    const result = mean([1n, 2n, 3n] as const);
-    expectTypeOf(result).toEqualTypeOf<bigint>();
-  });
-
-  test("fixed-size tuples", () => {
-    const result = mean([1n, 2n] as [bigint, bigint]);
-    expectTypeOf(result).toEqualTypeOf<bigint>();
-  });
-});
-
 describe("dataLast", () => {
   test("numbers", () => {
     const result = pipe([1, 2, 3] as const, mean());
     expectTypeOf(result).toEqualTypeOf<number>();
-  });
-
-  test("bigints", () => {
-    const result = pipe([1n, 2n, 3n] as const, mean());
-    expectTypeOf(result).toEqualTypeOf<bigint>();
   });
 
   test("arbitrary number arrays", () => {
@@ -80,16 +48,6 @@ describe("dataLast", () => {
 
   test("arbitrary readonly number arrays", () => {
     const result = pipe([] as ReadonlyArray<number>, mean());
-    expectTypeOf(result).toEqualTypeOf<number | undefined>();
-  });
-
-  test("arbitrary bigint arrays", () => {
-    const result = pipe([] as Array<bigint>, mean());
-    expectTypeOf(result).toEqualTypeOf<number | undefined>();
-  });
-
-  test("arbitrary readonly bigint arrays", () => {
-    const result = pipe([] as ReadonlyArray<bigint>, mean());
     expectTypeOf(result).toEqualTypeOf<number | undefined>();
   });
 });
@@ -108,9 +66,4 @@ describe("type-guards", () => {
       expectTypeOf(mean(data)).toEqualTypeOf<undefined>();
     }
   });
-});
-
-it("doesn't allow mixed arrays", () => {
-  // @ts-expect-error [ts2345] - Can't mean bigints and numbers...
-  mean([1, 2n]);
 });

--- a/src/mean.test-d.ts
+++ b/src/mean.test-d.ts
@@ -1,5 +1,3 @@
-import { hasAtLeast } from "./hasAtLeast";
-import { isEmpty } from "./isEmpty";
 import { mean } from "./mean";
 import { pipe } from "./pipe";
 
@@ -49,21 +47,5 @@ describe("dataLast", () => {
   test("arbitrary readonly number arrays", () => {
     const result = pipe([] as ReadonlyArray<number>, mean());
     expectTypeOf(result).toEqualTypeOf<number | undefined>();
-  });
-});
-
-describe("type-guards", () => {
-  it("narrows to `number` using `hasAtLeast`", () => {
-    const data = [] as Array<number>;
-    if (hasAtLeast(data, 1)) {
-      expectTypeOf(mean(data)).toEqualTypeOf<number>();
-    }
-  });
-
-  it("narrows to `undefined` using `isEmpty`", () => {
-    const data = [] as Array<number>;
-    if (isEmpty(data)) {
-      expectTypeOf(mean(data)).toEqualTypeOf<undefined>();
-    }
   });
 });

--- a/src/mean.test.ts
+++ b/src/mean.test.ts
@@ -10,11 +10,6 @@ describe("dataFirst", () => {
 
   it("should return undefined for an empty array", () => {
     expect(mean([])).toBeUndefined();
-    expect(mean([] as Array<bigint>)).toBeUndefined();
-  });
-
-  it("works on bigints", () => {
-    expect(mean([1n, 2n, 3n])).toBe(2n);
   });
 });
 
@@ -27,6 +22,5 @@ describe("dataLast", () => {
 
   it("should return undefined for an empty array", () => {
     expect(pipe([], mean())).toBeUndefined();
-    expect(pipe([] as Array<bigint>, mean())).toBeUndefined();
   });
 });

--- a/src/mean.ts
+++ b/src/mean.ts
@@ -1,25 +1,15 @@
-import type {
-  IterableContainer,
-  NonEmptyArray,
-  NonEmptyReadonlyArray,
-} from "./internal/types";
+import type { IterableContainer } from "./internal/types";
 import { purry } from "./purry";
 import { sum } from "./sum";
 
-type Mean<T extends IterableContainer<bigint> | IterableContainer<number>> =
-  T extends NonEmptyArray<bigint> | NonEmptyReadonlyArray<bigint>
-    ? bigint
-    : T extends NonEmptyArray<number> | NonEmptyReadonlyArray<number>
-      ? number
-      : T extends [] | readonly []
-        ? undefined
-        : number | undefined;
+type Mean<T extends IterableContainer<number>> =
+  | (T extends readonly [] ? never : number)
+  | (T extends readonly [unknown, ...Array<unknown>] ? never : undefined);
 
 /**
  * Returns the mean of the elements of an array.
  *
- * Works for both `number` and `bigint` arrays, but not arrays that contain both
- * types.
+ * Only `number` arrays are supported, as `bigint` is unable to represent fractional values.
  *
  * IMPORTANT: The result for empty arrays would be `undefined`, regardless of
  * the type of the array. This approach improves type-checking and ensures that
@@ -32,20 +22,16 @@ type Mean<T extends IterableContainer<bigint> | IterableContainer<number>> =
  *   R.mean(data);
  * @example
  *   R.mean([1, 2, 3]); // => 2
- *   R.mean([1n, 2n, 3n]); // => 2n
  *   R.mean([]); // => undefined
  * @dataFirst
  * @category Number
  */
-export function mean<
-  T extends IterableContainer<bigint> | IterableContainer<number>,
->(data: T): Mean<T>;
+export function mean<T extends IterableContainer<number>>(data: T): Mean<T>;
 
 /**
  * Returns the mean of the elements of an array.
  *
- * Works for both `number` and `bigint` arrays, but not arrays that contain both
- * types.
+ * Only `number` arrays are supported, as `bigint` is unable to represent fractional values.
  *
  * IMPORTANT: The result for empty arrays would be `undefined`, regardless of
  * the type of the array. This approach improves type-checking and ensures that
@@ -57,14 +43,11 @@ export function mean<
  *   R.mean()(data);
  * @example
  *   R.pipe([1, 2, 3], R.mean()); // => 2
- *   R.pipe([1n, 2n, 3n], R.mean()); // => 2n
  *   R.pipe([], R.mean()); // => undefined
  * @dataLast
  * @category Number
  */
-export function mean(): <
-  T extends IterableContainer<bigint> | IterableContainer<number>,
->(
+export function mean(): <T extends IterableContainer<number>>(
   data: T,
 ) => Mean<T>;
 
@@ -72,16 +55,12 @@ export function mean(...args: ReadonlyArray<unknown>): unknown {
   return purry(meanImplementation, args);
 }
 
-function meanImplementation<
-  T extends IterableContainer<bigint> | IterableContainer<number>,
->(data: T): T[number] | undefined {
+function meanImplementation<T extends IterableContainer<number>>(
+  data: T,
+): T[number] | undefined {
   if (data.length === 0) {
     return undefined;
   }
 
-  const dataSum = sum(data);
-
-  return typeof dataSum === "bigint"
-    ? dataSum / BigInt(data.length)
-    : dataSum / data.length;
+  return sum(data) / data.length;
 }


### PR DESCRIPTION
Related to #874, I have also integrated changes based on recent comments about `median` (e.g., removed type-guard related tests and modified the `Mean` type)

Please let me know if any additional adjustments are needed.
