### PR TITLE
fix(drop,partialBind): Fix types to handle optionals

### DIFF
--- a/packages/remeda/src/chunk.ts
+++ b/packages/remeda/src/chunk.ts
@@ -8,11 +8,11 @@ import type {
 } from "type-fest";
 import type { IntRangeInclusive } from "./internal/types/IntRangeInclusive";
 import type { IterableContainer } from "./internal/types/IterableContainer";
-import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 import type { NTuple } from "./internal/types/NTuple";
+import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
+import type { PartialArray } from "./internal/types/PartialArray";
 import type { TupleParts } from "./internal/types/TupleParts";
 import { purry } from "./purry";
-import type { RemedaTypeError } from "./internal/types/RemedaTypeError";
 
 // This prevents typescript from failing on complex arrays and large chunks. It
 // allows the typing to remain useful even when very large chunks are needed,
@@ -188,17 +188,7 @@ type GenericChunk<T extends IterableContainer> = T extends
 // TODO: Chunk was built before we handled optional elements correctly. It needs to be fixed to handle these correctly, specifically in regard to optional elements creating whole chunks that themselves need to be optional, but that their items themselves should not be optional, except the last chunk...
 type TuplePrefix<T extends IterableContainer> = [
   ...TupleParts<T>["required"],
-  ...(Partial<TupleParts<T>["optional"]> extends ReadonlyArray<unknown>
-    ? Partial<TupleParts<T>["optional"]>
-    : // TODO [>2.0]: TypeScript before version 5.4 couldn't infer the type correctly as an array. This shouldn't be needed once the minimum TypeScript version is bumped above this.
-      RemedaTypeError<
-        "TupleParts",
-        "Partial on arrays should always result in an array",
-        {
-          type: never;
-          metadata: [Partial<TupleParts<T>["optional"]>, T];
-        }
-      >),
+  ...PartialArray<TupleParts<T>["optional"]>,
 ];
 
 /**

--- a/packages/remeda/src/chunk.ts
+++ b/packages/remeda/src/chunk.ts
@@ -185,7 +185,7 @@ type GenericChunk<T extends IterableContainer> = T extends
   ? NonEmptyArray<NonEmptyArray<T[number]>>
   : Array<NonEmptyArray<T[number]>>;
 
-// TODO: This type was built before we handled optional elements correctly. It needs to be fixed to handle these correctly, specifically in regard to optional elements creating whole chunks that themselves need to be optional, but that their items themselves should not be optional, except the last chunk...
+// TODO: Chunk was built before we handled optional elements correctly. It needs to be fixed to handle these correctly, specifically in regard to optional elements creating whole chunks that themselves need to be optional, but that their items themselves should not be optional, except the last chunk...
 type TuplePrefix<T extends IterableContainer> = [
   ...TupleParts<T>["required"],
   ...(Partial<TupleParts<T>["optional"]> extends ReadonlyArray<unknown>

--- a/packages/remeda/src/chunk.ts
+++ b/packages/remeda/src/chunk.ts
@@ -10,8 +10,9 @@ import type { IntRangeInclusive } from "./internal/types/IntRangeInclusive";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 import type { NTuple } from "./internal/types/NTuple";
-import type { TupleParts, TuplePrefix } from "./internal/types/TupleParts";
+import type { TupleParts } from "./internal/types/TupleParts";
 import { purry } from "./purry";
+import type { RemedaTypeError } from "./internal/types/RemedaTypeError";
 
 // This prevents typescript from failing on complex arrays and large chunks. It
 // allows the typing to remain useful even when very large chunks are needed,
@@ -37,14 +38,10 @@ type Chunk<
     : GenericChunk<T>;
 
 type LiteralChunk<T extends IterableContainer, N extends number> =
-  | ChunkInfinite<
+  | ChunkRestElement<
       // Our result will always have the prefix tuple chunked the same way, so
       // we compute it once here and send it to the main logic below
-      ChunkFinite<
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-        TuplePrefix<T>,
-        N
-      >,
+      ChunkFixedTuple<TuplePrefix<T>, N>,
       TupleParts<T>["item"],
       TupleParts<T>["suffix"],
       N
@@ -52,21 +49,15 @@ type LiteralChunk<T extends IterableContainer, N extends number> =
   // If both the prefix and suffix tuples are empty then our input is a simple
   // array of the form `Array<Item>`. This means it could also be empty, so we
   // need to add the empty output to our return type.
-  | ([
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-      ...TuplePrefix<T>,
-      ...TupleParts<T>["suffix"],
-    ]["length"] extends 0
+  | ([...TuplePrefix<T>, ...TupleParts<T>["suffix"]] extends readonly []
       ? []
       : never);
 
 /**
- * This type **only** works if the input array `T` is a finite tuple (
- * `[number, "abc", true, { a: "hello" }]` etc..., and it doesn't contain a rest
- * parameter). For these inputs the chunked output could be computed as literal
- * finite tuples too.
+ * This type **only** works if the input array `T` is a fixed tuple. For these
+ * inputs the chunked output could be computed as literal finite tuples too.
  */
-type ChunkFinite<
+type ChunkFixedTuple<
   T,
   N extends number,
   // Important! Result is initialized with an empty array (and not `[[]]`)
@@ -74,7 +65,7 @@ type ChunkFinite<
   Result = [],
 > = T extends readonly [infer Head, ...infer Rest]
   ? // We continue consuming the input tuple recursively item by item.
