### PR TITLE
fix(mergeDeep): Support interfaces

### DIFF
--- a/src/mergeDeep.test-d.ts
+++ b/src/mergeDeep.test-d.ts
@@ -1,49 +1,86 @@
 import { mergeDeep } from "./mergeDeep";
 
 it("trivially merges disjoint objects", () => {
-  const a = { foo: "bar" };
-  const b = { bar: "baz" };
-  const result = mergeDeep(a, b);
+  const result = mergeDeep(
+    { foo: "bar" } as { foo: string },
+    { bar: "baz" } as { bar: string },
+  );
   expectTypeOf(result).toEqualTypeOf<{ foo: string; bar: string }>();
 });
 
 it("merges fully overlapping types", () => {
-  const a = { foo: "bar" };
-  const b = { foo: "baz" };
-  const result = mergeDeep(a, b);
+  const result = mergeDeep(
+    { foo: "bar" } as { foo: string },
+    { foo: "baz" } as { foo: string },
+  );
   expectTypeOf(result).toEqualTypeOf<{ foo: string }>();
 });
 
 it("merges semi-overlapping types", () => {
-  const a = { foo: "bar", x: 1 };
-  const b = { foo: "baz", y: 2 };
-  const result = mergeDeep(a, b);
+  const result = mergeDeep(
+    { foo: "bar", x: 1 } as { foo: string; x: number },
+    { foo: "baz", y: 2 } as { foo: string; y: number },
+  );
   expectTypeOf(result).toEqualTypeOf<{ foo: string; x: number; y: number }>();
 });
 
 it("deeply merges", () => {
-  const a = { foo: { bar: "baz" } };
-  const b = { foo: { qux: "quux" } };
-  const result = mergeDeep(a, b);
+  const result = mergeDeep(
+    { foo: { bar: "bar" } } as { foo: { bar: string } },
+    { foo: { qux: "qux" } } as { foo: { qux: string } },
+  );
   expectTypeOf(result).toEqualTypeOf<{ foo: { bar: string; qux: string } }>();
 });
 
 it("overrides types", () => {
-  const a = { foo: { bar: "baz" } };
-  const b = { foo: "qux" };
-  expectTypeOf(mergeDeep(a, b)).toEqualTypeOf<typeof b>();
-  expectTypeOf(mergeDeep(b, a)).toEqualTypeOf<typeof a>();
+  const a = { foo: { bar: "baz" } } as { foo: { bar: string } };
+  const b = { foo: "qux" } as { foo: string };
+
+  const resultAB = mergeDeep(a, b);
+  expectTypeOf(resultAB).toEqualTypeOf<{ foo: string }>();
+
+  const resultBA = mergeDeep(b, a);
+  expectTypeOf(resultBA).toEqualTypeOf<{ foo: { bar: string } }>();
 });
 
 it("doesn't spread arrays", () => {
-  const a = { foo: ["bar"] as const };
-  const b = { foo: ["baz"] as const };
-  const result = mergeDeep(a, b);
-  expectTypeOf(result).toEqualTypeOf<{ foo: readonly ["baz"] }>();
+  const result = mergeDeep(
+    { foo: ["bar"] } as const,
+    { foo: ["baz"] } as const,
+  );
+  expectTypeOf(result).toEqualTypeOf<{ readonly foo: readonly ["baz"] }>();
 });
 
 it("doesn't recurse into arrays", () => {
-  const a = { foo: [{ bar: "baz" }] };
-  const b = { foo: [{ bar: "hello, world" }] };
-  expectTypeOf(mergeDeep(a, b)).toEqualTypeOf<typeof b>();
+  const result = mergeDeep(
+    { foo: [{ bar: "baz", x: 123 }] } as {
+      foo: Array<{ bar: string; x: number }>;
+    },
+    { foo: [{ bar: "hello, world", y: 456 }] } as {
+      foo: Array<{ bar: string; y: number }>;
+    },
+  );
+  expectTypeOf(result).toEqualTypeOf<{
+    foo: Array<{ bar: string; y: number }>;
+  }>();
+});
+
+it("works with interfaces", () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Intentional
+  interface Foo {
+    a: string;
+    b: number;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Intentional
+  interface Bar {
+    a: string;
+    c: boolean;
+  }
+
+  const result = mergeDeep(
+    { a: "foo", b: 123 } as Foo,
+    { a: "bar", c: true } as Bar,
+  );
+  expectTypeOf(result).toEqualTypeOf<{ a: string; b: number; c: boolean }>();
 });

--- a/src/mergeDeep.ts
+++ b/src/mergeDeep.ts
@@ -15,10 +15,10 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Object
  */
-export function mergeDeep<
-  Destination extends Record<string, unknown>,
-  Source extends Record<string, unknown>,
->(destination: Destination, source: Source): MergeDeep<Destination, Source>;
+export function mergeDeep<Destination extends object, Source extends object>(
+  destination: Destination,
+  source: Source,
+): MergeDeep<Destination, Source>;
 
 /**
  * Merges the `source` object into the `destination` object. The merge is similar to performing `{ ...destination, ... source }` (where disjoint values from each object would be copied as-is, and for any overlapping props the value from `source` would be used); But for *each prop* (`p`), if **both** `destination` and `source` have a **plain-object** as a value, the value would be taken as the result of recursively deepMerging them (`result.p === deepMerge(destination.p, source.p)`).
@@ -35,18 +35,19 @@ export function mergeDeep<
  * @dataLast
  * @category Object
  */
-export function mergeDeep<
-  Destination extends Record<string, unknown>,
-  Source extends Record<string, unknown>,
->(source: Source): (target: Destination) => MergeDeep<Destination, Source>;
+export function mergeDeep<Source extends object>(
+  source: Source,
+): <Destination extends object>(
+  target: Destination,
+) => MergeDeep<Destination, Source>;
 
 export function mergeDeep(...args: ReadonlyArray<unknown>): unknown {
   return purry(mergeDeepImplementation, args);
 }
 
 function mergeDeepImplementation<
-  Destination extends Record<string, unknown>,
-  Source extends Record<string, unknown>,
+  Destination extends object,
+  Source extends object,
 >(destination: Destination, source: Source): MergeDeep<Destination, Source> {
   // At this point the output is already merged, simply not deeply merged.
   const output = { ...destination, ...source } as Record<


### PR DESCRIPTION
Fixes #522.

We don't have a lot of type tests so I don't feel very confident about this change, but I can't think of a specific thing I expect to break with this change. The only reason record was used was because that was easy to understand, as long as the runtime doesn't complain about the lack of data coming from `object` (vs `Record`) than it's unlikely the types themselves break.

And we rely on type-fest for the heavy lifting; they probably handle interfaces well...