### PR TITLE
docs: add mapping entry for Ramda's `pluck`

### DIFF
--- a/docs/src/content/mapping/ramda/__MISSING.md
+++ b/docs/src/content/mapping/ramda/__MISSING.md
@@ -67,7 +67,6 @@
 - move
 - none
 - pair
-- pluck
 - prepend
 - reduceBy
 - reduced

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -5,9 +5,7 @@ remeda: map
 
 _Not provided by Remeda._
 
-- `pluck(data, k)` is equivalent to `map(data, prop(k))`. `map` and `prop`
-  are available in Remeda so the same conversion is viable using these
-  functions.
+- `pluck(data, k)` is equivalent to `map(data, prop(k))`.
 
 - When data is an **object** (and not an _array_) use `mapValues` instead.
 

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -27,7 +27,7 @@ map(DATA, prop("val"));
 const DATA = { a: { val: "hello" }, b: { val: "world" } };
 
 // Ramda
-R.pluck("val", DATA); //=> { a: 3, b: 5 };
+R.pluck("val", DATA); //=> { a: "hello", b: "world" };
 
 // Remeda
 mapValues(DATA, prop("val"));

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -5,7 +5,7 @@ remeda: map
 
 _Not provided by Remeda._
 
-- `pluck(k, data)` is equivalent to `map(data, prop(k))`. `map` and `prop`
+- `pluck(data, k)` is equivalent to `map(data, prop(k))`. `map` and `prop`
   are available in Remeda so the same conversion is viable using these
   functions.
 

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -5,9 +5,9 @@ remeda: map
 
 _Not provided by Remeda._
 
-- The Ramda docs mention that `pluck(k, data)` is equivalent to
-  `R.map(R.prop(k), data)`. `map` and `prop` are available in Remeda so the same
-  conversion is viable using these functions.
+- `pluck(k, data)` is equivalent to `R.map(R.prop(k), data)`. `map` and `prop`
+  are available in Remeda so the same conversion is viable using these
+  functions.
 
 - When data is an **object** (and not an _array_) use `mapValues` instead.
 

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -5,7 +5,7 @@ remeda: map
 
 _Not provided by Remeda._
 
-- `pluck(k, data)` is equivalent to `R.map(R.prop(k), data)`. `map` and `prop`
+- `pluck(k, data)` is equivalent to `map(data, prop(k))`. `map` and `prop`
   are available in Remeda so the same conversion is viable using these
   functions.
 

--- a/docs/src/content/mapping/ramda/pluck.md
+++ b/docs/src/content/mapping/ramda/pluck.md
@@ -1,0 +1,36 @@
+---
+category: List
+remeda: map
+---
+
+_Not provided by Remeda._
+
+- The Ramda docs mention that `pluck(k, data)` is equivalent to
+  `R.map(R.prop(k), data)`. `map` and `prop` are available in Remeda so the same
+  conversion is viable using these functions.
+
+- When data is an **object** (and not an _array_) use `mapValues` instead.
+
+### Arrays
+
+```ts
+const DATA = [{ val: "hello" }, { val: "world" }];
+
+// Ramda
+R.pluck("val", DATA); //=> ["hello", "world"];
+
+// Remeda
+map(DATA, prop("val"));
+```
+
+### Objects
+
+```ts
+const DATA = { a: { val: "hello" }, b: { val: "world" } };
+
+// Ramda
+R.pluck("val", DATA); //=> { a: 3, b: 5 };
+
+// Remeda
+mapValues(DATA, prop("val"));
+```


### PR DESCRIPTION
`pluck` is our most popular missing search result after `throttle`.