### PR TITLE
(fix) Added keys and values to export type

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -4,7 +4,7 @@ import type {
 } from "./internal/types";
 import { purry } from "./purry";
 
-type Keys<T> = T extends IterableContainer ? ArrayKeys<T> : ObjectKeys<T>;
+export type Keys<T> = T extends IterableContainer ? ArrayKeys<T> : ObjectKeys<T>;
 
 // The keys output can mirror the input when it is an array/tuple. We do this by
 // "mapping" each item "key" (which is actually an index) as its own value. This

--- a/src/values.ts
+++ b/src/values.ts
@@ -4,7 +4,7 @@ import type {
 } from "./internal/types";
 import { purry } from "./purry";
 
-type Values<T extends object> = T extends IterableContainer
+export type Values<T extends object> = T extends IterableContainer
   ? Array<T[number]>
   : Array<EnumerableStringKeyedValueOf<T>>;
 


### PR DESCRIPTION
Added key and value to export. When upgrading to TS 5.6, the typechecker complains this type cannot be inferenced

```
 error TS2742: The inferred type of 'typedKeys' cannot be named without a reference to '../../../../node_modules/remeda/dist/types-B6Nc-8hG'. This is likely not portable. A type annotation is necessary.
 ```

yarn patching it to export fixed the problem, pushing the fix upstream
