### PR TITLE
fix(mergeAll): Improve type safety of tuple overloads

### DIFF
--- a/src/internal/types/MergeTuple.test-d.ts
+++ b/src/internal/types/MergeTuple.test-d.ts
@@ -1,0 +1,25 @@
+import type { MergeTuple } from "./MergeTuple";
+
+describe("the fields of the rightmost item should have the greatest priority in overrides", () => {
+  it("2 items", () => {
+    type A1 = { a: 1; b: 1 };
+    type A2 = { a: 2 };
+    type Input = [A1, A2];
+    type ExpectedType = { a: 2; b: 1 };
+    type Result = MergeTuple<Input>;
+
+    expectTypeOf<Result>().toEqualTypeOf<ExpectedType>();
+  });
+
+  it("3 items", () => {
+    type A1 = { a: 1; b: 1 };
+    type A2 = { a: 2 };
+    type A3 = { a: 3 };
+    type Input = [A1, A2, A3];
+    type ExpectedType = { a: 3; b: 1 };
+
+    type Result = MergeTuple<Input>;
+
+    expectTypeOf<Result>().toEqualTypeOf<ExpectedType>();
+  });
+});

--- a/src/internal/types/MergeTuple.ts
+++ b/src/internal/types/MergeTuple.ts
@@ -1,0 +1,11 @@
+import type { Merge } from "type-fest";
+
+/**
+ * Merges a tuple of objects types into a single object type from left to right.
+ */
+export type MergeTuple<
+  T extends ReadonlyArray<unknown>, // ideally unknown is narrowed to object for type safety but this is being used by mergeAll and would require additional object constraint on the function, could be a breaking change
+  _Current = object, // no-op for the first iteration in the successive merges, also infers object as type by default if an empty tuple is used
+> = T extends readonly [infer Head, ...infer PoppedStack] // if stack not empty
+  ? MergeTuple<PoppedStack, Merge<_Current, Head>>
+  : _Current;

--- a/src/mergeAll.test-d.ts
+++ b/src/mergeAll.test-d.ts
@@ -1,0 +1,28 @@
+import { mergeAll } from "./mergeAll";
+
+describe("tuple overload", () => {
+  describe("the fields of the rightmost item should have the greatest priority in overrides", () => {
+    it("2 types", () => {
+      type A1 = { a: 1; b: 1 };
+      type A2 = { a: 2 };
+      const input: [A1, A2] = [{ a: 1, b: 1 }, { a: 2 }];
+      type ExpectedType = { a: 2; b: 1 };
+
+      const result = mergeAll(input);
+
+      expectTypeOf(result).toEqualTypeOf<ExpectedType>();
+    });
+
+    it("3 types", () => {
+      type A1 = { a: 1; b: 1 };
+      type A2 = { a: 2 };
+      type A3 = { a: 3 };
+      const input: [A1, A2, A3] = [{ a: 1, b: 1 }, { a: 2 }, { a: 3 }];
+      type ExpectedType = { a: 3; b: 1 };
+
+      const result = mergeAll(input);
+
+      expectTypeOf(result).toEqualTypeOf<ExpectedType>();
+    });
+  });
+});

--- a/src/mergeAll.test-d.ts
+++ b/src/mergeAll.test-d.ts
@@ -2,6 +2,16 @@ import { mergeAll } from "./mergeAll";
 
 describe("tuple overload", () => {
   describe("the fields of the rightmost item should have the greatest priority in overrides", () => {
+    it("1 types", () => {
+      type A1 = { a: 1; b: 1 };
+      const input: [A1] = [{ a: 1, b: 1 }];
+      type ExpectedType = { a: 1; b: 1 };
+
+      const result = mergeAll(input);
+
+      expectTypeOf(result).toEqualTypeOf<ExpectedType>();
+    });
+
     it("2 types", () => {
       type A1 = { a: 1; b: 1 };
       type A2 = { a: 2 };

--- a/src/mergeAll.ts
+++ b/src/mergeAll.ts
@@ -1,3 +1,5 @@
+import type { MergeTuple } from "./internal/types/MergeTuple";
+
 /**
  * Merges a list of objects into a single object.
  *
@@ -9,11 +11,15 @@
  * @category Array
  */
 export function mergeAll<A>(array: readonly [A]): A;
-export function mergeAll<A, B>(array: readonly [A, B]): A & B;
-export function mergeAll<A, B, C>(array: readonly [A, B, C]): A & B & C;
+export function mergeAll<A, B>(
+  array: readonly [A, B],
+): MergeTuple<typeof array>;
+export function mergeAll<A, B, C>(
+  array: readonly [A, B, C],
+): MergeTuple<typeof array>;
 export function mergeAll<A, B, C, D>(
   array: readonly [A, B, C, D],
-): A & B & C & D;
+): MergeTuple<typeof array>;
 export function mergeAll<A, B, C, D, E>(
   array: readonly [A, B, C, D, E],
 ): A & B & C & D & E;

--- a/src/mergeAll.ts
+++ b/src/mergeAll.ts
@@ -22,7 +22,7 @@ export function mergeAll<A, B, C, D>(
 ): MergeTuple<typeof array>;
 export function mergeAll<A, B, C, D, E>(
   array: readonly [A, B, C, D, E],
-): A & B & C & D & E;
+): MergeTuple<typeof array>;
 export function mergeAll(array: ReadonlyArray<object>): object;
 
 export function mergeAll(items: ReadonlyArray<object>): object {


### PR DESCRIPTION
Fixes #1006 

- Changed tuple overloads to use `Merge` from type-fest instead of intersections to represent merged objects.
- Refactored return types to use recursive type to handle tuples of any arity. Can look into changing the overloads into a single signature as well after #1002 as separate PR as there may be potential complexities with overload resolution.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>