### PR TITLE
docs: fix incorrect github link and incorrect funnel api usage

### DIFF
--- a/packages/docs/src/content/mapping/lodash/debounce.md
+++ b/packages/docs/src/content/mapping/lodash/debounce.md
@@ -5,10 +5,10 @@ remeda: funnel
 
 - `debounce` can be implemented using the `funnel` utility. A reference
   implementation is provided below, and a more expanded version with inline
-  documentation and tests is available in the test file [`funnel.lodash-debounce.test.ts`](https://github.com/remeda/remeda/blob/main/src/funnel.lodash-debounce.test.ts).
+  documentation and tests is available in the test file [`funnel.lodash-debounce.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.lodash-debounce.test.ts).
 
 - A more complete reference implementation that also maintains Lodash's
-  capability to store the callback's return value is available below, and in [`funnel.lodash-debounce-with-cached-value.test.ts`](https://github.com/remeda/remeda/blob/main/src/funnel.lodash-debounce-with-cached-value.test.ts).
+  capability to store the callback's return value is available below, and in [`funnel.lodash-debounce-with-cached-value.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts).
 
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By

--- a/packages/docs/src/content/mapping/lodash/debounce.md
+++ b/packages/docs/src/content/mapping/lodash/debounce.md
@@ -42,9 +42,9 @@ function debounce<F extends (...args: any) => void>(
       }
     },
     {
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      triggerAt: trailing ? (leading ? "both" : "end") : "start",
     },
   );
   return Object.assign(call, rest);
@@ -79,9 +79,9 @@ function debounce<F extends (...args: any) => void>(
     },
     {
       reducer: (_, ...args: Parameters<F>) => args,
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      triggerAt: trailing ? (leading ? "both" : "end") : "start",
     },
   );
   return Object.assign(call, rest);
@@ -114,9 +114,9 @@ function debounce<F extends (...args: any) => any>(
     },
     {
       reducer: (_, ...args: Parameters<F>) => args,
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      triggerAt: trailing ? (leading ? "both" : "end") : "start",
     },
   );
   return Object.assign(

--- a/packages/docs/src/content/mapping/lodash/throttle.md
+++ b/packages/docs/src/content/mapping/lodash/throttle.md
@@ -69,9 +69,9 @@ function throttle<F extends (...args: any) => void>(
     },
     {
       reducer: (_, ...args: Parameters<F>) => args,
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       maxBurstDurationMs: wait,
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      triggerAt: trailing ? (leading ? "both" : "end") : "start",
     },
   );
   return Object.assign(call, rest);
@@ -99,9 +99,9 @@ function throttle<F extends (...args: any) => any>(
     },
     {
       reducer: (_, ...args: Parameters<F>) => args,
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       maxBurstDurationMs: wait,
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      triggerAt: trailing ? (leading ? "both" : "end") : "start",
     },
   );
 

--- a/packages/docs/src/content/mapping/lodash/throttle.md
+++ b/packages/docs/src/content/mapping/lodash/throttle.md
@@ -5,10 +5,10 @@ remeda: funnel
 
 - `throttle` can be implemented using the `funnel` utility. A reference
   implementation is provided below, and a more expanded version with inline
-  documentation and tests is available in the test file [`funnel.lodash-throttle.test.ts`](https://github.com/remeda/remeda/blob/main/src/funnel.lodash-throttle.test.ts).
+  documentation and tests is available in the test file [`funnel.lodash-throttle.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.lodash-throttle.test.ts).
 
 - A more complete reference implementation that also maintains Lodash's
-  capability to store the callback's return value is available below, and in [`funnel.lodash-throttle-with-cached-value.test.ts`](https://github.com/remeda/remeda/blob/main/src/funnel.lodash-throttle-with-cached-value.test.ts).
+  capability to store the callback's return value is available below, and in [`funnel.lodash-throttle-with-cached-value.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts).
 
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By

--- a/packages/remeda/src/debounce.ts
+++ b/packages/remeda/src/debounce.ts
@@ -57,7 +57,7 @@ type DebounceOptions = {
  * It stores the value returned by `func` whenever its invoked. This value is returned on every call, and is accessible via the `cachedValue` property of the debouncer. Its important to note that the value might be different from the value that would be returned from running `func` with the current arguments as it is a cached value from a previous invocation.
  * **Important**: The cool-down period defines the minimum between two invocations, and not the maximum. The period will be **extended** each time a call is made until a full cool-down period has elapsed without any additional calls.
  *
- *! **DEPRECATED**: This implementation of debounce is known to have issues and might not behave as expected. It should be replaced with the `funnel` utility instead. The test file [funnel.remeda-debounce.test.ts](https://github.com/remeda/remeda/blob/main/src/funnel.remeda-debounce.test.ts) offers a reference implementation that replicates `debounce` via `funnel`!
+ *! **DEPRECATED**: This implementation of debounce is known to have issues and might not behave as expected. It should be replaced with the `funnel` utility instead. The test file [funnel.remeda-debounce.test.ts](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts) offers a reference implementation that replicates `debounce` via `funnel`!
  *
  * @param func - The function to debounce, the returned `call` function will have
  * the exact same signature.

--- a/packages/remeda/src/funnel.ts
+++ b/packages/remeda/src/funnel.ts
@@ -80,7 +80,7 @@ type Funnel<Args extends RestArguments = []> = {
  *
  * - Debouncing: use `minQuietPeriodMs` and any `triggerAt`.
  * - Throttling: use `minGapMs` and `triggerAt: "start"` or `"both"`.
- * - Batching: See the reference implementation in [`funnel.reference-batch.test.ts`](https://github.com/remeda/remeda/blob/main/src/funnel.reference-batch.test.ts).
+ * - Batching: See the reference implementation in [`funnel.reference-batch.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.reference-batch.test.ts).
  *
  * @param callback - The main function that would be invoked periodically based
  * on `options`. The function would take the latest result of the `reducer`; if


### PR DESCRIPTION
> Replace this quote with a description of your changes

Fix the incorrect GitHub link related to Lodash documentation, which appears to be caused by the monorepo refactoring.
And fix incorrect funnel api usage in lodash migration guide.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
