### PR TITLE
chore(jsr): simplify jsr job

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -286,4 +286,4 @@ jobs:
 
       - name: 🦕 Publish to JSR.io
         if: steps.latest-released.outputs.version != ''
-        run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}"
+        run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}" --no-provenance

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -260,63 +260,30 @@ jobs:
       id-token: write
 
     steps:
+      - name: ⬇️ Checkout Repo
+        uses: actions/checkout@v4
+
       - name: 🏷️ Repo Latest Released Version?
         id: latest-released
         run: |
-          set -x
-          VERSION=$(
-            git ls-remote --tags "${{ github.server_url }}/${{ github.repository }}.git" \
-              | grep --only-matching --perl-regexp "\B(\d+\.){2}\d+$" \
-              | sort --version-sort \
-              | tail -1
-          )
-          set +x
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "::notice title=Latest released version in repo::$VERSION"
-
-      - name: 📘 JSR Latest Published Version?
-        id: latest-published
-        run: |
-          set -x
-          VERSION=$(
-            curl -s 'https://jsr.io/@remeda/remeda/meta.json' \
-              | jq --raw-output '.versions | keys | join("\n")' \
-              | sort --version-sort \
-              | tail -1
-          )
-          set +x
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "::notice title=Latest published version in JSR.io::$VERSION"
-
-      - name: ⬇️ Checkout Repo
-        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
-        uses: actions/checkout@v4
-        with:
-          # We want to publish the required tag and not the latest commit.
-          ref: v${{ steps.latest-released.outputs.version }}
+          echo "version=$(
+            git describe --exact-match --tags 2>/dev/null \
+            | grep --only-matching --perl-regexp "\B(\d+\.){2}\d+$" \
+            || true
+          )" >> "$GITHUB_OUTPUT"
 
       - name: ⎔ Setup Node
-        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
+        if: ${{ steps.latest-released.outputs.version != '' }}
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: 📥 Download Dependencies
-        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
+        if: ${{ steps.latest-released.outputs.version != '' }}
         uses: bahmutov/npm-install@v1
         env:
           HUSKY: 0
 
-      - name: 📝 Update Version
-        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
-        working-directory: packages/remeda
-        run: |
-          jq --arg version '${{ steps.latest-released.outputs.version }}' '.version = $version' jsr.json \
-          | tee jsr.json.tmp \
-          && mv jsr.json.tmp jsr.json
-
       - name: 🦕 Publish to JSR.io
-        if: steps.latest-released.outputs.version != steps.latest-published.outputs.version
-        # We allow dirty here because our jsr.json file has been modified and we
-        # don't want to commit it back to the repo.
-        run: npm --workspace=remeda run publish:jsr -- --allow-dirty --verbose
+        if: ${{ steps.latest-released.outputs.version != '' }}
+        run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}"

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -273,17 +273,17 @@ jobs:
           )" >> "$GITHUB_OUTPUT"
 
       - name: ⎔ Setup Node
-        if: ${{ steps.latest-released.outputs.version != '' }}
+        if: steps.latest-released.outputs.version != ''
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: 📥 Download Dependencies
-        if: ${{ steps.latest-released.outputs.version != '' }}
+        if: steps.latest-released.outputs.version != ''
         uses: bahmutov/npm-install@v1
         env:
           HUSKY: 0
 
       - name: 🦕 Publish to JSR.io
-        if: ${{ steps.latest-released.outputs.version != '' }}
+        if: steps.latest-released.outputs.version != ''
         run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}"

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -286,4 +286,4 @@ jobs:
 
       - name: 🦕 Publish to JSR.io
         if: steps.latest-released.outputs.version != ''
-        run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}" --no-provenance
+        run: npm --workspace=remeda run publish:jsr -- --set-version "${{ steps.latest-released.outputs.version }}"

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -51,7 +51,7 @@
     "format": "prettier . --write",
     "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/",
     "lint:build": "attw --pack . && publint",
-    "publish:jsr": "jsr publish",
+    "publish:jsr": "jsr publish --no-provenance",
     "publish:preview": "pkg-pr-new publish",
     "release": "semantic-release",
     "test": "tsc --project tsconfig.tests.json && vitest --typecheck.enabled --typecheck.ignoreSourceErrors",


### PR DESCRIPTION
From reading the code for the publish command, I learned that:
* there's a --set-version flag which allows us to tell JSR what version we are publishing instead of mutating the JSR file
* The job succeeds by ignoring versions that have already been published, making our optimization unnecessary.

Also waiting on some guidance with the provenance errors as reported in: https://github.com/denoland/deno/issues/29671