### PR TITLE
fix(filter): maintain tuple shape in result

### DIFF
--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -6,7 +6,7 @@ import { isNonNullish } from "./isNonNullish";
 import { isStrictEqual } from "./isStrictEqual";
 import { pipe } from "./pipe";
 
-// TODO [>2]: The Remeda `isNumber` utility isn't narrowing our types correctly for our tests here due to it inferring the types "too soon" because it is used "headless"ly. This is also a problem with TypeScript before version 5.5 because we can't use a simple arrow function too without being explicit about it's return type, which makes the whole code messy. In Remeda v3 we plan to bump the minimum TypeScript version so this wouldn't be an issue any way, but we also plan to deprecate headless type predicates.
+// TODO [>2]: Our type-narrowing utilities aren't narrowing our types correctly in these tests due to them inferring the types "too soon" (because they are invoked "headless"ly). This is also a problem with TypeScript before version 5.5 because we can't use a simple arrow function too without being explicit about it's return type, which makes the whole code messy. In Remeda v3 we plan to bump the minimum TypeScript version so this wouldn't be an issue any way, but we also plan to deprecate headless type predicates.
 declare function isNumber<T>(x: T): x is Extract<T, number>;
 declare function isString<T>(x: T): x is Extract<T, string>;
 

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -11,14 +11,14 @@ import { purry } from "./purry";
 // the filter.
 type NonRefinedFilteredArray<
   T extends IterableContainer,
-  B extends boolean,
-> = boolean extends B
+  IsItemIncluded extends boolean,
+> = boolean extends IsItemIncluded
   ? // We don't know which items of the array the predicate would allow in the
     // output so we can only safely say that the result is an array with items
     // from the input array.
     // TODO: Theoretically we could build an output shape that would take into account the **order** of elements in the input array by reconstructing it with every single element in it either included or not, but this type can grow to a union of as much as 2^n options which might not be usable in practice.
     Array<T[number]>
-  : B extends true
+  : IsItemIncluded extends true
     ? // If the predicate is always true we return a shallow copy of the array.
       // If it was originally readonly we need to strip that away.
       Writable<T>
@@ -52,10 +52,13 @@ export function filter<
   data: T,
   predicate: (value: T[number], index: number, data: T) => value is Condition,
 ): FilteredArray<T, Condition>;
-export function filter<T extends IterableContainer, B extends boolean>(
+export function filter<
+  T extends IterableContainer,
+  IsItemIncluded extends boolean,
+>(
   data: T,
-  predicate: (value: T[number], index: number, data: T) => B,
-): NonRefinedFilteredArray<T, B>;
+  predicate: (value: T[number], index: number, data: T) => IsItemIncluded,
+): NonRefinedFilteredArray<T, IsItemIncluded>;
 
 /**
  * Creates a shallow copy of a portion of a given array, filtered down to just
@@ -81,9 +84,12 @@ export function filter<
 >(
   predicate: (value: T[number], index: number, data: T) => value is Condition,
 ): (data: T) => FilteredArray<T, Condition>;
-export function filter<T extends IterableContainer, B extends boolean>(
-  predicate: (value: T[number], index: number, data: T) => B,
-): (data: T) => NonRefinedFilteredArray<T, B>;
+export function filter<
+  T extends IterableContainer,
+  IsItemIncluded extends boolean,
+>(
+  predicate: (value: T[number], index: number, data: T) => IsItemIncluded,
+): (data: T) => NonRefinedFilteredArray<T, IsItemIncluded>;
 
 export function filter(...args: ReadonlyArray<unknown>): unknown {
   return purry(filterImplementation, args, lazyImplementation);

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -7,8 +7,8 @@ import { purry } from "./purry";
 
 // When the predicate used for filter isn't refining (like a type-predicate) we
 // can narrow the result slightly if it's also trivial (it returns the same
-// result for all items). This is uncommon, but can be useful to
-// "short-circuiting" the filter.
+// result for all items). This is uncommon, but can be useful to "short-circuit"
+// the filter.
 type NonRefinedFilteredArray<T extends IterableContainer, B extends boolean> =
   IsEqual<B, true> extends true
     ? // If the predicate is always true we return a shallow copy of the array.

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -1,3 +1,6 @@
+import type { IsEqual, Writable } from "type-fest";
+import type { FilteredArray } from "./internal/types/FilteredArray";
+import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
@@ -21,14 +24,21 @@ import { purry } from "./purry";
  * @lazy
  * @category Array
  */
