### PR TITLE
fix(sumBy,funnel,toCamelCase): fix test coverage issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7392,40 +7392,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.0.tgz",
-      "integrity": "sha512-HjgvaokAiHxRMI5ioXl4WmgAi4zQtKtnltOOlmpzUqApdcTTZrZJAastbbRGydtiqwtYLFaIb6Jpo3PzowZ0cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.2.0",
-        "vitest": "3.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/eslint-plugin": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.2.1.tgz",
@@ -7455,6 +7421,8 @@
       "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.0",
@@ -7472,6 +7440,8 @@
       "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.2.0",
         "estree-walker": "^3.0.3",
@@ -7499,6 +7469,8 @@
       "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -7512,6 +7484,8 @@
       "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.0",
         "pathe": "^2.0.3"
@@ -7526,6 +7500,8 @@
       "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.0",
         "magic-string": "^0.30.17",
@@ -7541,6 +7517,8 @@
       "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -7554,6 +7532,8 @@
       "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.0",
         "loupe": "^3.1.3",
@@ -23349,6 +23329,8 @@
       "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.1",
@@ -23416,6 +23398,8 @@
       "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.0",
@@ -23489,6 +23473,8 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24532,7 +24518,7 @@
         "@eslint/js": "^9.28.0",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/node": "^22.15.29",
-        "@vitest/coverage-v8": "^3.2.0",
+        "@vitest/coverage-v8": "^3.2.1",
         "@vitest/eslint-plugin": "^1.2.1",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
@@ -24550,7 +24536,264 @@
         "tsup": "^8.5.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.1",
-        "vitest": "^3.2.0"
+        "vitest": "^3.2.1"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/coverage-v8": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.1.tgz",
+      "integrity": "sha512-6dy0uF/0BE3jpUW9bFzg0V2S4F7XVaZHL/7qma1XANvHPQGoJuc3wtx911zSoAgUnpfvcLVK1vancNJ95d+uxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.1",
+        "vitest": "3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "packages/remeda/node_modules/@vitest/expect": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
+      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/mocker": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
+      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/remeda/node_modules/@vitest/pretty-format": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
+      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/runner": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
+      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/snapshot": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
+      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/spy": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
+      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/@vitest/utils": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.1",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/remeda/node_modules/vite-node": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
+      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/remeda/node_modules/vitest": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
+      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.1",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/pretty-format": "^3.2.1",
+        "@vitest/runner": "3.2.1",
+        "@vitest/snapshot": "3.2.1",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.1",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.1",
+        "@vitest/ui": "3.2.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -67,7 +67,7 @@
     "@eslint/js": "^9.28.0",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/node": "^22.15.29",
-    "@vitest/coverage-v8": "^3.2.0",
+    "@vitest/coverage-v8": "^3.2.1",
     "@vitest/eslint-plugin": "^1.2.1",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
@@ -85,7 +85,7 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.1"
   },
   "sideEffects": false
 }

--- a/packages/remeda/src/funnel.test.ts
+++ b/packages/remeda/src/funnel.test.ts
@@ -17,6 +17,33 @@ const ARGS_COLLECTOR = (
 ): ReadonlyArray<string> =>
   accumulator === undefined ? [item] : [...accumulator, item];
 
+describe("without a reducer", () => {
+  test("still calls the executor", () => {
+    const mockFn = vi.fn<() => void>();
+    const foo = funnel(mockFn, { triggerAt: "start" });
+    foo.call();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenLastCalledWith();
+  });
+
+  test("handles multiple calls", async () => {
+    const mockFn = vi.fn<() => void>();
+    const foo = funnel(mockFn, { triggerAt: "both", minQuietPeriodMs: UT });
+    foo.call();
+    foo.call();
+    foo.call();
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenLastCalledWith();
+
+    await sleep(2 * UT);
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(mockFn).toHaveBeenLastCalledWith();
+  });
+});
+
 describe("reducer behavior", () => {
   it("passes the reduced arg to the executor", () => {
     const mockFn = vi.fn<(x: string) => void>();

--- a/packages/remeda/src/internal/withPrecision.test.ts
+++ b/packages/remeda/src/internal/withPrecision.test.ts
@@ -1,0 +1,11 @@
+import { identity } from "../identity";
+import { withPrecision } from "./withPrecision";
+
+it("handles numbers that can only be printed in scientific notation", () => {
+  const mockRoundingFn = vi.fn<(input: number) => number>(identity());
+  const roundingFn = withPrecision(mockRoundingFn);
+  roundingFn(Number.parseFloat("1.23e+45"), 6);
+
+  // Notice the shift in the exponent!
+  expect(mockRoundingFn).toHaveBeenCalledWith(Number.parseFloat("1.23e+51"));
+});

--- a/packages/remeda/src/sumBy.ts
+++ b/packages/remeda/src/sumBy.ts
@@ -96,7 +96,7 @@ const sumByImplementation = <T>(
   const iter = array.entries();
 
   const firstEntry = iter.next();
-  if (firstEntry.done ?? false) {
+  if ("done" in firstEntry && firstEntry.done) {
     return 0;
   }
 

--- a/packages/remeda/src/toCamelCase.ts
+++ b/packages/remeda/src/toCamelCase.ts
@@ -114,10 +114,8 @@ const toCamelCaseImplementation = (
     .map(
       (word, index) =>
         `${
-          (index === 0
-            ? // The first word is uncapitalized, the rest are capitalized
-              word[0]?.toLowerCase()
-            : word[0]?.toUpperCase()) ?? ""
+          // The first word is uncapitalized, the rest are capitalized
+          index === 0 ? word[0]!.toLowerCase() : word[0]!.toUpperCase()
         }${preserveConsecutiveUppercase ? word.slice(1) : word.slice(1).toLowerCase()}`,
     )
     .join("");

--- a/packages/remeda/vitest.config.ts
+++ b/packages/remeda/vitest.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
     globals: true,
     coverage: {
       include: ["src/**"],
-      exclude: ["src/index.ts", "src/**/*.test-d.ts"],
+      exclude: [
+        "src/**/*.test-d.ts",
+        "src/index.ts",
+        "src/internal/types/**/*.ts",
+      ],
     },
   },
 });


### PR DESCRIPTION
Our coverage reporting was broken for a while, meaning we weren't getting the signal when a PR broke coverage. Additionally, there have been improvements to coverage in vitest which we can take advantage of.

This PR brings our coverage back to 100% statements, 100% branches, and 100% functions. It does so by slight changes to our impl, and by adding tests:

* funnel: we didn't have any tests without a reducer, this is an important flow that needed proper testing. It also surfaced the fact that our impl was lacking for this case. We now use a symbol and use it to detect the case of void function calls and make it more deliberate that the functions are actually called without any args.
* toCamelCase: `words` would always return non-empty words, but we can't represent that via TypeScript (because there is no non-empty string type). Instead of shipping code that handles a case that can never happen, we now use the erasable non-null assertion symbol.
* sumBy: relied on coalescing the "done" param, but there is no way to cover this because it can't actually happen in v8 (probably in any engine), the fact that "done" is optional is TypeScript playing it extremely safe to begin with. Instead of disabling coverage, I refactored it so that we check the existence of done (which would always return true) and remove the dud coelescing.