### PR TITLE
fix(pick): support optional keys

### DIFF
--- a/src/internal/types/TupleParts.test-d.ts
+++ b/src/internal/types/TupleParts.test-d.ts
@@ -8,6 +8,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: never;
       suffix: [];
     }>();
@@ -18,6 +20,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: number;
       suffix: [];
     }>();
@@ -28,6 +32,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [1, 2, 3];
+      required: [1, 2, 3];
+      optional: [];
       item: never;
       suffix: [];
     }>();
@@ -38,6 +44,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [string];
+      required: [string];
+      optional: [];
       item: boolean;
       suffix: [];
     }>();
@@ -48,6 +56,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: boolean;
       suffix: [string];
     }>();
@@ -58,6 +68,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [number];
+      required: [number];
+      optional: [];
       item: boolean;
       suffix: [string];
     }>();
@@ -68,6 +80,8 @@ describe("mutable", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [number, string?, number?];
+      required: [number];
+      optional: [string, number];
       item: boolean;
       suffix: [];
     }>();
@@ -80,6 +94,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: never;
       suffix: [];
     }>();
@@ -90,6 +106,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: number;
       suffix: [];
     }>();
@@ -100,6 +118,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [1, 2, 3];
+      required: [1, 2, 3];
+      optional: [];
       item: never;
       suffix: [];
     }>();
@@ -110,6 +130,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [string];
+      required: [string];
+      optional: [];
       item: boolean;
       suffix: [];
     }>();
@@ -120,6 +142,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [];
+      required: [];
+      optional: [];
       item: boolean;
       suffix: [string];
     }>();
@@ -130,6 +154,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [number];
+      required: [number];
+      optional: [];
       item: boolean;
       suffix: [string];
     }>();
@@ -145,6 +171,8 @@ describe("readonly", () => {
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<{
       prefix: [number, string?, number?];
+      required: [number];
+      optional: [string, number];
       item: boolean;
       suffix: [];
     }>();
@@ -156,8 +184,8 @@ describe("unions", () => {
     const data = [] as Array<boolean> | Array<number>;
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<
-      | { prefix: []; item: boolean; suffix: [] }
-      | { prefix: []; item: number; suffix: [] }
+      | { prefix: []; required: []; optional: []; item: boolean; suffix: [] }
+      | { prefix: []; required: []; optional: []; item: number; suffix: [] }
     >();
   });
 
@@ -165,8 +193,14 @@ describe("unions", () => {
     const data = [] as Array<boolean> | [number, string];
     const result = tupleParts(data);
     expectTypeOf(result).toEqualTypeOf<
-      | { prefix: []; item: boolean; suffix: [] }
-      | { prefix: [number, string]; item: never; suffix: [] }
+      | { prefix: []; required: []; optional: []; item: boolean; suffix: [] }
+      | {
+          prefix: [number, string];
+          required: [number, string];
+          optional: [];
+          item: never;
+          suffix: [];
+        }
     >();
   });
 });

--- a/src/internal/types/TupleParts.ts
+++ b/src/internal/types/TupleParts.ts
@@ -8,9 +8,9 @@ import type { IsEqual } from "type-fest";
  *
  * NOTE: The prefix is split into 2 tuples where all items are non-optional so
  * that types that rely on the presence of a specific element can be built more
