### PR TITLE
fix(uniqueWith): return items that are not equal to themselves

### DIFF
--- a/src/uniqueWith.test.ts
+++ b/src/uniqueWith.test.ts
@@ -20,7 +20,7 @@ describe("data_first", () => {
     expect(uniqueWith(source, isDeepEqual)).toStrictEqual(expected);
   });
 
-  it("should return all unequivalent items respective to their identities", () => {
+  it("should return items that are not equal to themselves", () => {
     // test case based on https://github.com/remeda/remeda/issues/999
     const data = [
       { id: 1, reason: "No name" },

--- a/src/uniqueWith.test.ts
+++ b/src/uniqueWith.test.ts
@@ -19,6 +19,31 @@ describe("data_first", () => {
   test("should return uniq", () => {
     expect(uniqueWith(source, isDeepEqual)).toStrictEqual(expected);
   });
+
+  it("should return all unequivalent items respective to their identities", () => {
+    // test case based on https://github.com/remeda/remeda/issues/999
+    const data = [
+      { id: 1, reason: "No name" },
+      { id: 1, reason: "No name" },
+      { reason: "No name" },
+      { reason: "No name" },
+    ];
+    const expectedResult = [
+      { id: 1, reason: "No name" },
+      { reason: "No name" },
+      { reason: "No name" },
+    ];
+
+    const result = uniqueWith(data, (errorA, errorB) => {
+      // the objects with no ids should effectively be ignored from removal of duplicates
+      if (errorA.id === undefined || errorB.id === undefined) {
+        return false;
+      }
+      return errorA.id === errorB.id;
+    });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
 });
 
 describe("data_last", () => {

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -58,11 +58,15 @@ export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
 const lazyImplementation =
   <T>(isEquals: IsEquals<T>): LazyEvaluator<T> =>
   (value, index, data) => {
-    const res = data.findIndex((otherValue) => isEquals(value, otherValue));
-    if (res === -1) {
+    const otherIndex = data.findIndex((otherValue) =>
+      isEquals(value, otherValue),
+    );
+    // if there are no other matches, leave the result in.
+    if (otherIndex === -1) {
       return { done: false, hasNext: true, next: value };
     }
-    return res === index
+    // skip items that have a match at a different index.
+    return otherIndex === index
       ? { done: false, hasNext: true, next: value }
       : SKIP_ITEM;
   };

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -58,15 +58,16 @@ export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
 const lazyImplementation =
   <T>(isEquals: IsEquals<T>): LazyEvaluator<T> =>
   (value, index, data) => {
-    const otherIndex = data.findIndex((otherValue) =>
-      isEquals(value, otherValue),
+    const firstEqualIndex = data.findIndex(
+      (otherValue, otherIndex) =>
+        index === otherIndex || isEquals(value, otherValue),
     );
     // if there are no other matches, leave the result in.
-    if (otherIndex === -1) {
+    if (firstEqualIndex === -1) {
       return { done: false, hasNext: true, next: value };
     }
-    // skip items that have a match at a different index.
-    return otherIndex === index
+    // skip items that aren't at the first equal index.
+    return firstEqualIndex === index
       ? { done: false, hasNext: true, next: value }
       : SKIP_ITEM;
   };

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -62,10 +62,7 @@ const lazyImplementation =
       (otherValue, otherIndex) =>
         index === otherIndex || isEquals(value, otherValue),
     );
-    // if there are no other matches, leave the result in.
-    if (firstEqualIndex === -1) {
-      return { done: false, hasNext: true, next: value };
-    }
+
     // skip items that aren't at the first equal index.
     return firstEqualIndex === index
       ? { done: false, hasNext: true, next: value }

--- a/src/uniqueWith.ts
+++ b/src/uniqueWith.ts
@@ -55,16 +55,14 @@ export function uniqueWith(...args: ReadonlyArray<unknown>): unknown {
   return purryFromLazy(lazyImplementation, args);
 }
 
-const lazyImplementation = <T>(isEquals: IsEquals<T>): LazyEvaluator<T> => {
-  // the approach is to keep track of distinct entities and skip duplicates. we differentiate them by comparing each known distinct entity against the current value, adding the value to the entity list if there are no matches. worst case O(n^2) time complexity and O(n) space complexity.
-  const entities: Array<T> = [];
-  return (value) => {
-    for (const entity of entities) {
-      if (isEquals(entity, value)) {
-        return SKIP_ITEM;
-      }
+const lazyImplementation =
+  <T>(isEquals: IsEquals<T>): LazyEvaluator<T> =>
+  (value, index, data) => {
+    const res = data.findIndex((otherValue) => isEquals(value, otherValue));
+    if (res === -1) {
+      return { done: false, hasNext: true, next: value };
     }
-    entities.push(value);
-    return { done: false, hasNext: true, next: value };
+    return res === index
+      ? { done: false, hasNext: true, next: value }
+      : SKIP_ITEM;
   };
-};


### PR DESCRIPTION
Fixes #999 

- Previous implementation checked each item for a match that existed at a different index, skipping those. It checks the item's own equivalency as part of the implementation, but this can unexpectedly remove items due to interactions with the comparator's logic as shown in the issue.
- In the new implementation, the index equality check simultaneously handles this edge case and reduces unnecessary calls of the comparator.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
