### PR TITLE
fix(forEachObj,mapKeys,mapValues,omitBy,pickBy,values): support paramerized record keys

### DIFF
--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -104,7 +104,9 @@ test("empty object", () => {
 test("generic key type (Issue #1122)", () => {
   // @ts-expect-error [ts6133] -- Intentional for testing.
   // eslint-disable-next-line unicorn/consistent-function-scoping, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unused-vars
-  const foo = <K extends string>(data: Record<K, "hello">) => {
-    expectTypeOf(enumerableStringKeyedValueOf(data)).toEqualTypeOf<"hello">();
+  const foo = <K extends string>(data: Record<K, { a: "hello" }>) => {
+    const { a } = enumerableStringKeyedValueOf(data);
+
+    expectTypeOf(a).toEqualTypeOf<"hello">();
   };
 });

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -5,7 +5,7 @@ declare function enumerableStringKeyedValueOf<const T>(
   data: T,
 ): EnumerableStringKeyedValueOf<T>;
 
-declare const SymbolFoo: unique symbol;
+const SymbolFoo = Symbol("foo");
 
 test("string values", () => {
   expectTypeOf(
@@ -45,28 +45,26 @@ test("literal values", () => {
   ).toEqualTypeOf<1>();
 
   expectTypeOf(
-    enumerableStringKeyedValueOf({} as { a: "1" | "2" | 1 }),
+    enumerableStringKeyedValueOf({ a: 1 } as { a: "1" | "2" | 1 }),
   ).toEqualTypeOf<"1" | "2" | 1>();
 });
 
 test("optional values", () => {
   expectTypeOf(
-    enumerableStringKeyedValueOf({} as { a: 1; b?: 4 }),
+    enumerableStringKeyedValueOf({ a: 1 } as { a: 1; b?: 4 }),
   ).toEqualTypeOf<1 | 4>();
 
   expectTypeOf(
-    enumerableStringKeyedValueOf({} as { a: string; b?: number }),
+    enumerableStringKeyedValueOf({ a: "hello" } as { a: string; b?: number }),
   ).toEqualTypeOf<number | string>();
 });
 
 test("nullish and undefined values", () => {
   expectTypeOf(
-    enumerableStringKeyedValueOf(
-      {} as {
-        a: string | undefined;
-        b: string | null;
-      },
-    ),
+    enumerableStringKeyedValueOf({ a: "hello", b: "world" } as {
+      a: string | undefined;
+      b: string | null;
+    }),
   ).toEqualTypeOf<string | null | undefined>();
 
   expectTypeOf(
@@ -81,11 +79,11 @@ test("nullish and undefined values", () => {
 
 test("symbol keys", () => {
   expectTypeOf(
-    enumerableStringKeyedValueOf({} as { [SymbolFoo]: string }),
+    enumerableStringKeyedValueOf({ [SymbolFoo]: "hello" } as const),
   ).toEqualTypeOf<never>();
 
   expectTypeOf(
-    enumerableStringKeyedValueOf({} as { [SymbolFoo]: string; b: "1" }),
+    enumerableStringKeyedValueOf({ [SymbolFoo]: "hello", b: "1" } as const),
   ).toEqualTypeOf<"1">();
 
   expectTypeOf(

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -101,10 +101,14 @@ test("empty object", () => {
   ).toEqualTypeOf<never>();
 });
 
-test("generic key type (Issue #1122)", () => {
-  // @ts-expect-error [ts6133] -- Intentional for testing.
-  // eslint-disable-next-line unicorn/consistent-function-scoping, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unused-vars
-  const foo = <K extends string>(data: Record<K, { a: "hello" }>) => {
+test("parameterized record key (Issue #1122)", () => {
+  // @ts-expect-error [ts6133] -- Only functions allow us to define a parametrized record (I think...)
+  // eslint-disable-next-line unicorn/consistent-function-scoping, @typescript-eslint/no-unused-vars -- The function inside this test IS the main point of the test and can't be pulled out or used.
+  const foo = <K extends string>(data: Record<K, { a: "hello" }>): void => {
+    // TypeScript/Vitest (?!) is failing to infer the result of our function
+    // on this type directly, but still manages to typecheck it once we
+    // destructure the result and only test the type of the property. I don't
+    // know why that is and if there's any better more idiomatic way to do this.
     const { a } = enumerableStringKeyedValueOf(data);
 
     expectTypeOf(a).toEqualTypeOf<"hello">();

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -1,90 +1,102 @@
 import type { EmptyObject } from "type-fest";
 import type { EnumerableStringKeyedValueOf } from "./EnumerableStringKeyedValueOf";
 
+declare function enumerableStringKeyedValueOf<const T>(
+  data: T,
+): EnumerableStringKeyedValueOf<T>;
+
 declare const SymbolFoo: unique symbol;
 
 test("string values", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<Record<PropertyKey, string>>
-  >().toEqualTypeOf<string>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as Record<PropertyKey, string>),
+  ).toEqualTypeOf<string>();
 });
 
 test("number values", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<Record<PropertyKey, number>>
-  >().toEqualTypeOf<number>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as Record<PropertyKey, number>),
+  ).toEqualTypeOf<number>();
 });
 
 test("union of records", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<
-      Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">
-    >
-  >().toEqualTypeOf<"cat" | "dog">();
+  expectTypeOf(
+    enumerableStringKeyedValueOf(
+      {} as Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">,
+    ),
+  ).toEqualTypeOf<"cat" | "dog">();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<
-      Record<PropertyKey, number> | Record<PropertyKey, string>
-    >
-  >().toEqualTypeOf<number | string>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf(
+      {} as Record<PropertyKey, number> | Record<PropertyKey, string>,
+    ),
+  ).toEqualTypeOf<number | string>();
 });
 
 test("union values", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<Record<PropertyKey, number | string>>
-  >().toEqualTypeOf<number | string>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as Record<PropertyKey, number | string>),
+  ).toEqualTypeOf<number | string>();
 });
 
 test("literal values", () => {
-  expectTypeOf<EnumerableStringKeyedValueOf<{ a: 1 }>>().toEqualTypeOf<1>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({ a: 1 } as const),
+  ).toEqualTypeOf<1>();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{ a: "1" | "2" | 1 }>
-  >().toEqualTypeOf<"1" | "2" | 1>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as { a: "1" | "2" | 1 }),
+  ).toEqualTypeOf<"1" | "2" | 1>();
 });
 
 test("optional values", () => {
-  expectTypeOf<EnumerableStringKeyedValueOf<{ a: 1; b?: 4 }>>().toEqualTypeOf<
-    1 | 4
-  >();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as { a: 1; b?: 4 }),
+  ).toEqualTypeOf<1 | 4>();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{ a: string; b?: number }>
-  >().toEqualTypeOf<number | string>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as { a: string; b?: number }),
+  ).toEqualTypeOf<number | string>();
 });
 
 test("nullish and undefined values", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{
-      a: string | undefined;
-      b: string | null;
-    }>
-  >().toEqualTypeOf<string | null | undefined>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf(
+      {} as {
+        a: string | undefined;
+        b: string | null;
+      },
+    ),
+  ).toEqualTypeOf<string | null | undefined>();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{
-      a?: number | null;
-      b?: number | null | undefined;
-    }>
-  >().toEqualTypeOf<number | null | undefined>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf(
+      {} as {
+        a?: number | null;
+        b?: number | null | undefined;
+      },
+    ),
+  ).toEqualTypeOf<number | null | undefined>();
 });
 
 test("symbol keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{ [SymbolFoo]: string }>
-  >().toEqualTypeOf<never>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as { [SymbolFoo]: string }),
+  ).toEqualTypeOf<never>();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<{ [SymbolFoo]: string; b: "1" }>
-  >().toEqualTypeOf<"1">();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as { [SymbolFoo]: string; b: "1" }),
+  ).toEqualTypeOf<"1">();
 
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<Record<PropertyKey | typeof SymbolFoo, string>>
-  >().toEqualTypeOf<string>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf(
+      {} as Record<PropertyKey | typeof SymbolFoo, string>,
+    ),
+  ).toEqualTypeOf<string>();
 });
 
 test("empty object", () => {
-  expectTypeOf<
-    EnumerableStringKeyedValueOf<EmptyObject>
-  >().toEqualTypeOf<never>();
+  expectTypeOf(
+    enumerableStringKeyedValueOf({} as EmptyObject),
+  ).toEqualTypeOf<never>();
 });

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -100,3 +100,11 @@ test("empty object", () => {
     enumerableStringKeyedValueOf({} as EmptyObject),
   ).toEqualTypeOf<never>();
 });
