### PR TITLE
docs(just): Add a stub for migration guides from 'just'

### DIFF
--- a/docs/src/content/mapping/just/__MISSING.md
+++ b/docs/src/content/mapping/just/__MISSING.md
@@ -2,7 +2,8 @@ Just is built into individual packages for each util. This makes it easier to
 know which functions people actually use and which aren't. Below is the list of
 all functions as listed in the just docs, with a priority number in parenthesis
 based on the number of monthly downloads based on: https://www.npmjs.com/search?page=0&q=keywords%3Ajust&sortBy=downloads_monthly&perPage=100. Use this number when deciding what parts of Just need a migration
-guide or need to be implemented in Remeda.
+guide or need to be implemented in Remeda. Utilities without a number have a
+priority of 40+ and are not widely used.
 
 # Collections
 

--- a/docs/src/content/mapping/just/__MISSING.md
+++ b/docs/src/content/mapping/just/__MISSING.md
@@ -1,0 +1,109 @@
+Just is built into individual packages for each util. This makes it easier to
+know which functions people actually use and which aren't. Below is the list of
+all functions as listed in the just docs, with a priority number in parenthesis
+based on the number of monthly downloads based on: https://www.npmjs.com/search?page=0&q=keywords%3Ajust&sortBy=downloads_monthly&perPage=100. Use this number when deciding what parts of Just need a migration
+guide or need to be implemented in Remeda.
+
+# Collections
+
+- clone (5)
+- compare (8)
+- diff (2)
+- diff-apply (3)
+- flush (23)
+- pluck-it
+
+# Objects
+
+- deep-map-values (34)
+- entries
+- extend (1)
+- filter-object
+- flip-object
+- has (38)
+- is-circular
+- is-empty (15)
+- is-primitive
+- map-keys (39)
+- map-object
+- map-values (17)
+- merge (25)
+- omit (14)
+- pick (9)
+- reduce-object (30)
+- safe-get (13)
+- safe-set (18)
+- typeof (33)
+- values
+
+# Arrays
+
+- cartesian-product
+- compact
+- flatten-it (36)
+- group-by (20)
+- index
+- insert
+- intersect (29)
+- last
+- order-by (35)
+- partition
+- permutations
+- random
+- range (16)
+- remove (31)
+- shuffle
+- sort-by (32)
+- split (19)
+- split-at
+- tail
+- union (40)
+- unique (11)
+- zip-it (24)
+
+# Statistics
+
+- mean
+- median
+- mode
+- percentile
+- skewness
+- standard-deviation
+- variance
+
+# Strings
+
+- camel-case (7)
+- capitalize (27)
+- kebab-case (10)
+- left-pad
+- pascal-case (21)
+- prune
+- replace-all
+- right-pad
+- snake-case (22)
+- squash
+- template
+- truncate
+
+# Numbers
+
+- clamp
+- in-range
+- is-prime
+- modulo
+- random-integer
+
+# Functions
+
+- compose (37)
+- curry-it (4)
+- debounce-it (6)
+- demethodize
+- flip
+- memoize (26)
+- memoize-last
+- once (28)
+- partial-it
+- pipe
+- throttle (12)

--- a/docs/src/content/mapping/just/__MISSING.md
+++ b/docs/src/content/mapping/just/__MISSING.md
@@ -18,7 +18,6 @@ priority of 40+ and are not widely used.
 
 - deep-map-values (34)
 - entries
-- extend (1)
 - filter-object
 - flip-object
 - has (38)

--- a/docs/src/content/mapping/just/extend.md
+++ b/docs/src/content/mapping/just/extend.md
@@ -1,0 +1,73 @@
+---
+category: Objects
+remeda: merge
+---
+
+- Just's `extend` performs an in-place merge, mutating the first argument, but
+  in Remeda functions never mutate the arguments. Because of this extra care
+  is needed when migrating.
+- If you have the `deep` flag enabled use Remeda's [`mergeDeep`](/docs/#mergeDeep)
+  instead.
+- There is no equivalent function for merging of arrays. Extending arrays is
+  only relevant for [sparse arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays)
+  which are uncommon. For regular arrays `extend` is similar to [`splice`](/docs/#splice).
+- If you are merging more than two objects, use [`mergeAll`](/docs/#mergeAll)
+  which takes an array of objects to merge. Notice that this merge is shallow;
+  there is no equivalent function in Remeda which would perform a deep merge of
+  multiple objects.
+
+### New object
+
+```ts
+// Just
+const result = extend({}, a, b);
+
+// Remeda
+const result = merge(a, b);
+```
+
+### Replace
+
+```ts
+// Just
+const DATA = { ... };
+extend(DATA, b);
+
+// Remeda
+let DATA = { ... };
+DATA = merge(DATA, b);
+```
+
+### Deep
+
+```ts
+// Just
+extend(true /* deep */, a, b);
+
+// Remeda
+mergeDeep(a, b);
+```
+
+### Arrays
+
+```ts
+// Just
+const DATA = [...];
+extend(DATA, b);
+
+// Remeda
+let DATA = [...];
+DATA = splice(DATA, 0 /* start */, b.length /* deleteCount */, b /* replacement */);
+```
+
+### Multiple objects
+
+```ts
+// Just
+const DATA = { ... };
+extend(DATA, b, c, d);
+
+// Remeda
+let DATA = { ... };
+DATA = mergeDeep([DATA, b, c, d]);
+```

--- a/docs/src/content/mapping/just/extend.md
+++ b/docs/src/content/mapping/just/extend.md
@@ -3,11 +3,12 @@ category: Objects
 remeda: merge
 ---
 
-- Just's `extend` performs an in-place merge, mutating the first argument, but
-  in Remeda functions never mutate the arguments. Because of this extra care
-  is needed when migrating.
+- Just's `extend` performs an **in-place** merge which mutates the first
+  argument. Remeda functions never mutate the arguments. Because of this extra
+  care is needed when migrating.
 - If you have the `deep` flag enabled use Remeda's [`mergeDeep`](/docs/#mergeDeep)
-  instead.
+  instead. Arrays are **not** merged deeply in Remeda, unlike `extend` which
+  clones arrays.
 - There is no equivalent function for merging of arrays. Extending arrays is
   only relevant for [sparse arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays)
   which are uncommon. For regular arrays `extend` is similar to [`splice`](/docs/#splice).

--- a/docs/src/lib/mappings.ts
+++ b/docs/src/lib/mappings.ts
@@ -66,5 +66,8 @@ export function mappingUrl(library: Library, name: string): string {
 
     case "ramda":
       return `https://ramdajs.com/docs/#${name}`;
+
+    case "just":
+      return `https://anguscroll.com/just/just-${name}`;
   }
 }


### PR DESCRIPTION
Just is the biggest utility library after Lodash, Underscore and Ramda.