### PR TITLE
docs: fix a typo on homepage

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -179,7 +179,7 @@ just runtime behavior but also types!
 We use the strictest TypeScript settings and extensive linting to ensure that
 nothing slips through the cracks.
 
-## 🥳 Collabrative
+## 🥳 Collaborative
 
 Remeda is provided with an MIT license and is open to contributions from the
 community. We are always looking for new contributors and are happy to help you


### PR DESCRIPTION
"Collaborative" instead of "Collabrative" :)