+
+test("generic key type (Issue #1122)", () => {
+  // @ts-expect-error [ts6133] -- Intentional for testing.
+  // eslint-disable-next-line unicorn/consistent-function-scoping, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unused-vars
+  const foo = <K extends string>(data: Record<K, "hello">) => {
+    expectTypeOf(enumerableStringKeyedValueOf(data)).toEqualTypeOf<"hello">();
+  };
+});

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
@@ -11,7 +11,10 @@ export type EnumerableStringKeyedValueOf<T> =
     ? IfNever<
         Exclude<keyof T, symbol>,
         // If the only keys in T are symbols then there are no enumerable values
-        // in the object.
+        // in the object. We rely on this `IfNever` construct because it turns
+        // out that Record<PropertyKey, "something">[never] results in
+        // `"something"` and not `never`?!
+        // (@see https://www.typescriptlang.org/play/?#code/C4TwDgpgBAGlC8UBKEDGB7ATgEwDwAVN1JNQBpCEAGigCIBndAWwmAAsBLAOwHNaA+ANpcIANwiYAugG4AUAHp5UZQD0A-LNmhIUAJoJkaLHlpsIAG3PpaNWgHcs57AOFiJMhUtVqgA)
         never,
         // Otherwise we take all possible values from all remaining keys. We use
         // Required to make sure we don't include `undefined` in the result if

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
@@ -1,21 +1,13 @@
-import type { EmptyObject } from "type-fest";
+import type { IfNever } from "type-fest";
 
 /**
  * A union of all values of properties in T which are not keyed by a symbol,
  * following the definition of `Object.values` and `Object.entries`.
  */
