### PR TITLE
chore(dependabot): remove package config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,36 +15,6 @@ updates:
         update-types:
           - minor
 
-  - package-ecosystem: npm
-    directory: /packages/remeda
-    schedule:
-      interval: monthly
-    groups:
-      # We only group minor and patch updates so that its easy to review and
-      # accept without too much fuss. For major updates we still want a separate
-      # PR for each dependency so we can discuss and review it properly.
-      patches:
-        update-types:
-          - patch
-      minor:
-        update-types:
-          - minor
-
-  - package-ecosystem: npm
-    directory: /packages/docs
-    schedule:
-      interval: monthly
-    groups:
-      # We only group minor and patch updates so that its easy to review and
-      # accept without too much fuss. For major updates we still want a separate
-      # PR for each dependency so we can discuss and review it properly.
-      patches:
-        update-types:
-          - patch
-      minor:
-        update-types:
-          - minor
-
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
dependabot is misconfigured. We don't need to set the packages themselves because the lock file only sits in the monorepo root, and dependabot needs the lock file to send the correct update PR