### PR TITLE
docs: deno/jsr.io install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ npm install remeda
 pnpm add remeda
 yarn add remeda
 bun install remeda
+deno add jsr:@remeda/remeda
 ```
 
 ### Usage

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,7 @@
+Welcome to the Remeda monorepo!
+
+- [remeda](remeda/): The library's code.
+- [docs](docs/): The documentation site's code (which is deployed to
+  [remedajs.com](https://remedajs.com)).
+- [pr-sandbox](pr-sandbox/): The sandbox build by [codesandbox](codesandbox.io)
+  for each PR.

--- a/packages/docs/src/components/install-commands.astro
+++ b/packages/docs/src/components/install-commands.astro
@@ -8,6 +8,7 @@ const COMMANDS = [
   "pnpm add remeda",
   "yarn add remeda",
   "bun install remeda",
+  "deno add jsr:@remeda/remeda",
 ];
 ---
 

--- a/packages/remeda/README.md
+++ b/packages/remeda/README.md
@@ -40,6 +40,7 @@ npm install remeda
 pnpm add remeda
 yarn add remeda
 bun install remeda
+deno add jsr:@remeda/remeda
 ```
 
 ### Usage


### PR DESCRIPTION
Also added a readme for the packages root because otherwise GitHub use the one under /docs because an unfortunate fallback path by github :( (

> If you put your README file in your repository's hidden .github, root, **or docs directory**, GitHub will recognize and automatically surface your README to repository visitors.

> If a repository contains more than one README file, then the file shown is chosen from locations in the following order: the .github directory, then the repository's root directory, **and finally the docs directory**.