-export function filter<T, S extends T>(
-  data: ReadonlyArray<T>,
-  predicate: (value: T, index: number, data: ReadonlyArray<T>) => value is S,
-): Array<S>;
-export function filter<T>(
-  data: ReadonlyArray<T>,
-  predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
-): Array<T>;
+export function filter<
+  T extends IterableContainer,
+  Condition extends T[number],
+>(
+  data: T,
+  predicate: (value: T[number], index: number, data: T) => value is Condition,
+): FilteredArray<T, Condition>;
+export function filter<T extends IterableContainer, B extends boolean>(
+  data: T,
+  predicate: (value: T[number], index: number, data: T) => B,
+): IsEqual<B, true> extends true
+  ? Writable<T>
+  : IsEqual<B, false> extends true
+    ? []
+    : Array<T[number]>;
 
 /**
  * Creates a shallow copy of a portion of a given array, filtered down to just
@@ -48,12 +58,21 @@ export function filter<T>(
  * @lazy
  * @category Array
  */
-export function filter<T, S extends T>(
-  predicate: (value: T, index: number, data: ReadonlyArray<T>) => value is S,
-): (data: ReadonlyArray<T>) => Array<S>;
-export function filter<T>(
-  predicate: (value: T, index: number, data: ReadonlyArray<T>) => boolean,
-): (data: ReadonlyArray<T>) => Array<T>;
+export function filter<
+  T extends IterableContainer,
+  Condition extends T[number],
+>(
+  predicate: (value: T[number], index: number, data: T) => value is Condition,
+): (data: T) => FilteredArray<T, Condition>;
+export function filter<T extends IterableContainer, B extends boolean>(
+  predicate: (value: T[number], index: number, data: T) => B,
+): (
+  data: T,
+) => IsEqual<B, true> extends true
+  ? Writable<T>
+  : IsEqual<B, false> extends true
+    ? []
+    : Array<T[number]>;
 
 export function filter(...args: ReadonlyArray<unknown>): unknown {
   return purry(filterImplementation, args, lazyImplementation);

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -1,0 +1,873 @@
+import type { FilteredArray } from "./FilteredArray";
+import type { IterableContainer } from "./IterableContainer";
+
+declare function filteredArray<T extends IterableContainer, C>(
+  data: T,
+  condition: C,
+): FilteredArray<T, C>;
+
+test("empty array", () => {
+  expectTypeOf(filteredArray([], "" as string)).toEqualTypeOf<[]>();
+});
+
+test("empty readonly array", () => {
+  expectTypeOf(filteredArray([] as const, "" as string)).toEqualTypeOf<[]>();
+});
+
+describe("condition is a primitive", () => {
+  test("primitive array", () => {
+    expectTypeOf(
+      filteredArray([] as Array<string>, "" as string),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("primitive readonly array", () => {
+    expectTypeOf(
+      filteredArray([] as ReadonlyArray<string>, "" as string),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("union of primitives array", () => {
+    expectTypeOf(
+      filteredArray([] as Array<string | number | boolean>, "" as string),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("union of primitives readonly array", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as ReadonlyArray<string | number | boolean>,
+        "" as string,
+      ),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("array of literals", () => {
+    expectTypeOf(
+      filteredArray([] as Array<"hello">, "" as string),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("readonly array of literals", () => {
+    expectTypeOf(
+      filteredArray([] as ReadonlyArray<"hello">, "" as string),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("array with a union of literals", () => {
+    expectTypeOf(
+      filteredArray([] as Array<"hello" | 3 | true>, "" as string),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("readonly array with a union of literals", () => {
+    expectTypeOf(
+      filteredArray([] as ReadonlyArray<"hello" | 3 | true>, "" as string),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("tuple of primitives", () => {
+    expectTypeOf(
+      filteredArray(
+        [1, "hello", true] as [number, string, boolean],
+        "" as string,
+      ),
+    ).toEqualTypeOf<[string]>();
+  });
+
+  test("readonly tuple of primitives", () => {
+    expectTypeOf(
+      filteredArray(
+        [1, "hello", true] as readonly [number, string, boolean],
+        "" as string,
+      ),
+    ).toEqualTypeOf<[string]>();
+  });
+
+  test("tuple of literals", () => {
+    expectTypeOf(
+      filteredArray([1, "hello", true] as [1, "hello", true], "" as string),
+    ).toEqualTypeOf<["hello"]>();
+  });
+
+  test("readonly tuple of literals", () => {
+    expectTypeOf(
+      filteredArray([1, "hello", true] as const, "" as string),
+    ).toEqualTypeOf<["hello"]>();
+  });
+
+  test("complex tuple of primitives, filtered on the prefix", () => {
+    expectTypeOf(
+      filteredArray(
+        ["hello", 3] as [string, ...Array<boolean>, number],
+        "" as string,
+      ),
+    ).toEqualTypeOf<[string]>();
+  });
+
+  test("complex tuple of primitives, filtered on the rest", () => {
+    expectTypeOf(
+      filteredArray(
+        [true, 3] as [boolean, ...Array<string>, number],
+        "" as string,
+      ),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("complex tuple of primitives, filtered on the suffix", () => {
+    expectTypeOf(
+      filteredArray(
+        [true, "hello"] as [boolean, ...Array<number>, string],
+        "" as string,
+      ),
+    ).toEqualTypeOf<[string]>();
+  });
+
+  test("tuple with unions of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        ["hello", "foo"] as ["hello" | "world", "foo" | "bar"],
+        "" as string,
+      ),
+    ).toEqualTypeOf<
+      ["hello", "foo"] | ["world", "foo"] | ["hello", "bar"] | ["world", "bar"]
+    >();
+  });
+
+  test("complex tuple with union of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        ["prefix", "suffix"] as [
+          "prefix" | 123,
+          ...Array<"rest" | true>,
+          "suffix" | Date,
+        ],
+        "" as string,
+      ),
+    ).toEqualTypeOf<
+      | Array<"rest">
+      | [...Array<"rest">, "suffix"]
+      | ["prefix", ...Array<"rest">]
+      | ["prefix", ...Array<"rest">, "suffix"]
+    >();
+  });
+
+  test("disjoint types", () => {
+    expectTypeOf(
+      filteredArray([] as Array<number>, "" as string),
+    ).toEqualTypeOf<[]>();
+  });
+});
+
+describe("condition is a literal", () => {
+  test("array with matching literal", () => {
+    expectTypeOf(
+      filteredArray([] as Array<string>, "hello" as const),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("array with literal union including the condition", () => {
+    expectTypeOf(
+      filteredArray([] as Array<"hello" | "world">, "hello" as const),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+
+  test("array with no matching literals", () => {
+    expectTypeOf(
+      filteredArray([] as Array<"world" | "goodbye">, "hello" as const),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("tuple with primitive types", () => {
+    expectTypeOf(
+      filteredArray(
+        ["hello", 1, "world"] as [string, number, string],
+        "hello" as const,
+      ),
+    ).toEqualTypeOf<[] | ["hello"] | ["hello", "hello"]>();
+  });
+
+  test("tuple with matching and non-matching literals", () => {
+    expectTypeOf(
+      filteredArray(
+        ["hello", "world", "hello"] as ["hello", "world", "hello"],
+        "hello" as const,
+      ),
+    ).toEqualTypeOf<["hello", "hello"]>();
+  });
+
+  test("readonly tuple with matching literal", () => {
+    expectTypeOf(
+      filteredArray(["hello", "world", "hello"] as const, "hello" as const),
+    ).toEqualTypeOf<["hello", "hello"]>();
+  });
+
+  test("complex tuple with matching literal in rest position", () => {
+    expectTypeOf(
+      filteredArray(
+        ["start", "hello", "hello", "end"] as [
+          "start",
+          ...Array<"hello" | "world">,
+          "end",
+        ],
+        "hello" as const,
+      ),
+    ).toEqualTypeOf<Array<"hello">>();
+  });
+});
+
+describe("condition is a simple object", () => {
+  test("array of matching objects", () => {
+    expectTypeOf(
+      filteredArray([] as Array<{ a: string }>, { a: "" } as { a: string }),
+    ).toEqualTypeOf<Array<{ a: string }>>();
+  });
+
+  test("array of objects with matching and additional properties", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: string; b: number }>,
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<Array<{ a: string; b: number }>>();
+  });
+
+  test("array with mixed types including matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: string } | string | number>,
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<Array<{ a: string }>>();
+  });
+
+  test("tuple with mixed types including matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [""] as [{ a: string } | string | number],
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<[] | [{ a: string }]>();
+  });
+
+  test("array with no matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ b: string } | string>,
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("tuple with matching and non-matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          { a: "value" },
+          { a: "hello" },
+          { b: 42 },
+          { a: "hello", c: true },
+        ] as [
+          { a: string },
+          { a: "hello" },
+          { b: number },
+          { a: string; c: boolean },
+        ],
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<
+      [{ a: string }, { a: "hello" }, { a: string; c: boolean }]
+    >();
+  });
+});
+
+describe("condition is a complex object", () => {
+  test("array of exactly matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "hello"; b?: number }>,
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<Array<{ a: "hello"; b?: number }>>();
+  });
+
+  test("array of objects with compatible literal property", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "hello" | "world"; b?: number }>,
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<Array<{ a: "hello"; b?: number }>>();
+  });
+
+  test("array of objects with incompatible literal property", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "world"; b?: number }>,
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("array of objects missing optional property", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "hello" }>,
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<Array<{ a: "hello" }>>();
+  });
+
+  test("array with mixed types including matching objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "hello"; b: number } | { a: "world" } | string>,
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<Array<{ a: "hello"; b: number }>>();
+  });
+
+  test("tuple with mixed complex objects", () => {
+    expectTypeOf(
+      filteredArray(
+        [{ a: "hello" }, { a: "world" }, { a: "hello", b: 42 }] as [
+          { a: "hello" },
+          { a: "world" },
+          { a: "hello"; b: number },
+        ],
+        { a: "hello" } as { a: "hello"; b?: number },
+      ),
+    ).toEqualTypeOf<[{ a: "hello" }, { a: "hello"; b: number }]>();
+  });
+
+  test("partial matches", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          { a: "hello" },
+          { a: "world" },
+          { b: "hello" },
+          { b: "world" },
+          { a: "hello", b: "world" },
+          { a: "hello", b: "world", c: 1234 },
+        ] as const,
+        { a: "hello", b: "world" } as { a: "hello"; b: "world" },
+      ),
+    ).toEqualTypeOf<
+      [
+        { readonly a: "hello"; readonly b: "world" },
+        { readonly a: "hello"; readonly b: "world"; readonly c: 1234 },
+      ]
+    >();
+  });
+
+  test("condition value with union of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          { a: "hello" },
+          { b: "world" },
+          { a: "hello", b: "world" },
+          { a: "world" },
+        ] as const,
+        { a: "hello" } as { a: "hello" | "world" },
+      ),
+    ).toEqualTypeOf<
+      [
+        { readonly a: "hello" },
+        { readonly a: "hello"; readonly b: "world" },
+        { readonly a: "world" },
+      ]
+    >();
+  });
+});
+
+describe("condition is an array or primitives", () => {
+  test("array of string arrays", () => {
+    expectTypeOf(
+      filteredArray([] as Array<Array<string>>, [] as Array<string>),
+    ).toEqualTypeOf<Array<Array<string>>>();
+  });
+
+  test("array of mixed array types", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<Array<string> | Array<number> | Array<boolean>>,
+        [] as Array<string>,
+      ),
+    ).toEqualTypeOf<Array<Array<string>>>();
+  });
+
+  test("array containing compatible array types", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<Array<string | number> | Array<boolean>>,
+        [] as Array<string>,
+      ),
+    ).toEqualTypeOf<Array<Array<string>>>();
+  });
+
+  test("tuple containing arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [["a", "b"], [1, 2], ["c"]] as [
+          Array<string>,
+          Array<number>,
+          Array<string>,
+        ],
+        [] as Array<string>,
+      ),
+    ).toEqualTypeOf<[Array<string>, Array<string>]>();
+  });
+
+  test("complex tuple with arrays in rest position", () => {
+    expectTypeOf(
+      filteredArray(
+        [["a"], ["b"], ["c"]] as [
+          Array<string>,
+          ...Array<Array<string> | Array<number>>,
+        ],
+        [] as Array<string>,
+      ),
+    ).toEqualTypeOf<[Array<string>, ...Array<Array<string>>]>();
+  });
+});
+
+describe("condition is a readonly array of primitives", () => {
+  test("array of readonly string arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<ReadonlyArray<string>>,
+        [] as ReadonlyArray<string>,
+      ),
+    ).toEqualTypeOf<Array<ReadonlyArray<string>>>();
+  });
+
+  test("array of mixed readonly and mutable arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<ReadonlyArray<string> | Array<string>>,
+        [] as ReadonlyArray<string>,
+      ),
+    ).toEqualTypeOf<Array<ReadonlyArray<string> | Array<string>>>();
+  });
+
+  test("array with non-matching readonly arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<ReadonlyArray<number>>,
+        [] as ReadonlyArray<string>,
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("tuple containing readonly arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [["a"] as const, [1, 2], ["c"] as const] as [
+          ReadonlyArray<string>,
+          Array<number>,
+          ReadonlyArray<string>,
+        ],
+        [] as ReadonlyArray<string>,
+      ),
+    ).toEqualTypeOf<[ReadonlyArray<string>, ReadonlyArray<string>]>();
+  });
+});
+
+describe("condition is an array of literals", () => {
+  test("array of arrays of matching literals", () => {
+    expectTypeOf(
+      filteredArray([] as Array<Array<"hello">>, [] as Array<"hello">),
+    ).toEqualTypeOf<Array<Array<"hello">>>();
+  });
+
+  test("array with mixed literal arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<Array<"hello"> | Array<"world">>,
+        [] as Array<"hello">,
+      ),
+    ).toEqualTypeOf<Array<Array<"hello">>>();
+  });
+
+  test("array with arrays containing unions of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<Array<"hello" | "world">>,
+        [] as Array<"hello">,
+      ),
+    ).toEqualTypeOf<Array<Array<"hello">>>();
+  });
+
+  test("tuple containing literal arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [["hello", "hello"], ["world"], ["hello"]] as [
+          Array<"hello">,
+          Array<"world">,
+          Array<"hello">,
+        ],
+        [] as Array<"hello">,
+      ),
+    ).toEqualTypeOf<[Array<"hello">, Array<"hello">]>();
+  });
+
+  test("readonly arrays of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        [[], []] as [ReadonlyArray<"hello">, ReadonlyArray<"world">],
+        [] as Array<"hello">,
+      ),
+    ).toEqualTypeOf<[]>();
+
+    expectTypeOf(
+      filteredArray(
+        [[], []] as [ReadonlyArray<"hello">, ReadonlyArray<"world">],
+        [] as ReadonlyArray<"hello">,
+      ),
+    ).toEqualTypeOf<[ReadonlyArray<"hello">]>();
+  });
+});
+
+describe("condition is a tuple", () => {
+  test("array of matching tuples", () => {
+    expectTypeOf(
+      filteredArray([] as Array<[string, number]>, ["", 0] as [string, number]),
+    ).toEqualTypeOf<Array<[string, number]>>();
+  });
+
+  test("array of compatible tuples", () => {
+    expectTypeOf(
+      filteredArray([] as Array<["hello", 42]>, ["", 0] as [string, number]),
+    ).toEqualTypeOf<Array<["hello", 42]>>();
+  });
+
+  test("array of incompatible tuples", () => {
+    expectTypeOf(
+      filteredArray([] as Array<[number, string]>, ["", 0] as [string, number]),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("array with mixed tuples and other types", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<[string, number] | Array<string> | number>,
+        ["", 0] as [string, number],
+      ),
+    ).toEqualTypeOf<Array<[string, number]>>();
+  });
+
+  test("tuple containing different sized tuples", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          ["a", 1],
+          [2, "b"],
+          ["c", 3, true],
+        ] as [[string, number], [number, string], [string, number, boolean]],
+        ["", 0] as [string, number],
+      ),
+    ).toEqualTypeOf<[[string, number]]>();
+  });
+
+  test("complex nested tuples", () => {
+    expectTypeOf(
+      filteredArray(
+        [[["a", 1]], [["b", 2]]] as const,
+        ["", 0] as [string, number],
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("readonly tuples", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          ["a", 1],
+          [2, "b"],
+        ] as [readonly [string, number], readonly [number, string]],
+        ["", 0] as [string, number],
+      ),
+    ).toEqualTypeOf<[]>();
+
+    expectTypeOf(
+      filteredArray(
+        [
+          ["a", 1],
+          [2, "b"],
+        ] as [readonly [string, number], readonly [number, string]],
+        ["", 0] as readonly [string, number],
+      ),
+    ).toEqualTypeOf<[readonly [string, number]]>();
+  });
+});
+
+describe("condition is a union of primitives", () => {
+  test("array with elements matching multiple parts of the union", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<string | number | boolean>,
+        "" as string | number,
+      ),
+    ).toEqualTypeOf<Array<string | number>>();
+  });
+
+  test("array with only one union member type", () => {
+    expectTypeOf(
+      filteredArray([] as Array<string>, "" as string | number),
+    ).toEqualTypeOf<Array<string>>();
+  });
+
+  test("tuple with mixed primitives", () => {
+    expectTypeOf(
+      filteredArray(
+        ["hello", 42, true] as [string, number, boolean],
+        "" as string | number,
+      ),
+    ).toEqualTypeOf<[string, number]>();
+  });
+
+  test("tuple with literal types that extend union members", () => {
+    expectTypeOf(
+      filteredArray(["hello", 42, true] as const, "" as string | number),
+    ).toEqualTypeOf<["hello", 42]>();
+  });
+
+  test("tuple with union of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        ["", "", 123] as [string | number, string | boolean, number | boolean],
+        "cat" as string | number,
+      ),
+    ).toEqualTypeOf<
+      | [string, number]
+      | [number, string]
+      | [string]
+      | [string, string, number]
+      | [number]
+      | [string, string]
+      | [number, string, number]
+      | [number, number]
+    >();
+  });
+});
+
+describe("condition is a union of literals", () => {
+  test("array with elements matching any part of the union", () => {
+    expectTypeOf(
+      filteredArray(
+        ["cat", "dog", "fish"] as Array<string>,
+        "cat" as "cat" | "dog",
+      ),
+    ).toEqualTypeOf<Array<"cat" | "dog">>();
+  });
+
+  test("array with union literals only", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<"cat" | "dog" | "fish">,
+        "cat" as "cat" | "dog",
+      ),
+    ).toEqualTypeOf<Array<"cat" | "dog">>();
+  });
+
+  test("tuple with mixed elements", () => {
+    expectTypeOf(
+      filteredArray(["cat", "fish", "dog"] as const, "cat" as "cat" | "dog"),
+    ).toEqualTypeOf<["cat", "dog"]>();
+  });
+
+  test("tuple with union of literals", () => {
+    expectTypeOf(
+      filteredArray(
+        ["cat", "cat", "dog"] as ["cat" | "dog", "cat" | "foo", "dog" | "bar"],
+        "cat" as "cat" | "dog",
+      ),
+    ).toEqualTypeOf<
+      | ["cat"]
+      | ["dog"]
+      | ["cat", "dog"]
+      | ["cat", "cat", "dog"]
+      | ["cat", "cat"]
+      | ["dog", "cat"]
+      | ["dog", "dog"]
+      | ["dog", "cat", "dog"]
+    >();
+  });
+});
+
+describe("condition is a discriminated union", () => {
+  test("array with discriminated union elements", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "cat"; b: number } | { a: "dog"; c: boolean }>,
+        { a: "cat" } as { a: "cat" } | { a: "dog" },
+      ),
+    ).toEqualTypeOf<
+      Array<{ a: "cat"; b: number } | { a: "dog"; c: boolean }>
+    >();
+  });
+
+  test("tuple with mixed discriminated types", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          { a: "cat", b: 1 },
+          { a: "dog", c: true },
+          { a: "cat", b: 2 },
+        ] as const,
+        { a: "cat" } as { a: "cat" } | { a: "dog" },
+      ),
+    ).toEqualTypeOf<
+      [
+        { readonly a: "cat"; readonly b: 1 },
+        { readonly a: "dog"; readonly c: true },
+        { readonly a: "cat"; readonly b: 2 },
+      ]
+    >();
+  });
+
+  test("filtering with discriminator only", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: "cat"; b: number } | { a: "dog"; c: boolean }>,
+        { a: "cat" } as { a: "cat" | "dog" },
+      ),
+    ).toEqualTypeOf<
+      Array<{ a: "cat"; b: number } | { a: "dog"; c: boolean }>
+    >();
+  });
+});
+
+describe("disjoint object types ({ a: string } | { b: number })", () => {
+  test("array with disjoint union elements", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: string } | { b: number }>,
+        { a: "" } as { a: string } | { b: number },
+      ),
+    ).toEqualTypeOf<Array<{ a: string } | { b: number }>>();
+  });
+
+  test("filtering for only one variant", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: string } | { b: number }>,
+        { a: "" } as { a: string },
+      ),
+    ).toEqualTypeOf<Array<{ a: string }>>();
+  });
+
+  test("array with objects having both properties", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as Array<{ a: string } | { b: number } | { a: string; b: number }>,
+        { a: "" } as { a: string } | { b: number },
+      ),
+    ).toEqualTypeOf<
+      Array<{ a: string } | { b: number } | { a: string; b: number }>
+    >();
+  });
+
+  test("tuple with mixed disjoint types", () => {
+    expectTypeOf(
+      filteredArray(
+        [{ a: "hello" }, { b: 42 }, { a: "world", b: 123 }] as const,
+        { b: 0 } as { a: string } | { b: number },
+      ),
+    ).toEqualTypeOf<
+      [
+        { readonly a: "hello" },
+        { readonly b: 42 },
+        { readonly a: "world"; readonly b: 123 },
+      ]
+    >();
+  });
+});
+
+describe("complex nested union conditions", () => {
+  test("union of arrays", () => {
+    expectTypeOf(
+      filteredArray(
+        [["a"], [1], ["b"]] as [Array<string>, Array<number>, Array<string>],
+        [] as Array<string> | Array<number>,
+      ),
+    ).toEqualTypeOf<[Array<string>, Array<number>, Array<string>]>();
+  });
+
+  test("union of tuples with different structures", () => {
+    expectTypeOf(
+      filteredArray(
+        [
+          ["a", 1],
+          [true, "b"],
+          [42, "c"],
+        ] as [[string, number], [boolean, string], [number, string]],
+        ["", 0] as [string, number] | [boolean, string],
+      ),
+    ).toEqualTypeOf<[[string, number], [boolean, string]]>();
+  });
+});
+
+describe("tuples with optional elements", () => {
+  test("removes the partialness once filtered", () => {
+    expectTypeOf(
+      filteredArray([] as [number?, string?], "" as string),
+    ).toEqualTypeOf<[] | [string]>();
+  });
+
+  test("multiple matches", () => {
+    expectTypeOf(
+      filteredArray([] as [number?, string?, number?, string?], "" as string),
+    ).toEqualTypeOf<[] | [string] | [string, string]>();
+  });
+
+  test("literal unions, primitive condition", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as [("hello" | "world")?, ("foo" | "bar")?],
+        "" as string,
+      ),
+    ).toEqualTypeOf<
+      | []
+      | ["hello"]
+      | ["world"]
+      | ["foo"]
+      | ["hello", "foo"]
+      | ["world", "foo"]
+      | ["bar"]
+      | ["hello", "bar"]
+      | ["world", "bar"]
+    >();
+  });
+
+  test("literal unions, matching condition", () => {
+    expectTypeOf(
+      filteredArray(
+        [] as [("hello" | "world")?, ("foo" | "bar")?],
+        "hello" as "hello" | "foo",
+      ),
+    ).toEqualTypeOf<[] | ["hello"] | ["foo"] | ["hello", "foo"]>();
+  });
+
+  test("primitive items, literal union condition", () => {
+    expectTypeOf(
+      filteredArray([] as [string?, string?], "hello" as "hello" | "foo"),
+    ).toEqualTypeOf<
+      | []
+      | ["hello"]
+      | ["foo"]
+      | ["hello", "foo"]
+      | ["hello", "hello"]
+      | ["foo", "hello"]
+      | ["foo", "foo"]
+    >();
+  });
+});
+
+test("null filtering", () => {
+  expectTypeOf(
+    filteredArray([] as Array<string | undefined>, "" as string),
+  ).toEqualTypeOf<Array<string>>();
+});

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -5,11 +5,17 @@ import type { TupleParts } from "./TupleParts";
 export type FilteredArray<T extends IterableContainer, Condition> =
   // We distribute the array type to support unions of arrays/tuples.
   T extends unknown
