### PR TITLE
fix: Handling of strings that are `Object` instance method names (in`groupBy` and `countBy`)

### DIFF
--- a/packages/remeda/src/countBy.test.ts
+++ b/packages/remeda/src/countBy.test.ts
@@ -1,5 +1,6 @@
 import { countBy } from "./countBy";
 import { pipe } from "./pipe";
+import { prop } from "./prop";
 
 describe("dataFirst", () => {
   test("countBy", () => {
@@ -129,4 +130,17 @@ test("empty array", () => {
   const result = countBy([], (x) => x);
 
   expect(result).toStrictEqual({});
+});
+
+// https://github.com/remeda/remeda/pull/1049
+test("category is an object instance method name", () => {
+  const data = [
+    { a: "toString", b: "toString" },
+    { a: "toString", b: "valueOf" },
+    { a: "valueOf", b: "toString" },
+    { a: "toString", b: "__proto__" },
+  ];
+  const result = countBy(data, prop("a"));
+
+  expect(result).toStrictEqual({ toString: 3, valueOf: 1 });
 });

--- a/packages/remeda/src/countBy.ts
+++ b/packages/remeda/src/countBy.ts
@@ -63,15 +63,19 @@ const countByImplementation = <T>(
     data: ReadonlyArray<T>,
   ) => PropertyKey | undefined,
 ): ExactRecord<PropertyKey, number> => {
-  const out: ExactRecord<PropertyKey, number> = {};
+  const out = new Map<PropertyKey, number>();
 
   for (const [index, item] of data.entries()) {
     const category = categorizationFn(item, index, data);
     if (category !== undefined) {
-      out[category] ??= 0;
-      out[category] += 1;
+      const count = out.get(category);
+      if (count === undefined) {
+        out.set(category, 1);
+      } else {
+        out.set(category, count + 1);
+      }
     }
   }
 
-  return out;
+  return Object.fromEntries(out);
 };

--- a/packages/remeda/src/groupBy.test.ts
+++ b/packages/remeda/src/groupBy.test.ts
@@ -74,7 +74,8 @@ describe("filtering on undefined grouper result", () => {
   });
 });
 
-describe("tricky string", () => {
+// https://github.com/remeda/remeda/pull/1049
+describe("key is an object instance method name", () => {
   test("groupBy", () => {
     expect(
       groupBy(

--- a/packages/remeda/src/groupBy.test.ts
+++ b/packages/remeda/src/groupBy.test.ts
@@ -73,3 +73,26 @@ describe("filtering on undefined grouper result", () => {
     expect(result.even).toStrictEqual(["a", "c", "e", "g", "i"]);
   });
 });
+
+describe("tricky string", () => {
+  test("groupBy", () => {
+    expect(
+      groupBy(
+        [
+          { a: "toString", b: "toString" },
+          { a: "toString", b: "valueOf" },
+          { a: "valueOf", b: "toString" },
+          { a: "toString", b: "__proto__" },
+        ],
+        prop("a"),
+      ),
+    ).toStrictEqual({
+      toString: [
+        { a: "toString", b: "toString" },
+        { a: "toString", b: "valueOf" },
+        { a: "toString", b: "__proto__" },
+      ],
+      valueOf: [{ a: "valueOf", b: "toString" }],
+    });
+  });
+});

--- a/packages/remeda/src/groupBy.ts
+++ b/packages/remeda/src/groupBy.ts
@@ -80,19 +80,19 @@ const groupByImplementation = <T, Key extends PropertyKey = PropertyKey>(
     data: ReadonlyArray<T>,
   ) => Key | undefined,
 ): ExactRecord<Key, NonEmptyArray<T>> => {
-  const output: Partial<Record<Key, Array<T>>> = {};
+  const output = new Map<Key, Array<T>>();
 
   for (const [index, item] of data.entries()) {
     const key = callbackfn(item, index, data);
     if (key !== undefined) {
-      let { [key]: items } = output;
+      let items = output.get(key);
       if (items === undefined) {
         items = [];
-        output[key] = items;
+        output.set(key, items);
       }
       items.push(item);
     }
   }
 
-  return output as ExactRecord<Key, NonEmptyArray<T>>;
+  return Object.fromEntries(output) as ExactRecord<Key, NonEmptyArray<T>>;
 };


### PR DESCRIPTION
Closes https://github.com/remeda/remeda/issues/1046

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
