### PR TITLE
docs(evolve): Correct variable name from `object` to `data` in example usage

### DIFF
--- a/packages/remeda/src/evolve.ts
+++ b/packages/remeda/src/evolve.ts
@@ -117,7 +117,7 @@ export function evolve<T extends object, E extends Evolver<T>>(
  *      count: 10,
  *      time: { elapsed: 100, remaining: 1400 },
  *    };
- *    R.pipe(object, R.evolve(evolver))
+ *    R.pipe(data, R.evolve(evolver))
  *    // => {
  *    //   id: 10,
  *    //   count: 11,


### PR DESCRIPTION
Corrected incorrect variable names in document comments.

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [x] New methods added to `docs/src/content/mapping` for both Lodash and Ramda.

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
