### PR TITLE
fix(dropWhile, dropLastWhile): revert #1076

### DIFF
--- a/packages/remeda/src/dropLastWhile.test-d.ts
+++ b/packages/remeda/src/dropLastWhile.test-d.ts
@@ -1,6 +1,5 @@
 import { constant } from "./constant";
 import { dropLastWhile } from "./dropLastWhile";
-import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";
 
 describe("data-first", () => {
@@ -62,12 +61,6 @@ describe("data-first", () => {
     );
 
     expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
-  });
-
-  test("assert type using predicate", () => {
-    const result = dropLastWhile([1, "a"], isNumber);
-
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 });
 
@@ -133,12 +126,6 @@ describe("data-last", () => {
     );
 
     expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
-  });
-
-  test("assert type using predicate", () => {
-    const result = pipe([1, "a"], dropLastWhile(isNumber));
-
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   describe("predicate is typed correctly", () => {

--- a/packages/remeda/src/dropLastWhile.ts
+++ b/packages/remeda/src/dropLastWhile.ts
@@ -15,10 +15,6 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Array
  */
-export function dropLastWhile<T extends IterableContainer, S extends T[number]>(
-  data: T,
-  predicate: (item: T[number], index: number, data: T) => item is S,
-): Array<S>;
 export function dropLastWhile<T extends IterableContainer>(
   data: T,
   predicate: (item: T[number], index: number, data: T) => boolean,
@@ -37,9 +33,6 @@ export function dropLastWhile<T extends IterableContainer>(
  * @dataLast
  * @category Array
  */
-export function dropLastWhile<T extends IterableContainer, S extends T[number]>(
-  predicate: (item: T[number], index: number, data: T) => item is S,
-): (array: T) => Array<S>;
 export function dropLastWhile<T extends IterableContainer>(
   predicate: (item: T[number], index: number, data: T) => boolean,
 ): (data: T) => Array<T[number]>;

--- a/packages/remeda/src/dropWhile.test-d.ts
+++ b/packages/remeda/src/dropWhile.test-d.ts
@@ -1,7 +1,6 @@
-import { pipe } from "./pipe";
-import { dropWhile } from "./dropWhile";
 import { constant } from "./constant";
-import { isNumber } from "./isNumber";
+import { dropWhile } from "./dropWhile";
+import { pipe } from "./pipe";
 
 describe("data-first", () => {
   test("empty array", () => {
@@ -62,12 +61,6 @@ describe("data-first", () => {
     );
 
     expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
-  });
-
-  test("assert type using predicate", () => {
-    const result = dropWhile([1, "a"], isNumber);
-
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 });
 
@@ -133,12 +126,6 @@ describe("data-last", () => {
     );
 
     expectTypeOf(result).toEqualTypeOf<Array<boolean | string>>();
-  });
-
-  test("assert type using predicate", () => {
-    const result = pipe([1, "a"], dropWhile(isNumber));
-
-    expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
   describe("predicate is typed correctly", () => {

--- a/packages/remeda/src/dropWhile.ts
+++ b/packages/remeda/src/dropWhile.ts
@@ -15,10 +15,6 @@ import { purry } from "./purry";
  * @dataFirst
  * @category Array
  */
-export function dropWhile<T extends IterableContainer, S extends T[number]>(
-  data: T,
-  predicate: (item: T[number], index: number, data: T) => item is S,
-): Array<S>;
 export function dropWhile<T extends IterableContainer>(
   data: T,
   predicate: (item: T[number], index: number, data: T) => boolean,
@@ -37,9 +33,6 @@ export function dropWhile<T extends IterableContainer>(
  * @dataLast
  * @category Array
  */
-export function dropWhile<T extends IterableContainer, S extends T[number]>(
-  predicate: (item: T[number], index: number, data: T) => item is S,
-): (array: T) => Array<S>;
 export function dropWhile<T extends IterableContainer>(
   predicate: (item: T[number], index: number, data: T) => boolean,
 ): (data: T) => Array<T[number]>;


### PR DESCRIPTION
#1076 introduced an error to the return type when `dropWhile` and `dropLastWhile` is used with a type-predicate. This PR reverts those changes until we can implement more accurate types.