-    ? [
-        // Reconstruct the array from it's parts, but with each part being filtered on
-        // the condition.
+    ? // Reconstruct the array from it's parts, but with each part being
+      // filtered on the condition.
+      [
         ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
+
+        // The optional elements are added as if they were required instead.
+        // This is because when building the filtered fixed tuples we create
+        // unions of possible outcomes, simulating the way optional elements
+        // work.
         ...FilteredFixedTuple<TupleParts<T>["optional"], Condition>,
+
         ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
         ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
       ]

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -59,7 +59,9 @@ type FilteredFixedTuple<
               Output
     >
   : // We assume that T is a fixed tuple so it's safe to recurse via chopping
-    // off the head element until the array is consumed.
+    // off the head element until the array is consumed. When that condition
+    // isn't met we safely assume that T is now empty and we can end the
+    // recursion.
     Output;
 
 // This type is similar to the built-in `Extract` type, but allows us to have

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -1,0 +1,66 @@
+import type { CoercedArray } from "./CoercedArray";
+import type { IterableContainer } from "./IterableContainer";
+import type { TupleParts } from "./TupleParts";
+
+export type FilteredArray<
+  T extends IterableContainer,
+  Condition,
+> = T extends unknown
+  ? [
+      // Reconstruct the array from it's parts, but with each part being filtered on
+      // the condition.
+      ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
+      ...FilteredFixedTuple<TupleParts<T>["optional"], Condition>,
+      ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
+      ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
+    ]
+  : never;
+
+// The real logic for filtering an array is done on fixed tuples (as those make
+// up the required prefix, the optional prefix, and the suffix of the array).
+type FilteredFixedTuple<
+  T,
+  Condition,
+  Output extends Array<unknown> = [],
+> = T extends readonly [infer Head, ...infer Rest]
+  ? FilteredFixedTuple<
+      Rest,
+      Condition,
+      Head extends Condition
+        ? // If the item in the array already satisfies the condition we pass
+          // it through to the output.
+          [...Output, Head]
+        : Head | Condition extends object
+          ? // TypeScript defines "extends" for objects differently than it
+            // does for primitives, e.g. `{ a: string, b: number }` extends
+            // `{ a: string }` because any function that would accept the latter
+            // would be able to accept the former (by ignoring the extra props)
+            // because TypeScript is structurally typed; but for filtering we
+            // want the opposite semantics, and at this point we already know
+            // that that is false, so we can safely say this item doesn't meet
+            // the condition and skip it.
+            Output
+          : Condition extends Head
+            ? // But for any other type (mostly primitives), if the condition
+              // extends the item it means that there are situations where the
+              // item could satisfy the condition and cases where it won't
+              // (e.g. if the item type is `string` and the condition type is
+              // `"hello"`, then item could be `"hello"` or it could be any
+              // other string, e.g. `"world"`). In this case we need to take
+              // both into consideration in the output type.
+              Output | [...Output, Condition]
+            : // But if the item and condition are disjoint then we simply skip
+              // it as it would never satisfy the condition.
+              Output
+    >
+  : // We assume that T is a fixed tuple so it's safe to recurse via chopping
+    // off the head element until the array is consumed.
+    Output;
+
+// This type is similar to the built-in `Extract` type, but allows us to have
+// either Item or Condition be narrower than the other.
+type SymmetricRefine<Item, Condition> = Item extends Condition
+  ? Item
+  : Condition extends Item
+    ? Condition
+    : never;

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -58,7 +58,7 @@ type FilteredFixedTuple<
               // it as it would never satisfy the condition.
               Output
     >
-  : [];
+  : Output;
 
 // This type is similar to the built-in `Extract` type, but allows us to have
 // either Item or Condition be narrower than the other.

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -2,19 +2,18 @@ import type { CoercedArray } from "./CoercedArray";
 import type { IterableContainer } from "./IterableContainer";
 import type { TupleParts } from "./TupleParts";
 
-export type FilteredArray<
-  T extends IterableContainer,
-  Condition,
-> = T extends unknown
-  ? [
-      // Reconstruct the array from it's parts, but with each part being filtered on
-      // the condition.
-      ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
-      ...FilteredFixedTuple<TupleParts<T>["optional"], Condition>,
-      ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
-      ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
-    ]
-  : never;
+export type FilteredArray<T extends IterableContainer, Condition> =
+  // We distribute the array type to support unions of arrays/tuples.
+  T extends unknown
+    ? [
+        // Reconstruct the array from it's parts, but with each part being filtered on
+        // the condition.
+        ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
+        ...FilteredFixedTuple<TupleParts<T>["optional"], Condition>,
+        ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
+        ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
+      ]
+    : never;
 
 // The real logic for filtering an array is done on fixed tuples (as those make
 // up the required prefix, the optional prefix, and the suffix of the array).

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -5,7 +5,7 @@ import type { TupleParts } from "./TupleParts";
 export type FilteredArray<T extends IterableContainer, Condition> =
   // We distribute the array type to support unions of arrays/tuples.
   T extends unknown
-    ? // Reconstruct the array from it's parts, but with each part being
+    ? // Reconstruct the array from its parts, but with each part being
       // filtered on the condition.
       [
         ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -58,11 +58,7 @@ type FilteredFixedTuple<
               // it as it would never satisfy the condition.
               Output
     >
-  : // We assume that T is a fixed tuple so it's safe to recurse via chopping
-    // off the head element until the array is consumed. When that condition
-    // isn't met we safely assume that T is now empty and we can end the
-    // recursion.
-    Output;
+  : [];
 
 // This type is similar to the built-in `Extract` type, but allows us to have
 // either Item or Condition be narrower than the other.


### PR DESCRIPTION
Using the new TupleParts we can improve the return type for filter when used with a type-predicate. This allows us to consider every element in the input tuple shape and consider whether it could possibly be in the output or not.

Additionally we can also improve the result when filter is used with trivial predicates (that always return true, or always return false), allowing "short-circuit" style code where users effectively bypass the filtering via the predicate itself. 

The main type here was pulled out of the filter impl because it would be the basis (together with ArrayRequiredPrefix) for the groupByProp return type.