-export type EnumerableStringKeyedValueOf<T> = ValuesOf<{
-  [K in keyof T]-?: K extends symbol ? never : T[K];
-}>;
-
-/**
- * Extracts the value type from an object type T.
- */
-type ValuesOf<T> =
-  // EmptyObject is used to infer value type as never instead of unknown
-  // for an empty object
-  T extends EmptyObject
-    ? T[keyof T]
-    : T extends Record<PropertyKey, infer V>
-      ? V
-      : never;
+export type EnumerableStringKeyedValueOf<T> = T extends unknown
+  ? IfNever<
+      Exclude<keyof T, symbol>,
+      never,
+      Required<T>[Exclude<keyof T, symbol>]
+    >
+  : never;

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.ts
@@ -4,10 +4,19 @@ import type { IfNever } from "type-fest";
  * A union of all values of properties in T which are not keyed by a symbol,
  * following the definition of `Object.values` and `Object.entries`.
  */
-export type EnumerableStringKeyedValueOf<T> = T extends unknown
-  ? IfNever<
-      Exclude<keyof T, symbol>,
-      never,
-      Required<T>[Exclude<keyof T, symbol>]
-    >
-  : never;
+export type EnumerableStringKeyedValueOf<T> =
+  // Distribute the union so that the result is the union of outputs of all
+  // possible inputs.
+  T extends unknown
+    ? IfNever<
+        Exclude<keyof T, symbol>,
+        // If the only keys in T are symbols then there are no enumerable values
+        // in the object.
+        never,
+        // Otherwise we take all possible values from all remaining keys. We use
+        // Required to make sure we don't include `undefined` in the result if
+        // props are only optional but don't take `undefined` as a value.
+        // (because we adhere to `exactOptionalPropertyTypes`).
+        Required<T>[Exclude<keyof T, symbol>]
+      >
+    : never;


### PR DESCRIPTION
Fixes #1122

I tested it with the rerpo I put in the issue via the sandbox playground and got the correct types.