### PR TITLE
fix(split): split on literal unions with separator as a prefix

### DIFF
--- a/src/split.test-d.ts
+++ b/src/split.test-d.ts
@@ -99,3 +99,8 @@ test("0 limit", () => {
   const result = split("a,b,c", ",", 0);
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
+
+test("optional prefix separator on literal unions (issue: #921)", () => {
+  const result = split("a" as "a" | "-a", "-");
+  expectTypeOf(result).toEqualTypeOf<["a"] | ["", "a"]>();
+});

--- a/src/split.ts
+++ b/src/split.ts
@@ -5,29 +5,27 @@ import type {
   Split as SplitBase,
 } from "type-fest";
 
+// We can use the type-fest's split **only** if all the params are literals.
+// For all other cases it would return the wrong type so we use
+// `Array.prototype.split`s return type instead.
+type BuiltInReturnType = ReturnType<typeof String.prototype.split>;
+
 type Split<
   S extends string,
   Separator extends string,
   N extends number | undefined = undefined,
 > = string extends S
-  ? Array<string>
+  ? BuiltInReturnType
   : string extends Separator
-    ? Array<string>
+    ? BuiltInReturnType
     : number extends N
-      ? Array<string>
+      ? BuiltInReturnType
       : // TODO: We need a way to "floor" non-integer numbers, until then we return a lower fidelity type instead.
         IsFloat<N> extends true
-        ? Array<string>
-        : ArraySlice<
-            // We can use the base (type-fest) split **only** if all the params
-            // are literals. For all other cases it would return the wrong type
-            // so we fallback to the built-in Array.prototype.split return type.
-            SplitBase<S, Separator>,
-            0,
-            // `undefined` and negative numbers are treated as non-limited
-            // splits, which is what we'd get when using `never` for ArraySlice.
-            N extends number ? NonNegative<N> : never
-          >;
+        ? BuiltInReturnType
+        : N extends number
+          ? ArraySlice<SplitBase<S, Separator>, 0, NonNegative<N>>
+          : SplitBase<S, Separator>;
 
 /**
  * Takes a pattern and divides this string into an ordered list of substrings by


### PR DESCRIPTION
A problem in type-fest's ArraySlice causes the issue (https://github.com/sindresorhus/type-fest/issues/982) but could be avoided in most cases by avoiding using ArraySlice when not needed.

This is a patch, and the problem would still exist when the optional limit param is used, but for the vast majority of usages of this utility, it should be enough to reduce the surface area of the issue, giving time for the issue to be resolved on the type-fest side.

Closes: #921