-    ChunkFinite<
+    ChunkFixedTuple<
       Rest,
       N,
       Result extends [
@@ -105,7 +96,7 @@ type ChunkFinite<
  * creates all possible combinations of adding items to the prefix and suffix
  * for all possible scenarios for how many items the rest param "represents".
  */
-type ChunkInfinite<
+type ChunkRestElement<
   PrefixChunks,
   Item,
   Suffix extends Array<unknown>,
@@ -134,7 +125,7 @@ type ChunkInfinite<
               Subtract<N, LastPrefixChunk["length"]>
             >]: [
               ...PrefixFullChunks,
-              ...ChunkFinite<
+              ...ChunkFixedTuple<
                 // Create a new array that would **not** contain a rest param
                 // (so it's finite) made of the last prefix chunk, padding from
                 // the rest param, and the suffix.
@@ -178,7 +169,7 @@ type SuffixChunk<
   : ValueOf<{
       // When suffix isn't empty we pad the head of the suffix and compute it's
       // chunks for all possible padding sizes.
-      [Padding in IntRange<0, N>]: ChunkFinite<
+      [Padding in IntRange<0, N>]: ChunkFixedTuple<
         [...NTuple<Item, Padding>, ...T],
         N
       >;
@@ -193,6 +184,22 @@ type GenericChunk<T extends IterableContainer> = T extends
   | readonly [unknown, ...Array<unknown>]
   ? NonEmptyArray<NonEmptyArray<T[number]>>
   : Array<NonEmptyArray<T[number]>>;
+
+// TODO: This type was built before we handled optional elements correctly. It needs to be fixed to handle these correctly, specifically in regard to optional elements creating whole chunks that themselves need to be optional, but that their items themselves should not be optional, except the last chunk...
+type TuplePrefix<T extends IterableContainer> = [
+  ...TupleParts<T>["required"],
+  ...(Partial<TupleParts<T>["optional"]> extends ReadonlyArray<unknown>
+    ? Partial<TupleParts<T>["optional"]>
+    : // TODO [>2.0]: TypeScript before version 5.4 couldn't infer the type correctly as an array. This shouldn't be needed once the minimum TypeScript version is bumped above this.
+      RemedaTypeError<
+        "TupleParts",
+        "Partial on arrays should always result in an array",
+        {
+          type: never;
+          metadata: [Partial<TupleParts<T>["optional"]>, T];
+        }
+      >),
+];
 
 /**
  * Split an array into groups the length of `size`. If `array` can't be split evenly, the final chunk will be the remaining elements.

--- a/packages/remeda/src/drop.test-d.ts
+++ b/packages/remeda/src/drop.test-d.ts
@@ -29,9 +29,7 @@ describe("data-first", () => {
   test("suffixed array", () => {
     const result = drop([1] as [...Array<boolean>, number], 2);
 
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean>, number] | [] | [number]
-    >();
+    expectTypeOf(result).toEqualTypeOf<[...Array<boolean>, number] | []>();
   });
 
   describe("arrays with a prefix (2) and a suffix (2)", () => {
@@ -73,7 +71,7 @@ describe("data-first", () => {
       );
 
       expectTypeOf(result).toEqualTypeOf<
-        [...Array<boolean>, string, string] | [string, string] | [string]
+        [...Array<boolean>, string, string] | [string]
       >();
     });
 
@@ -84,7 +82,7 @@ describe("data-first", () => {
       );
 
       expectTypeOf(result).toEqualTypeOf<
-        [...Array<boolean>, string, string] | [] | [string, string] | [string]
+        [...Array<boolean>, string, string] | [] | [string]
       >();
     });
 
@@ -95,7 +93,7 @@ describe("data-first", () => {
       );
 
       expectTypeOf(result).toEqualTypeOf<
-        [...Array<boolean>, string, string] | [] | [string, string] | [string]
+        [...Array<boolean>, string, string] | [] | [string]
       >();
     });
   });
@@ -122,6 +120,16 @@ describe("data-first", () => {
     const result = drop(["a", 1, true] as const, 1 as number);
 
     expectTypeOf(result).toEqualTypeOf<Array<"a" | 1 | true>>();
+  });
+
+  test("union of tuples of different length", () => {
+    expectTypeOf(
+      drop([1, "a"] as [number, string] | [boolean, boolean, number], 1),
+    ).toEqualTypeOf<[string] | [boolean, number]>();
+  });
+
+  test("dropping more than available", () => {
+    expectTypeOf(drop([1, 2, 3] as const, 10)).toEqualTypeOf<[]>();
   });
 });
 
@@ -153,9 +161,7 @@ describe("data-last", () => {
   test("suffix array", () => {
     const result = pipe([1] as [...Array<boolean>, number], drop(2));
 
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean>, number] | [] | [number]
-    >();
+    expectTypeOf(result).toEqualTypeOf<[...Array<boolean>, number] | []>();
   });
 
   test("array with suffix and prefix", () => {
@@ -164,9 +170,7 @@ describe("data-last", () => {
       drop(2),
     );
 
-    expectTypeOf(result).toEqualTypeOf<
-      [...Array<boolean>, string] | [] | [string]
-    >();
+    expectTypeOf(result).toEqualTypeOf<[...Array<boolean>, string] | []>();
   });
 
   test("tuple", () => {

--- a/packages/remeda/src/drop.ts
+++ b/packages/remeda/src/drop.ts
@@ -3,6 +3,7 @@ import type { ClampedIntegerSubtract } from "./internal/types/ClampedIntegerSubt
 import type { CoercedArray } from "./internal/types/CoercedArray";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { PartialArray } from "./internal/types/PartialArray";
 import type { TupleParts } from "./internal/types/TupleParts";
 import { SKIP_ITEM, lazyIdentityEvaluator } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
@@ -29,7 +30,7 @@ type Drop<T extends IterableContainer, N extends number> =
             // the tuple.
             [
               ...DropFixedTuple<TupleParts<T>["required"], N>,
-              ...Partial<TupleParts<T>["optional"]>,
+              ...PartialArray<TupleParts<T>["optional"]>,
               ...CoercedArray<TupleParts<T>["item"]>,
               ...TupleParts<T>["suffix"],
             ]
@@ -43,7 +44,7 @@ type Drop<T extends IterableContainer, N extends number> =
                 // from the optional part, and reconstruct the rest of the
                 // tuple.
                 [
-                  ...Partial<
+                  ...PartialArray<
                     DropFixedTuple<TupleParts<T>["optional"], RemainingPrefix>
                   >,
                   ...CoercedArray<TupleParts<T>["item"]>,

--- a/packages/remeda/src/drop.ts
+++ b/packages/remeda/src/drop.ts
@@ -1,16 +1,17 @@
-import type { IsInteger, IsNegative, Subtract } from "type-fest";
+import type { IsInteger, IsNegative, Writable } from "type-fest";
+import type { ClampedIntegerSubtract } from "./internal/types/ClampedIntegerSubtract";
 import type { CoercedArray } from "./internal/types/CoercedArray";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import type { NTuple } from "./internal/types/NTuple";
-import type { TupleParts, TuplePrefix } from "./internal/types/TupleParts";
+import type { TupleParts } from "./internal/types/TupleParts";
 import { SKIP_ITEM, lazyIdentityEvaluator } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
 
 type Drop<T extends IterableContainer, N extends number> =
   IsNegative<N> extends true
-    ? // Negative numbers result in nothing being dropped.
-      T
+    ? // Negative numbers result in nothing being dropped, we return a shallow
+      // clone of the array.
+      Writable<T>
     : IsInteger<N> extends false
       ? // We can't compute accurate types for non-integer numbers so we
         // fallback to the "legacy" typing where we convert our output to a
@@ -18,66 +19,79 @@ type Drop<T extends IterableContainer, N extends number> =
         // (e.g. it is `number`).
         // TODO: We can improve this type by returning a union of all possible dropped shapes (e.g. the equivalent of Drop<T, 1> | Drop<T, 2> | Drop<T, 3> | ...).
         Array<T[number]>
-      : // We have an non-negative integer N so we start chopping up the array.
-        // first we take a look at its prefix:
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-        TuplePrefix<T> extends [...NTuple<unknown, N>, ...infer Remaining]
-        ? // If the prefix is as long as N, we know the drop would only remove
-          // items from the prefix, so we reconstruct the array with any
-          // remaining items from the prefix, and the rest of the array as it
-          // is...
-          [
-            ...Remaining,
-            ...CoercedArray<TupleParts<T>["item"]>,
-            ...TupleParts<T>["suffix"],
-          ]
-        : // But if the prefix is shorter than N, the drop would also remove
-          // items from the rest param and possibly the suffix.
-          0 extends TupleParts<T>["suffix"]["length"]
-          ? // When there is no suffix the result is simply the rest param, and
-            // dropping items from a simple array results in the same array
-            // type.
-            CoercedArray<TupleParts<T>["item"]>
-          : // But if we have a suffix, the drop could remove items from it.
-            | DropUpTo<
-                  TupleParts<T>["suffix"],
-                  // If the suffix has any items dropped, it would be after all
-                  // prefix items have been removed, so we need to take those
-                  // into account when counting how many items to drop from the
-                  // suffix.
-                  Subtract<
-                    Subtract<N, TupleParts<T>["required"]["length"]>,
-                    // TODO: This type wasn't built with the optional part in mind, we need to consider how it impacts the computed type.
-                    TupleParts<T>["optional"]["length"]
-                  >
-                >
-              // And because we have a rest component, we also need to
-              // consider that all items were removed from that part, leaving
-              // the suffix intact.
-              | [...Array<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]];
+      : ClampedIntegerSubtract<
+            N,
+            TupleParts<T>["required"]["length"]
+          > extends infer RemainingPrefix extends number
+        ? RemainingPrefix extends 0
+          ? // The drop will occur within the required part of the tuple, we
+            // simply remove those elements from it and reconstruct the rest of
+            // the tuple.
+            [
+              ...DropFixedTuple<TupleParts<T>["required"], N>,
+              ...Partial<TupleParts<T>["optional"]>,
+              ...CoercedArray<TupleParts<T>["item"]>,
+              ...TupleParts<T>["suffix"],
+            ]
+          : ClampedIntegerSubtract<
+                RemainingPrefix,
+                TupleParts<T>["optional"]["length"]
+              > extends infer RemainingOptional extends number
+            ? RemainingOptional extends 0
+              ? // The dorp will occur within the optional part of the tuple, we
+                // completely remove the required part, remove enough elements
+                // from the optional part, and reconstruct the rest of the
+                // tuple.
+                [
+                  ...Partial<
+                    DropFixedTuple<TupleParts<T>["optional"], RemainingPrefix>
+                  >,
+                  ...CoercedArray<TupleParts<T>["item"]>,
+                  ...TupleParts<T>["suffix"],
+                ]
+              : // The drop will occur within the rest element or the suffix.
+                // Because the suffix can contain any number of elements this
+                // case adds more complexity as we need to consider all possible
+                // (relevant) lengths. We start by considering the case where
+                // there are enough elements within the rest param; this means
+                // we still maintain the rest element as it could contain even
+                // more elements, and we add the suffix untouched.
+                | [
+                      ...CoercedArray<TupleParts<T>["item"]>,
+                      ...TupleParts<T>["suffix"],
+                    ]
+                  // Additionally, we need to consider the case where the rest
+                  // element has up to the same number of elements as the
+                  // suffix; this will result in removing the rest element
+                  // entirely, and dropping elements from the suffix. We do this
+                  // for all possible values from 0 to N where N is the
+                  // remaining value after we handled the prefix. We can exclude
+                  // the 0 case because it is contained in the previous case.
+                  | Exclude<
+                      DropFixedTuple<
+                        TupleParts<T>["suffix"],
+                        RemainingOptional,
+                        true /* IncludePrefixes */
+                      >,
+                      TupleParts<T>["suffix"]
+                    >
+            : never
+        : never;
 
-/**
- * Arrays with a fixed suffix will result in any number of items being dropped,
- * up to N, and not just N itself. This is because we don't know during typing
- * how many items the "rest" part of the tuple will have in runtime.
- *
- * !Important: This is an internal type and assumes that T is a fixed-size
- * tuple! It will not work if T has a rest element.
- */
-type DropUpTo<
+type DropFixedTuple<
   T,
   N,
-  Dropped extends ReadonlyArray<unknown> = [],
+  // This flag controls if we want a union of all possible prefixes, or just the
+  // final tuple with all N items dropped.
+  IncludePrefixes = false,
+  Dropped extends Array<unknown> = [],
 > = Dropped["length"] extends N
-  ? // The last item had been dropped off T
-    T
-  : T extends [unknown, ...infer Rest]
-    ? // Take the current value, and then recurse with the array where it is
-      // dropped, while counting how many items we've already dropped.
-      DropUpTo<Rest, N, [...Dropped, unknown]> | T
-    : // T is most likely [] at this point, but we use T instead of [] just to
-      // be on the safe side.
-      T;
+  ? T
+  : T extends readonly [unknown, ...infer Rest]
+    ?
+        | DropFixedTuple<Rest, N, IncludePrefixes, [...Dropped, unknown]>
+        | (true extends IncludePrefixes ? T : never)
+    : [];
 
 /**
  * Removes first `n` elements from the `array`.

--- a/packages/remeda/src/drop.ts
+++ b/packages/remeda/src/drop.ts
@@ -39,7 +39,7 @@ type Drop<T extends IterableContainer, N extends number> =
                 TupleParts<T>["optional"]["length"]
               > extends infer RemainingOptional extends number
             ? RemainingOptional extends 0
-              ? // The dorp will occur within the optional part of the tuple, we
+              ? // The drop will occur within the optional part of the tuple, we
                 // completely remove the required part, remove enough elements
                 // from the optional part, and reconstruct the rest of the
                 // tuple.

--- a/packages/remeda/src/internal/types/PartialArray.ts
+++ b/packages/remeda/src/internal/types/PartialArray.ts
@@ -1,0 +1,10 @@
+/**
+ * In versions of TypeScript prior to 5.4 there is an issue inferring an array
+ * type after passing it to Partial without additional testing. To allow simpler
+ * code we pulled this check into it's own utility.
+ *
+ * TODO [>2]: Remove this utility once the minimum TypeScript version is bumped.
+ */
+export type PartialArray<T> = T extends ReadonlyArray<unknown> | []
+  ? Partial<T>
+  : never;

--- a/packages/remeda/src/internal/types/TupleParts.ts
+++ b/packages/remeda/src/internal/types/TupleParts.ts
@@ -135,25 +135,3 @@ type TuplePartsRest<T extends IterableContainer> = {
    */
   item: T extends readonly [] ? never : T[number];
 };
-
-/**
- * ! **DO NOT USE THIS IN NEW CODE** !
- *
- * @deprecated The tuple prefix contains both optional and required elements and
- * doesn't differentiate between them. Most types would require different logic
- * for the optional part than the required part.
- */
-export type TuplePrefix<T extends IterableContainer> = [
-  ...TupleParts<T>["required"],
-  ...(Partial<TupleParts<T>["optional"]> extends ReadonlyArray<unknown>
-    ? Partial<TupleParts<T>["optional"]>
-    : // TODO [>2.0]: TypeScript before version 5.4 couldn't infer the type correctly as an array. This shouldn't be needed once the minimum TypeScript version is bumped above this.
-      RemedaTypeError<
-        "TupleParts",
-        "Partial on arrays should always result in an array",
-        {
-          type: never;
-          metadata: [Partial<TupleParts<T>["optional"]>, T];
-        }
-      >),
-];

--- a/packages/remeda/src/internal/types/TupleSplits.test-d.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.test-d.ts
@@ -3,232 +3,217 @@ import type { TupleSplits } from "./TupleSplits";
 
 declare function tupleSplits<T extends IterableContainer>(x: T): TupleSplits<T>;
 
-describe("mutable", () => {
-  test("empty array", () => {
-    const data = [] as [];
-    const result = tupleSplits(data);
+describe("all tuple shapes", () => {
+  test("empty tuple", () => {
+    expectTypeOf(tupleSplits([])).toEqualTypeOf<{ left: []; right: [] }>();
 
-    expectTypeOf(result).toEqualTypeOf<{
+    expectTypeOf(tupleSplits([] as const)).toEqualTypeOf<{
       left: [];
       right: [];
     }>();
   });
 
-  test("regular array", () => {
-    const data = [] as Array<number>;
-    const result = tupleSplits(data);
-
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: Array<number>;
-        }
-      | {
-          left: Array<number>;
-          right: Array<number>;
-        }
-      | {
-          left: Array<number>;
-          right: [];
-        }
-    >();
-  });
-
   test("fixed tuple", () => {
-    const data = [1, 2, 3] as [1, 2, 3];
-    const result = tupleSplits(data);
+    expectTypeOf(tupleSplits([1, 2, 3] as [1, 2, 3])).toEqualTypeOf<
+      | { left: [1, 2, 3]; right: [] }
+      | { left: [1, 2]; right: [3] }
+      | { left: [1]; right: [2, 3] }
+      | { left: []; right: [1, 2, 3] }
+    >();
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [1, 2, 3];
-          right: [];
-        }
-      | {
-          left: [1, 2];
-          right: [3];
-        }
-      | {
-          left: [1];
-          right: [2, 3];
-        }
-      | {
-          left: [];
-          right: [1, 2, 3];
-        }
+    expectTypeOf(tupleSplits([1, 2, 3] as const)).toEqualTypeOf<
+      | { left: [1, 2, 3]; right: [] }
+      | { left: [1, 2]; right: [3] }
+      | { left: [1]; right: [2, 3] }
+      | { left: []; right: [1, 2, 3] }
     >();
   });
 
-  test("array with prefix", () => {
-    const data = ["a"] as [string, ...Array<boolean>];
-    const result = tupleSplits(data);
+  test("optional tuple", () => {
+    expectTypeOf(tupleSplits([] as [1?, 2?, 3?])).toEqualTypeOf<
+      | { left: [1?, 2?, 3?]; right: [] }
+      | { left: [1?, 2?]; right: [3?] }
+      | { left: [1?]; right: [2?, 3?] }
+      | { left: []; right: [1?, 2?, 3?] }
+    >();
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: [string, ...Array<boolean>];
-        }
-      | {
-          left: [string];
-          right: Array<boolean>;
-        }
-      | {
-          left: [string, ...Array<boolean>];
-          right: Array<boolean>;
-        }
-      | {
-          left: [string, ...Array<boolean>];
-          right: [];
-        }
+    expectTypeOf(tupleSplits([] as readonly [1?, 2?, 3?])).toEqualTypeOf<
+      | { left: [1?, 2?, 3?]; right: [] }
+      | { left: [1?, 2?]; right: [3?] }
+      | { left: [1?]; right: [2?, 3?] }
+      | { left: []; right: [1?, 2?, 3?] }
     >();
   });
 
-  test("array with suffix", () => {
-    const data = ["a"] as [...Array<boolean>, string];
-    const result = tupleSplits(data);
+  test("mixed tuple", () => {
+    expectTypeOf(tupleSplits([1, 2] as [1, 2, 3?, 4?])).toEqualTypeOf<
+      | { left: [1, 2, 3?, 4?]; right: [] }
+      | { left: [1, 2, 3?]; right: [4?] }
+      | { left: [1, 2]; right: [3?, 4?] }
+      | { left: [1]; right: [2, 3?, 4?] }
+      | { left: []; right: [1, 2, 3?, 4?] }
+    >();
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: [...Array<boolean>, string];
-        }
-      | {
-          left: Array<boolean>;
-          right: [...Array<boolean>, string];
-        }
-      | {
-          left: Array<boolean>;
-          right: [string];
-        }
-      | {
-          left: [...Array<boolean>, string];
-          right: [];
-        }
+    expectTypeOf(tupleSplits([1, 2] as readonly [1, 2, 3?, 4?])).toEqualTypeOf<
+      | { left: [1, 2, 3?, 4?]; right: [] }
+      | { left: [1, 2, 3?]; right: [4?] }
+      | { left: [1, 2]; right: [3?, 4?] }
+      | { left: [1]; right: [2, 3?, 4?] }
+      | { left: []; right: [1, 2, 3?, 4?] }
     >();
   });
 
-  test("array with prefix and suffix", () => {
-    const data = [1, "a"] as [number, ...Array<boolean>, string];
-    const result = tupleSplits(data);
+  test("array", () => {
+    expectTypeOf(tupleSplits([] as Array<number>)).toEqualTypeOf<
+      | { left: Array<number>; right: [] }
+      | { left: Array<number>; right: Array<number> }
+      | { left: []; right: Array<number> }
+    >();
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: [number, ...Array<boolean>, string];
-        }
-      | {
-          left: [number];
-          right: [...Array<boolean>, string];
-        }
-      | {
-          left: [number, ...Array<boolean>];
-          right: [...Array<boolean>, string];
-        }
-      | {
-          left: [number, ...Array<boolean>];
-          right: [string];
-        }
-      | {
-          left: [number, ...Array<boolean>, string];
-          right: [];
-        }
+    expectTypeOf(tupleSplits([] as ReadonlyArray<number>)).toEqualTypeOf<
+      | { left: Array<number>; right: [] }
+      | { left: Array<number>; right: Array<number> }
+      | { left: []; right: Array<number> }
     >();
   });
 
-  test("array with optional prefixes", () => {
-    const data = [1, "a"] as [number, string?, number?, ...Array<boolean>];
-    const result = tupleSplits(data);
+  test("fixed-prefix array", () => {
+    expectTypeOf(tupleSplits([1, 2] as [1, 2, ...Array<3>])).toEqualTypeOf<
+      | { left: [1, 2, ...Array<3>]; right: [] }
+      | { left: [1, 2, ...Array<3>]; right: Array<3> }
+      | { left: [1, 2]; right: Array<3> }
+      | { left: [1]; right: [2, ...Array<3>] }
+      | { left: []; right: [1, 2, ...Array<3>] }
+    >();
 
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: [number, string?, number?, ...Array<boolean>];
-        }
-      | {
-          left: [number];
-          right: [string?, number?, ...Array<boolean>];
-        }
-      | {
-          left: [number, string?];
-          right: [number?, ...Array<boolean>];
-        }
-      | {
-          left: [number, string?, number?];
-          right: [...Array<boolean>];
-        }
-      | {
-          left: [number, string?, number?, ...Array<boolean>];
-          right: Array<boolean>;
-        }
-      | {
-          left: [number, string?, number?, ...Array<boolean>];
-          right: [];
-        }
+    expectTypeOf(
+      tupleSplits([1, 2] as readonly [1, 2, ...Array<3>]),
+    ).toEqualTypeOf<
+      | { left: [1, 2, ...Array<3>]; right: [] }
+      | { left: [1, 2, ...Array<3>]; right: Array<3> }
+      | { left: [1, 2]; right: Array<3> }
+      | { left: [1]; right: [2, ...Array<3>] }
+      | { left: []; right: [1, 2, ...Array<3>] }
+    >();
+  });
+
+  test("optional-prefix array", () => {
+    expectTypeOf(tupleSplits([] as [1?, 2?, ...Array<3>])).toEqualTypeOf<
+      | { left: [1?, 2?, ...Array<3>]; right: [] }
+      | { left: [1?, 2?, ...Array<3>]; right: Array<3> }
+      | { left: [1?, 2?]; right: Array<3> }
+      | { left: [1?]; right: [2?, ...Array<3>] }
+      | { left: []; right: [1?, 2?, ...Array<3>] }
+    >();
+
+    expectTypeOf(
+      tupleSplits([] as readonly [1?, 2?, ...Array<3>]),
+    ).toEqualTypeOf<
+      | { left: [1?, 2?, ...Array<3>]; right: [] }
+      | { left: [1?, 2?, ...Array<3>]; right: Array<3> }
+      | { left: [1?, 2?]; right: Array<3> }
+      | { left: [1?]; right: [2?, ...Array<3>] }
+      | { left: []; right: [1?, 2?, ...Array<3>] }
+    >();
+  });
+
+  test("mixed-prefix array", () => {
+    expectTypeOf(
+      tupleSplits([1, 2] as [1, 2, 3?, 4?, ...Array<5>]),
+    ).toEqualTypeOf<
+      | { left: [1, 2, 3?, 4?, ...Array<5>]; right: [] }
+      | { left: [1, 2, 3?, 4?, ...Array<5>]; right: Array<5> }
+      | { left: [1, 2, 3?, 4?]; right: Array<5> }
+      | { left: [1, 2, 3?]; right: [4?, ...Array<5>] }
+      | { left: [1, 2]; right: [3?, 4?, ...Array<5>] }
+      | { left: [1]; right: [2, 3?, 4?, ...Array<5>] }
+      | { left: []; right: [1, 2, 3?, 4?, ...Array<5>] }
+    >();
+
+    expectTypeOf(
+      tupleSplits([1, 2] as readonly [1, 2, 3?, 4?, ...Array<5>]),
+    ).toEqualTypeOf<
+      | { left: [1, 2, 3?, 4?, ...Array<5>]; right: [] }
+      | { left: [1, 2, 3?, 4?, ...Array<5>]; right: Array<5> }
+      | { left: [1, 2, 3?, 4?]; right: Array<5> }
+      | { left: [1, 2, 3?]; right: [4?, ...Array<5>] }
+      | { left: [1, 2]; right: [3?, 4?, ...Array<5>] }
+      | { left: [1]; right: [2, 3?, 4?, ...Array<5>] }
+      | { left: []; right: [1, 2, 3?, 4?, ...Array<5>] }
+    >();
+  });
+
+  test("fixed-suffix array", () => {
+    expectTypeOf(tupleSplits([2, 3] as [...Array<1>, 2, 3])).toEqualTypeOf<
+      | { left: [...Array<1>, 2, 3]; right: [] }
+      | { left: [...Array<1>, 2]; right: [3] }
+      | { left: Array<1>; right: [2, 3] }
+      | { left: Array<1>; right: [...Array<1>, 2, 3] }
+      | { left: []; right: [...Array<1>, 2, 3] }
+    >();
+
+    expectTypeOf(
+      tupleSplits([2, 3] as readonly [...Array<1>, 2, 3]),
+    ).toEqualTypeOf<
+      | { left: [...Array<1>, 2, 3]; right: [] }
+      | { left: [...Array<1>, 2]; right: [3] }
+      | { left: Array<1>; right: [2, 3] }
+      | { left: Array<1>; right: [...Array<1>, 2, 3] }
+      | { left: []; right: [...Array<1>, 2, 3] }
+    >();
+  });
+
+  test("fixed-elements array", () => {
+    expectTypeOf(
+      tupleSplits([1, 2, 4, 5] as [1, 2, ...Array<3>, 4, 5]),
+    ).toEqualTypeOf<
+      | { left: [1, 2, ...Array<3>, 4, 5]; right: [] }
+      | { left: [1, 2, ...Array<3>, 4]; right: [5] }
+      | { left: [1, 2, ...Array<3>]; right: [4, 5] }
+      | { left: [1, 2, ...Array<3>]; right: [...Array<3>, 4, 5] }
+      | { left: [1, 2]; right: [...Array<3>, 4, 5] }
+      | { left: [1]; right: [2, ...Array<3>, 4, 5] }
+      | { left: []; right: [1, 2, ...Array<3>, 4, 5] }
+    >();
+
+    expectTypeOf(
+      tupleSplits([1, 2, 4, 5] as readonly [1, 2, ...Array<3>, 4, 5]),
+    ).toEqualTypeOf<
+      | { left: [1, 2, ...Array<3>, 4, 5]; right: [] }
+      | { left: [1, 2, ...Array<3>, 4]; right: [5] }
+      | { left: [1, 2, ...Array<3>]; right: [4, 5] }
+      | { left: [1, 2, ...Array<3>]; right: [...Array<3>, 4, 5] }
+      | { left: [1, 2]; right: [...Array<3>, 4, 5] }
+      | { left: [1]; right: [2, ...Array<3>, 4, 5] }
+      | { left: []; right: [1, 2, ...Array<3>, 4, 5] }
     >();
   });
 });
 
 describe("unions", () => {
   test("union of arrays", () => {
-    const data = [] as Array<boolean> | Array<number>;
-    const result = tupleSplits(data);
-
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: Array<boolean>;
-        }
-      | {
-          left: Array<boolean>;
-          right: Array<boolean>;
-        }
-      | {
-          left: Array<boolean>;
-          right: [];
-        }
-      | {
-          left: [];
-          right: Array<number>;
-        }
-      | {
-          left: Array<number>;
-          right: Array<number>;
-        }
-      | {
-          left: Array<number>;
-          right: [];
-        }
+    expectTypeOf(
+      tupleSplits([] as Array<boolean> | Array<number>),
+    ).toEqualTypeOf<
+      | { left: []; right: Array<boolean> }
+      | { left: Array<boolean>; right: Array<boolean> }
+      | { left: Array<boolean>; right: [] }
+      | { left: []; right: Array<number> }
+      | { left: Array<number>; right: Array<number> }
+      | { left: Array<number>; right: [] }
     >();
   });
 
   test("mixed unions", () => {
-    const data = [] as Array<boolean> | [number, string];
-    const result = tupleSplits(data);
-
-    expectTypeOf(result).toEqualTypeOf<
-      | {
-          left: [];
-          right: Array<boolean>;
-        }
-      | {
-          left: Array<boolean>;
-          right: Array<boolean>;
-        }
-      | {
-          left: Array<boolean>;
-          right: [];
-        }
-      | {
-          left: [];
-          right: [number, string];
-        }
-      | {
-          left: [number];
-          right: [string];
-        }
-      | {
-          left: [number, string];
-          right: [];
-        }
+    expectTypeOf(
+      tupleSplits([] as Array<boolean> | [number, string]),
+    ).toEqualTypeOf<
+      | { left: []; right: Array<boolean> }
+      | { left: Array<boolean>; right: Array<boolean> }
+      | { left: Array<boolean>; right: [] }
+      | { left: []; right: [number, string] }
+      | { left: [number]; right: [string] }
+      | { left: [number, string]; right: [] }
     >();
   });
 });

--- a/packages/remeda/src/internal/types/TupleSplits.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.ts
@@ -1,6 +1,7 @@
 import type { CoercedArray } from "./CoercedArray";
 import type { IterableContainer } from "./IterableContainer";
 import type { PartialArray } from "./PartialArray";
+import type { RemedaTypeError } from "./RemedaTypeError";
 import type { TupleParts } from "./TupleParts";
 
 /**
@@ -33,7 +34,11 @@ type SplitPrefix<T extends IterableContainer> =
             ...TupleParts<T>["suffix"],
           ];
         }
-      : never
+      : RemedaTypeError<
+          "SplitPrefix",
+          "Unexpected result shape from FixedTupleSplits",
+          { type: never; metadata: [Req, T] }
+        >
     : never;
 
 type SplitOptional<T extends IterableContainer> =
@@ -55,7 +60,11 @@ type SplitOptional<T extends IterableContainer> =
             ...TupleParts<T>["suffix"],
           ];
         }
-      : never
+      : RemedaTypeError<
+          "SplitOptional",
+          "Unexpected result shape from FixedTupleSplits",
+          { type: never; metadata: [Optional, T] }
+        >
     : never;
 
 type SplitRest<T extends IterableContainer> = {
@@ -92,7 +101,11 @@ type SplitSuffix<T extends IterableContainer> =
           ];
           right: Right;
         }
-      : never
+      : RemedaTypeError<
+          "SplitSuffix",
+          "Unexpected result shape from FixedTupleSplits",
+          { type: never; metadata: [Suffix, T] }
+        >
     : never;
 
 type FixedTupleSplits<L, R extends Array<unknown> = []> =

--- a/packages/remeda/src/internal/types/TupleSplits.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.ts
@@ -1,5 +1,6 @@
 import type { CoercedArray } from "./CoercedArray";
 import type { IterableContainer } from "./IterableContainer";
+import type { PartialArray } from "./PartialArray";
 import type { TupleParts } from "./TupleParts";
 
 /**
@@ -27,7 +28,7 @@ type SplitPrefix<T extends IterableContainer> =
           left: Left;
           right: [
             ...Right,
-            ...Partial<TupleParts<T>["optional"]>,
+            ...PartialArray<TupleParts<T>["optional"]>,
             ...CoercedArray<TupleParts<T>["item"]>,
             ...TupleParts<T>["suffix"],
           ];
@@ -65,7 +66,7 @@ type SplitRest<T extends IterableContainer> = {
   // optional prefixes, and for the right side it's the suffix.
   left: [
     ...TupleParts<T>["required"],
-    ...Partial<TupleParts<T>["optional"]>,
+    ...PartialArray<TupleParts<T>["optional"]>,
     ...CoercedArray<TupleParts<T>["item"]>,
   ];
   right: [...CoercedArray<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]];
@@ -85,7 +86,7 @@ type SplitSuffix<T extends IterableContainer> =
           // the tuple.
           left: [
             ...TupleParts<T>["required"],
-            ...Partial<TupleParts<T>["optional"]>,
+            ...PartialArray<TupleParts<T>["optional"]>,
             ...CoercedArray<TupleParts<T>["item"]>,
             ...Left,
           ];

--- a/packages/remeda/src/internal/types/TupleSplits.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.ts
@@ -1,60 +1,101 @@
-import type { IterableContainer } from "./IterableContainer";
-import type { TupleParts, TuplePrefix } from "./TupleParts";
 import type { CoercedArray } from "./CoercedArray";
+import type { IterableContainer } from "./IterableContainer";
+import type { TupleParts } from "./TupleParts";
 
 /**
  * The union of all possible ways to write a tuple as [...left, ...right].
  */
 export type TupleSplits<T extends IterableContainer> =
-  // Use a distributive conditional type, in case T is a union:
+  // Use a distributive conditional type, in case T is a union.
   T extends unknown
-    ?
-        | FixedTupleSplits<
-            // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-            TuplePrefix<T>,
-            [...CoercedArray<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]]
-          >
-        | {
-            left: [
-              // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-              ...TuplePrefix<T>,
-              ...CoercedArray<TupleParts<T>["item"]>,
-            ];
-            right: [
-              ...CoercedArray<TupleParts<T>["item"]>,
-              ...TupleParts<T>["suffix"],
-            ];
-          }
-        | (FixedTupleSplits<TupleParts<T>["suffix"]> extends infer U
-            ? U extends {
-                left: infer L extends ReadonlyArray<unknown>;
-                right: infer R;
-              }
-              ? {
-                  left: [
-                    // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: We need to consider how the 'optional' part of the tuple is handled in this type
-                    ...TuplePrefix<T>,
-                    ...CoercedArray<TupleParts<T>["item"]>,
-                    ...L,
-                  ];
-                  right: R;
-                }
-              : never
-            : never)
+    ? // The complete set of all splits is the union of splitting each part of
+      // the tuple individually.
+      SplitPrefix<T> | SplitOptional<T> | SplitRest<T> | SplitSuffix<T>
     : never;
 
-/**
- * Helper type for `TupleSplits`, for tuples without rest params.
- */
-type FixedTupleSplits<
-  L extends IterableContainer,
-  R extends IterableContainer = [],
-> =
+type SplitPrefix<T extends IterableContainer> =
+  // This distributes the union, which is needed to allow us to "iterate" over
+  // the splits.
+  FixedTupleSplits<TupleParts<T>["required"]> extends infer Req
+    ? Req extends {
+        left: infer Left;
+        right: infer Right extends Array<unknown>;
+      }
+      ? {
+          // For required part we take whatever the left split is, and we
+          // reconstruct the rest of the array for the right side.
+          left: Left;
+          right: [
+            ...Right,
+            ...Partial<TupleParts<T>["optional"]>,
+            ...CoercedArray<TupleParts<T>["item"]>,
+            ...TupleParts<T>["suffix"],
+          ];
+        }
+      : never
+    : never;
+
+type SplitOptional<T extends IterableContainer> =
+  // This distributes the union, which is needed to allow us to "iterate" over
+  // the splits.
+  FixedTupleSplits<TupleParts<T>["optional"]> extends infer Optional
+    ? Optional extends {
+        left: infer Left extends Array<unknown>;
+        right: infer Right extends Array<unknown>;
+      }
+      ? {
+          // For optional part we need to add the required prefix to each left
+          // side, we need to make the partial part partial, and we need to
+          // reconstruct the rest of the tuple for the right side.
+          left: [...TupleParts<T>["required"], ...Partial<Left>];
+          right: [
+            ...Partial<Right>,
+            ...CoercedArray<TupleParts<T>["item"]>,
+            ...TupleParts<T>["suffix"],
+          ];
+        }
+      : never
+    : never;
+
+type SplitRest<T extends IterableContainer> = {
+  // Splitting the rest element is easy, we only need to consider the split
+  // happening "in the middle", which would cause the rest element to be n both
+  // the right and left sides. For each side we simply put the parts of the
+  // tuple that live in that part, for the left side it's the required and
+  // optional prefixes, and for the right side it's the suffix.
+  left: [
+    ...TupleParts<T>["required"],
+    ...Partial<TupleParts<T>["optional"]>,
+    ...CoercedArray<TupleParts<T>["item"]>,
+  ];
+  right: [...CoercedArray<TupleParts<T>["item"]>, ...TupleParts<T>["suffix"]];
+};
+
+type SplitSuffix<T extends IterableContainer> =
+  // This distributes the union, which is needed to allow us to "iterate" over
+  // the splits.
+  FixedTupleSplits<TupleParts<T>["suffix"]> extends infer Suffix
+    ? Suffix extends {
+        left: infer Left extends Array<unknown>;
+        right: infer Right;
+      }
+      ? {
+          // Similar to the required prefix part, the suffix uses the right side
+          // as-is, and reconstructs the left side with all the other parts of
+          // the tuple.
+          left: [
+            ...TupleParts<T>["required"],
+            ...Partial<TupleParts<T>["optional"]>,
+            ...CoercedArray<TupleParts<T>["item"]>,
+            ...Left,
+          ];
+          right: Right;
+        }
+      : never
+    : never;
+
+type FixedTupleSplits<L, R extends Array<unknown> = []> =
   | { left: L; right: R }
-  | (L extends readonly []
-      ? never
-      : L extends readonly [...infer LHead, infer LTail]
-        ? FixedTupleSplits<LHead, [LTail, ...R]>
-        : L extends readonly [...infer LHead, (infer LTail)?]
-          ? FixedTupleSplits<LHead, [LTail?, ...R]>
-          : never);
+  | (L extends readonly [...infer Head, infer Tail]
+      ? FixedTupleSplits<Head, [Tail, ...R]>
+      : never);

--- a/packages/remeda/src/internal/types/TupleSplits.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.ts
@@ -48,9 +48,9 @@ type SplitOptional<T extends IterableContainer> =
           // For optional part we need to add the required prefix to each left
           // side, we need to make the partial part partial, and we need to
           // reconstruct the rest of the tuple for the right side.
-          left: [...TupleParts<T>["required"], ...Partial<Left>];
+          left: [...TupleParts<T>["required"], ...PartialArray<Left>];
           right: [
-            ...Partial<Right>,
+            ...PartialArray<Right>,
             ...CoercedArray<TupleParts<T>["item"]>,
             ...TupleParts<T>["suffix"],
           ];


### PR DESCRIPTION
Removing the deprecated TuplePrefix type and reimplementing the relveant types to handle optional items correctly.

important: chunk has only minor nits changed, it still doesn't handle optionals correctly.