### PR TITLE
fix(jsr.io): trigger release

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -35,8 +35,8 @@ jobs:
           HUSKY: 0
 
       - name: 📝 Rewrite package version
-        working-directory: ./packages/remeda
-        run: jq --arg version "${{ github.event.release.tag_name || github.event.inputs.tag }}" '.version = $version' jsr.json | sponge jsr.json
+        working-directory: packages/remeda
+        run: jq '.version = "${{ github.event.release.tag_name || github.event.inputs.tag }}"' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
 
       - name: 🚀 Publish
         run: npm run --workspace=remeda jsr:publish

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: 📝 Rewrite package version
         working-directory: packages/remeda
-        run: jq '.version = "${{ github.event.release.tag_name || github.event.inputs.tag }}"' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
+        run: pwd && jq '.version = "${{ github.event.release.tag_name || github.event.inputs.tag }}"' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
 
       - name: 🚀 Publish
         run: npm run --workspace=remeda jsr:publish

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -17,9 +17,6 @@ jobs:
     name: 🦕 Publish
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -17,6 +17,9 @@ jobs:
     name: 🦕 Publish
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -37,16 +37,9 @@ jobs:
         env:
           HUSKY: 0
 
-      - name: 🔍 Debug - Check files
-        working-directory: packages/remeda
-        run: |
-          pwd
-          ls -la
-          cat jsr.json
-
       - name: 📝 Rewrite package version
         working-directory: packages/remeda
-        run: jq --arg version "${{ github.event.release.tag_name || github.event.inputs.tag }}" '.version = $version' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
+        run: jq '.version = "${{ github.event.release.tag_name || github.event.inputs.tag }}"' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
 
       - name: 🚀 Publish
         run: npm run --workspace=remeda jsr:publish

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -37,9 +37,16 @@ jobs:
         env:
           HUSKY: 0
 
+      - name: 🔍 Debug - Check files
+        working-directory: packages/remeda
+        run: |
+          pwd
+          ls -la
+          cat jsr.json
+
       - name: 📝 Rewrite package version
         working-directory: packages/remeda
-        run: pwd && jq '.version = "${{ github.event.release.tag_name || github.event.inputs.tag }}"' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
+        run: jq --arg version "${{ github.event.release.tag_name || github.event.inputs.tag }}" '.version = $version' jsr.json > jsr.json.tmp && mv jsr.json.tmp jsr.json
 
       - name: 🚀 Publish
         run: npm run --workspace=remeda jsr:publish


### PR DESCRIPTION
We need to trigger a full release so that we get a git tag with a version that includes the jsr.json file we can use when running our release script; otherwise, we cannot debug the release script.