### PR TITLE
fix(toSnakeCase, toKebabCase): literal types for literal strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^4.26.1"
+        "type-fest": "^4.27.0"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.4",
@@ -10903,9 +10903,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.27.0.tgz",
+      "integrity": "sha512-3IMSWgP7C5KSQqmo1wjhKrwsvXAtF33jO3QY+Uy++ia7hqvgSK6iXbbg5PbDBc1P2ZbNEDgejOrN4YooXvhwCw==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:typing": "vitest --typecheck.only --typecheck.ignoreSourceErrors"
   },
   "dependencies": {
-    "type-fest": "^4.26.1"
+    "type-fest": "^4.27.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.16.4",

--- a/src/internal/words.test.ts
+++ b/src/internal/words.test.ts
@@ -1,4 +1,4 @@
-import { splitWords } from "./splitWords";
+import { words } from "./words";
 
 describe("copied from the type-fest tests", () => {
   test.each([
@@ -66,7 +66,7 @@ describe("copied from the type-fest tests", () => {
     { input: "BBBBa", output: ["BBB", "Ba"] },
     { input: "BBBBB", output: ["BBBBB"] },
   ])("case changes: $input", ({ input, output }) => {
-    expect(splitWords(input)).toStrictEqual(output);
+    expect(words(input)).toStrictEqual(output);
   });
 
   test.each([
@@ -92,7 +92,7 @@ describe("copied from the type-fest tests", () => {
     { input: "hello WORLD-lowercase", output: ["hello", "WORLD", "lowercase"] },
     { input: "hello WORLD Uppercase", output: ["hello", "WORLD", "Uppercase"] },
   ])("white spaces: $input", ({ input, output }) => {
-    expect(splitWords(input)).toStrictEqual(output);
+    expect(words(input)).toStrictEqual(output);
   });
 
   test.each([
@@ -109,6 +109,6 @@ describe("copied from the type-fest tests", () => {
       output: ["item", "0", "item", "1", "item", "2"],
     },
   ])("digits: $input", ({ input, output }) => {
-    expect(splitWords(input)).toStrictEqual(output);
+    expect(words(input)).toStrictEqual(output);
   });
 });

--- a/src/internal/words.ts
+++ b/src/internal/words.ts
@@ -1,3 +1,5 @@
+import type { Words } from "type-fest";
+
 // @see https://github.com/sindresorhus/type-fest/blob/main/source/internal/characters.d.ts#L5-L31
 const WHITESPACE = [
   "\u{9}", // '\t'
@@ -51,5 +53,8 @@ const WORD_SPLITTING_RE = new RegExp(
   "u",
 );
 
-export const splitWords = (data: string): Array<string> =>
+export const words = <S extends string>(
+  data: S,
+): string extends S ? Array<string> : Words<S> =>
+  // @ts-expect-error [ts2322] -- TypeScript can't infer this type...
   data.split(WORD_SPLITTING_RE).filter(({ length }) => length > 0);

--- a/src/toCamelCase.ts
+++ b/src/toCamelCase.ts
@@ -1,5 +1,5 @@
 import type { CamelCase } from "type-fest";
-import { splitWords } from "./internal/splitWords";
+import { words } from "./internal/words";
 
 const LOWER_CASE_CHARACTER_RE = /[a-z]/u;
 
@@ -94,7 +94,7 @@ const toCamelCaseImplementation = (
     preserveConsecutiveUppercase = DEFAULT_OPTIONS.preserveConsecutiveUppercase,
   }: CamelCaseOptions = {},
 ): string =>
-  splitWords(
+  words(
     LOWER_CASE_CHARACTER_RE.test(data)
       ? data
       : // If the text doesn't have **any** lower case characters we also lower

--- a/src/toKebabCase.test-d.ts
+++ b/src/toKebabCase.test-d.ts
@@ -1,0 +1,57 @@
+import { expectTypeOf } from "expect-type";
+import { toKebabCase } from "./toKebabCase";
+
+test("primitive string", () => {
+  const result = toKebabCase("hello world" as string);
+  expectTypeOf(result).toEqualTypeOf<string>();
+});
+
+test("empty string", () => {
+  const result = toKebabCase("" as const);
+  expectTypeOf(result).toEqualTypeOf<"">();
+});
+
+test("camelCase", () => {
+  const result = toKebabCase("helloWorld" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("spaces and mixed cases", () => {
+  const result = toKebabCase("Hello World" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("spaces and lower case", () => {
+  const result = toKebabCase("hello world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("spaces and UPPERCASE", () => {
+  const result = toKebabCase("HELLO WORLD" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("snake_case", () => {
+  const result = toKebabCase("hello_world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("kebab-case", () => {
+  const result = toKebabCase("hello-world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world">();
+});
+
+test("string with multiple delimiters", () => {
+  const result = toKebabCase("foo---bar" as const);
+  expectTypeOf(result).toEqualTypeOf<"foo-bar">();
+});
+
+test("numbers", () => {
+  const result = toKebabCase("helloWorld123" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-world-123">();
+});
+
+test("string with special characters", () => {
+  const result = toKebabCase("hello@world!" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello-@world-!">();
+});

--- a/src/toKebabCase.ts
+++ b/src/toKebabCase.ts
@@ -1,5 +1,10 @@
-import { splitWords } from "./internal/splitWords";
+import type { Join, Words } from "type-fest";
+import { words } from "./internal/words";
 import { purry } from "./purry";
+
+type KebabCase<S extends string> = string extends S
+  ? string
+  : Lowercase<Join<Words<S>, "-">>;
 
 /**
  * Convert a text to kebab-Case by splitting it into words and joining them back
@@ -19,7 +24,7 @@ import { purry } from "./purry";
  * @dataFirst
  * @category String
  */
-export function toKebabCase(data: string): string;
+export function toKebabCase<S extends string>(data: S): KebabCase<S>;
 
 /**
  * Convert a text to kebabCase by splitting it into words and joining them back
@@ -38,11 +43,15 @@ export function toKebabCase(data: string): string;
  * @dataLast
  * @category String
  */
-export function toKebabCase(): (data: string) => string;
+export function toKebabCase(): <S extends string>(data: S) => KebabCase<S>;
 
 export function toKebabCase(...args: ReadonlyArray<unknown>): unknown {
   return purry(toKebabCaseImplementation, args);
 }
 
-const toKebabCaseImplementation = (data: string): string =>
-  splitWords(data).join("-").toLowerCase();
+const toKebabCaseImplementation = <S extends string>(data: S): KebabCase<S> =>
+  // @ts-expect-error [ts2322] -- To avoid importing our own utilities for this
+  // we are using the built-in `join` and `toLowerCase` functions which aren't
+  // typed as well. This is equivalent to `toLowerCase(join(words(data), "-"))`
+  // which TypeScript infers correctly as KebabCase.
+  words(data).join("-").toLowerCase();

--- a/src/toSnakeCase.test-d.ts
+++ b/src/toSnakeCase.test-d.ts
@@ -1,0 +1,57 @@
+import { expectTypeOf } from "expect-type";
+import { toSnakeCase } from "./toSnakeCase";
+
+test("primitive string", () => {
+  const result = toSnakeCase("hello world" as string);
+  expectTypeOf(result).toEqualTypeOf<string>();
+});
+
+test("empty string", () => {
+  const result = toSnakeCase("" as const);
+  expectTypeOf(result).toEqualTypeOf<"">();
+});
+
+test("camelCase", () => {
+  const result = toSnakeCase("helloWorld" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("spaces and mixed cases", () => {
+  const result = toSnakeCase("Hello World" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("spaces and lower case", () => {
+  const result = toSnakeCase("hello world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("spaces and UPPERCASE", () => {
+  const result = toSnakeCase("HELLO WORLD" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("snake_case", () => {
+  const result = toSnakeCase("hello_world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("kebab-case", () => {
+  const result = toSnakeCase("hello-world" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world">();
+});
+
+test("string with multiple delimiters", () => {
+  const result = toSnakeCase("foo___bar" as const);
+  expectTypeOf(result).toEqualTypeOf<"foo_bar">();
+});
+
+test("numbers", () => {
+  const result = toSnakeCase("helloWorld123" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_world_123">();
+});
+
+test("string with special characters", () => {
+  const result = toSnakeCase("hello@world!" as const);
+  expectTypeOf(result).toEqualTypeOf<"hello_@world_!">();
+});

--- a/src/toSnakeCase.ts
+++ b/src/toSnakeCase.ts
@@ -1,5 +1,10 @@
-import { splitWords } from "./internal/splitWords";
+import type { Join, Words } from "type-fest";
+import { words } from "./internal/words";
 import { purry } from "./purry";
+
+type SnakeCase<S extends string> = string extends S
+  ? string
+  : Lowercase<Join<Words<S>, "_">>;
 
 /**
  * Convert a text to snake-case by splitting it into words and joining them back
@@ -19,7 +24,7 @@ import { purry } from "./purry";
  * @dataFirst
  * @category String
  */
-export function toSnakeCase(data: string): string;
+export function toSnakeCase<S extends string>(data: S): SnakeCase<S>;
 
 /**
  * Convert a text to snake-case by splitting it into words and joining them back
@@ -38,11 +43,15 @@ export function toSnakeCase(data: string): string;
  * @dataLast
  * @category String
  */
-export function toSnakeCase(): (data: string) => string;
+export function toSnakeCase(): <S extends string>(data: S) => SnakeCase<S>;
 
 export function toSnakeCase(...args: ReadonlyArray<unknown>): unknown {
   return purry(toSnakeCaseImplementation, args);
 }
 
-const toSnakeCaseImplementation = (data: string): string =>
-  splitWords(data).join("_").toLowerCase();
+const toSnakeCaseImplementation = <S extends string>(data: S): SnakeCase<S> =>
+  // @ts-expect-error [ts2322] -- To avoid importing our own utilities for this
+  // we are using the built-in `join` and `toLowerCase` functions which aren't
+  // typed as well. This is equivalent to `toLowerCase(join(words(data), "_"))`
+  // which TypeScript infers correctly as KebabCase.
+  words(data).join("_").toLowerCase();

--- a/src/toSnakeCase.ts
+++ b/src/toSnakeCase.ts
@@ -53,5 +53,5 @@ const toSnakeCaseImplementation = <S extends string>(data: S): SnakeCase<S> =>
   // @ts-expect-error [ts2322] -- To avoid importing our own utilities for this
   // we are using the built-in `join` and `toLowerCase` functions which aren't
   // typed as well. This is equivalent to `toLowerCase(join(words(data), "_"))`
-  // which TypeScript infers correctly as KebabCase.
+  // which TypeScript infers correctly as SnakeCase.
   words(data).join("_").toLowerCase();


### PR DESCRIPTION
Using the now exported `Words` utility from type-fest we can improve the typing for snake-case and kebab-case to take advantage of it.