### PR TITLE
docs: correct docstring for stringToPath

### DIFF
--- a/src/stringToPath.ts
+++ b/src/stringToPath.ts
@@ -22,8 +22,8 @@ type StringToPath<T extends string> = string extends T
  * access" functions like `pathOr` or `setPath`.
  *
  * @param path - A string path.
- * @signature R.stringToPathArray(path)
- * @example R.stringToPathArray('a.b[0].c') // => ['a', 'b', '0', 'c']
+ * @signature R.stringToPath(path)
+ * @example R.stringToPath('a.b[0].c') // => ['a', 'b', '0', 'c']
  * @dataFirst
  * @category Utility
  */


### PR DESCRIPTION
> Fix bad docstring for `stringToPath`

These seemingly reflected an old name for the function.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