- * accurately. For backwards compatibility, the `prefix` accessor which hides
- * some of this complexity is also provided (but we might deprecate it in the
- * future).
+ * accurately.
+ *
+ * TODO: Some existing types use the `prefix` accessor which doesn't handle the optional part correctly. We need to fix each of those types before we can remove it.
  *
  * The output could be used to reconstruct the input: `[
  *   ...TupleParts<T>["required"],

--- a/src/internal/types/TupleParts.ts
+++ b/src/internal/types/TupleParts.ts
@@ -2,37 +2,53 @@ import type { IsEqual } from "type-fest";
 
 /**
  * Takes an array and returns the types that make up its parts. The prefix is
- * anything before the rest parameter (if any), the suffix is anything after
- * the rest parameter (if any), and the item is the type of the rest parameter.
+ * anything before the rest parameter (if any), split between it's required
+ * part, and it's optional part. The suffix is anything after the rest
+ * parameter (if any), and the item is the type of the rest parameter.
+ *
+ * NOTE: The prefix is split into 2 tuples where all items are non-optional so
+ * that types that rely on the presence of a specific element can be built more
+ * accurately. For backwards compatibility, the `prefix` accessor which hides
+ * some of this complexity is also provided (but we might deprecate it in the
+ * future).
  *
  * The output could be used to reconstruct the input: `[
- *   ...TupleParts<T>["prefix"],
- *   ...Array<TupleParts<T>["item"]>,
+ *   ...TupleParts<T>["required"],
+ *   ...Partial<TupleParts<T>["optional"]>,
+ *   ...CoercedArray<TupleParts<T>["item"]>,
  *   ...TupleParts<T>["suffix"],
  * ]`.
  */
 export type TupleParts<
   T,
-  Prefix extends Array<unknown> = [],
+  PrefixRequired extends Array<unknown> = [],
+  PrefixOptionals extends Array<unknown> = [],
   Suffix extends Array<unknown> = [],
 > = T extends readonly [infer Head, ...infer Tail]
-  ? TupleParts<Tail, [...Prefix, Head], Suffix>
+  ? TupleParts<Tail, [...PrefixRequired, Head], PrefixOptionals, Suffix>
   : T extends readonly [...infer Head, infer Tail]
-    ? TupleParts<Head, Prefix, [Tail, ...Suffix]>
+    ? TupleParts<Head, PrefixRequired, PrefixOptionals, [Tail, ...Suffix]>
     : // We need to distinguish between e.g. [number? ...Array<string>] and
       // Array<number | string>.
-      IsTupleRestOnly<T> extends false
-      ? // This is the [number? ...Array<string>] case.
-        T extends readonly [(infer MaybeHead)?, ...infer Tail]
-        ? TupleParts<Tail, [...Prefix, MaybeHead?], Suffix>
-        : never
-      : // This is the Array<number | string> case.
+      IsTupleRestOnly<T> extends true
+      ? // This is the Array<number | string> case.
         T extends ReadonlyArray<infer Item>
         ? {
-            prefix: Prefix;
+            prefix: [...PrefixRequired, ...Partial<PrefixOptionals>];
+            required: PrefixRequired;
+            optional: PrefixOptionals;
             item: Item;
             suffix: Suffix;
           }
+        : never
+      : // This is the [number? ...Array<string>] case.
+        T extends readonly [(infer OptionalHead)?, ...infer Tail]
+        ? TupleParts<
+            Tail,
+            PrefixRequired,
+            [...PrefixOptionals, OptionalHead],
+            Suffix
+          >
         : never;
 
 /**

--- a/src/pick.test-d.ts
+++ b/src/pick.test-d.ts
@@ -16,8 +16,7 @@ describe("data first", () => {
     >();
   });
 
-  // @see https://github.com/remeda/remeda/issues/886
-  it("infers the key types from the keys array", () => {
+  it("infers the key types from the keys array (issue #886)", () => {
     const data = { foo: "hello", bar: "world" };
 
     const raw = pick(data, ["foo"]);
@@ -28,6 +27,15 @@ describe("data first", () => {
 
     const withConstKeys = keys(pick(data, ["foo"] as const));
     expectTypeOf(withConstKeys).toEqualTypeOf<Array<"foo">>();
+  });
+
+  it("handles optional keys (issue #911)", () => {
+    const data = { foo: "hello", bar: "world" } as const;
+    const result = pick(data, [] as Array<keyof typeof data>);
+    expectTypeOf(result).toEqualTypeOf<{
+      readonly foo?: "hello";
+      readonly bar?: "world";
+    }>();
   });
 });
 


### PR DESCRIPTION
Expanding our TupleParts utility to allow easy access to the optional part of the prefix, and then using this to improve the type of pick so that optional keys are marked as optional in the output.

Closes: #911