### PR TITLE
chore(jsr): add verbose flag to debug failing jobs

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -266,7 +266,7 @@ jobs:
           set -x
           VERSION=$(
             git ls-remote --tags "${{ github.repositoryUrl }}" \
-              | grep --only-matching --extended-regexp "\B(\d+\.){2}\d+$" \
+              | grep --only-matching --perl-regexp "\B(\d+\.){2}\d+$" \
               | sort --version-sort \
               | tail -1
           )

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -265,8 +265,8 @@ jobs:
         run: |
           # Get the latest version tag
           VERSION=$(
-            git ls-remote --tags https://github.com/${{ github.repository }}.git \
-            | grep --only-matching --extended-regexp 'v[0-9]+\.[0-9]+\.[0-9]+$' \
+            git ls-remote --tags "https://github.com/${{ github.repository }}.git" \
+            | grep --only-matching --extended-regexp "v[0-9]+\.[0-9]+\.[0-9]+$" \
             | sort --version-sort \
             | tail -1 \
             | tr -d 'v'
@@ -277,7 +277,7 @@ jobs:
           # otherwise, we set the required (unpublished) version for the rest 
           # of the job.
           curl -s "https://jsr.io/@remeda/remeda/meta.json" \
-          | jq --exit-status --arg version $VERSION '.versions | has($version)' >/dev/null \
+          | jq --exit-status --arg version "$VERSION" ".versions | has($version)" >/dev/null \
           || echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: ⬇️ Checkout Repo
@@ -310,4 +310,4 @@ jobs:
         if: steps.extract-missing.outputs.version != ''
         # We allow dirty here because our jsr.json file has been modified and we
         # don't want to commit it back to the repo.
-        run: npm --workspace=remeda run publish:jsr -- --allow-dirty
+        run: npm --workspace=remeda run publish:jsr -- --allow-dirty --verbose

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -260,54 +260,63 @@ jobs:
       id-token: write
 
     steps:
-      - name: 🫥 Extract Missing Version
-        id: extract-missing
+      - name: 🏷️ Repo Latest Released Version?
+        id: latest-released
         run: |
-          # Get the latest version tag
+          set -x
           VERSION=$(
-            git ls-remote --tags "https://github.com/${{ github.repository }}.git" \
-            | grep --only-matching --extended-regexp "v[0-9]+\.[0-9]+\.[0-9]+$" \
-            | sort --version-sort \
-            | tail -1 \
-            | tr -d 'v'
+            git ls-remote --tags "${{ github.repositoryUrl }}" \
+              | grep --only-matching --extended-regexp "\B(\d+\.){2}\d+$" \
+              | sort --version-sort \
+              | tail -1
           )
+          set +x
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "::notice title=Latest released version in repo::$VERSION"
 
-          # Get the list of published versions from JSR.io and check if the 
-          # latest version has already been published. If it has, we're done;
-          # otherwise, we set the required (unpublished) version for the rest 
-          # of the job.
-          curl -s "https://jsr.io/@remeda/remeda/meta.json" \
-          | jq --exit-status --arg version "$VERSION" ".versions | has($version)" >/dev/null \
-          || echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: 📘 JSR Latest Published Version?
+        id: latest-published
+        run: |
+          set -x
+          VERSION=$(
+            curl -s 'https://jsr.io/@remeda/remeda/meta.json' \
+              | jq --raw-output '.versions | keys | join("\n")' \
+              | sort --version-sort \
+              | tail -1
+          )
+          set +x
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "::notice title=Latest published version in JSR.io::$VERSION"
 
       - name: ⬇️ Checkout Repo
-        if: steps.extract-missing.outputs.version != ''
+        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
         uses: actions/checkout@v4
         with:
           # We want to publish the required tag and not the latest commit.
-          ref: v${{ steps.extract-missing.outputs.version }}
+          ref: v${{ steps.latest-released.outputs.version }}
 
       - name: ⎔ Setup Node
-        if: steps.extract-missing.outputs.version != ''
+        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: 📥 Download Dependencies
-        if: steps.extract-missing.outputs.version != ''
+        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
         uses: bahmutov/npm-install@v1
         env:
           HUSKY: 0
 
       - name: 📝 Update Version
-        if: steps.extract-missing.outputs.version != ''
+        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
         working-directory: packages/remeda
         run: |
-          jq --arg version "${{ steps.extract-missing.outputs.version }}" '.version = $version' jsr.json > jsr.json.tmp \
+          jq --arg version '${{ steps.latest-released.outputs.version }}' '.version = $version' jsr.json \
+          | tee jsr.json.tmp \
           && mv jsr.json.tmp jsr.json
 
       - name: 🦕 Publish to JSR.io
-        if: steps.extract-missing.outputs.version != ''
+        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
         # We allow dirty here because our jsr.json file has been modified and we
         # don't want to commit it back to the repo.
         run: npm --workspace=remeda run publish:jsr -- --allow-dirty --verbose

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -289,26 +289,26 @@ jobs:
           echo "::notice title=Latest published version in JSR.io::$VERSION"
 
       - name: ⬇️ Checkout Repo
-        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
+        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
         uses: actions/checkout@v4
         with:
           # We want to publish the required tag and not the latest commit.
           ref: v${{ steps.latest-released.outputs.version }}
 
       - name: ⎔ Setup Node
-        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
+        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: 📥 Download Dependencies
-        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
+        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
         uses: bahmutov/npm-install@v1
         env:
           HUSKY: 0
 
       - name: 📝 Update Version
-        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
+        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
         working-directory: packages/remeda
         run: |
           jq --arg version '${{ steps.latest-released.outputs.version }}' '.version = $version' jsr.json \
@@ -316,7 +316,7 @@ jobs:
           && mv jsr.json.tmp jsr.json
 
       - name: 🦕 Publish to JSR.io
-        if: steps.latest-released.outputs.version != steps.latest-published.outcome.version
+        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
         # We allow dirty here because our jsr.json file has been modified and we
         # don't want to commit it back to the repo.
         run: npm --workspace=remeda run publish:jsr -- --allow-dirty --verbose


### PR DESCRIPTION
The job fails with a cryptic message:

>     Invalid symbol 45, offset 1102.

It's not clear where this is coming from as it doesn't reproduce locally and it seems that the publish actually succeeds.

Adding the --verbose flag to try and get more info.
