### PR TITLE
fix(floor, ceil, round): do not divide and multiply by a floating point number

### DIFF
--- a/src/ceil.test.ts
+++ b/src/ceil.test.ts
@@ -12,6 +12,11 @@ describe("data-first", () => {
     expect(ceil(8123.4317, -4)).toBe(10_000);
   });
 
+  // Makes sure the issue github.com/remeda/remeda/issues/1003 doesn't happen.
+  test("does not output floating point number for negative precision", () => {
+    expect(ceil(123_456, -5)).toBe(200_000);
+  });
+
   test("should work with precision = 0", () => {
     expect(ceil(8123.4317, 0)).toBe(8124);
   });

--- a/src/floor.test.ts
+++ b/src/floor.test.ts
@@ -12,6 +12,11 @@ describe("data-first", () => {
     expect(floor(8123.4317, -4)).toBe(0);
   });
 
+  // Makes sure the issue github.com/remeda/remeda/issues/1003 doesn't happen.
+  test("does not output floating point number for negative precision", () => {
+    expect(floor(123_456, -5)).toBe(100_000);
+  });
+
   test("should work with precision = 0", () => {
     expect(floor(8123.4317, 0)).toBe(8123);
   });

--- a/src/internal/withPrecision.ts
+++ b/src/internal/withPrecision.ts
@@ -26,7 +26,14 @@ export function withPrecision(roundingFn: (value: number) => number) {
       return roundingFn(value);
     }
 
-    const multiplier = RADIX ** precision;
-    return roundingFn(value * multiplier) / multiplier;
+    const multiplier = RADIX ** Math.abs(precision);
+
+    if (precision > 0) {
+      return roundingFn(value * multiplier) / multiplier;
+    }
+
+    // It is tricky to divide and multiple by a floating point number.
+    // Instead, it can use integers, but first divide and then multiply.
+    return roundingFn(value / multiplier) * multiplier;
   };
 }

--- a/src/internal/withPrecision.ts
+++ b/src/internal/withPrecision.ts
@@ -26,14 +26,13 @@ export function withPrecision(roundingFn: (value: number) => number) {
       return roundingFn(value);
     }
 
-    const multiplier = RADIX ** Math.abs(precision);
-
     if (precision > 0) {
+      const multiplier = RADIX ** precision;
       return roundingFn(value * multiplier) / multiplier;
     }
 
-    // It is tricky to divide and multiple by a floating point number.
-    // Instead, it can use integers, but first divide and then multiply.
-    return roundingFn(value / multiplier) * multiplier;
+    // Avoid losing precision by dividing first.
+    const divisor = RADIX ** -precision;
+    return roundingFn(value / divisor) * divisor;
   };
 }

--- a/src/round.test.ts
+++ b/src/round.test.ts
@@ -12,6 +12,11 @@ describe("data-first", () => {
     expect(round(8123.4317, -4)).toBe(10_000);
   });
 
+  // Makes sure the issue github.com/remeda/remeda/issues/1003 doesn't happen.
+  test("does not output floating point number for negative precision", () => {
+    expect(round(123_456, -5)).toBe(100_000);
+  });
+
   test("should work with precision = 0", () => {
     expect(round(8123.4317, 0)).toBe(8123);
   });


### PR DESCRIPTION
The changes aim to increase the accuracy of the `floor`, `cail`, and `round` functions by using only integers when dividing and multiplying, avoiding floating point numbers.

Resolves #1003 


---

Make sure that you:

- [ ] ~Typedoc added for new methods and updated for changed~
- [x] Tests added for new methods and updated for changed
- [ ] ~New methods added to `src/index.ts`~
- [ ] ~New methods added to `docs/src/content/mapping` for both Lodash and Ramda.~

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
