### PR TITLE
fix(mapValues): preserve number keys in the resulting object

### DIFF
--- a/packages/remeda/src/mapValues.test-d.ts
+++ b/packages/remeda/src/mapValues.test-d.ts
@@ -118,6 +118,18 @@ test("number keys are converted to string in the mapper", () => {
   });
 });
 
+test("number keys are preserved in the resulting object", () => {
+  const data = {} as Record<number, unknown>;
+
+  const dataFirst = mapValues(data, constant(true));
+
+  expectTypeOf(dataFirst).toEqualTypeOf<Record<number, boolean>>();
+
+  const dataLast = pipe(data, mapValues(constant(true)));
+
+  expectTypeOf(dataLast).toEqualTypeOf<Record<number, boolean>>();
+});
+
 test("maintains partiality", () => {
   const result = mapValues(
     {} as { a?: number; b?: string; c: number; d: string },
@@ -138,12 +150,12 @@ test("unions of records", () => {
   const dataFirst = mapValues(data, constant("hello" as string));
 
   expectTypeOf(dataFirst).toEqualTypeOf<
-    Record<`${number}`, string> | Record<string, string>
+    Record<number, string> | Record<string, string>
   >();
 
   const dataLast = pipe(data, mapValues(constant("hello" as string)));
 
   expectTypeOf(dataLast).toEqualTypeOf<
-    Record<`${number}`, string> | Record<string, string>
+    Record<number, string> | Record<string, string>
   >();
 });

--- a/packages/remeda/src/mapValues.ts
+++ b/packages/remeda/src/mapValues.ts
@@ -4,7 +4,7 @@ import type { EnumerableStringKeyedValueOf } from "./internal/types/EnumerableSt
 import { purry } from "./purry";
 
 type MappedValues<T extends object, Value> = Simplify<{
-  -readonly [P in keyof T as `${P extends number | string ? P : never}`]: Value;
+  -readonly [P in keyof T as P extends number | string ? P : never]: Value;
 }>;
 
 /**


### PR DESCRIPTION
Removed converting `number` keys to  the`` `${number}` `` type

Resolves #1071

---

Make sure that you:

- [x] Tests added for new methods and updated for changed

---

<details><summary>We use semantic PR titles to automate the release process!</summary>

https://conventionalcommits.org

PRs should be titled following using the format: `< TYPE >(< scope >)?: description`

### Available Types:

- `feat`: new functions, and changes to a function's type that would impact users.
- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
- `test`: tests-only changes (transparent to users of the function).
- `docs`: changes to the documentation of a function **or the documentation site**.
- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.

For scope put the name of the function you are working on (either new or
existing).

</details>
