### PR TITLE
fix(pickBy): dont add `undefined` to value type of unbounded records

### DIFF
--- a/packages/remeda/src/pickBy.test-d.ts
+++ b/packages/remeda/src/pickBy.test-d.ts
@@ -184,7 +184,7 @@ describe("records with non-narrowing predicates (Issue #696)", () => {
 });
 
 // @see https://github.com/remeda/remeda/issues/1075
-test("narrowing correctly on unbounded records (Issue #1075)", () => {
+test("type-predicates with unbounded records (Issue #1075)", () => {
   expectTypeOf(
     pickBy({} as Record<string, number | null>, isNonNull),
   ).toEqualTypeOf<Record<string, number>>();

--- a/packages/remeda/src/pickBy.test-d.ts
+++ b/packages/remeda/src/pickBy.test-d.ts
@@ -144,12 +144,6 @@ test("works well with nullish type-guards", () => {
   }>();
 });
 
-test("narrowing correctly on unbounded records (Issue #1075)", () => {
-  expectTypeOf(
-    pickBy({} as Record<string, number | null>, isNonNull),
-  ).toEqualTypeOf<Record<string, number>>();
-});
-
 // @see https://github.com/remeda/remeda/issues/696
 describe("records with non-narrowing predicates (Issue #696)", () => {
   test("string keys", () => {
@@ -187,4 +181,11 @@ describe("records with non-narrowing predicates (Issue #696)", () => {
       Record<`${number}`, string> | Record<string, string>
     >();
   });
+});
+
+// @see https://github.com/remeda/remeda/issues/1075
+test("narrowing correctly on unbounded records (Issue #1075)", () => {
+  expectTypeOf(
+    pickBy({} as Record<string, number | null>, isNonNull),
+  ).toEqualTypeOf<Record<string, number>>();
 });

--- a/packages/remeda/src/pickBy.test-d.ts
+++ b/packages/remeda/src/pickBy.test-d.ts
@@ -184,8 +184,52 @@ describe("records with non-narrowing predicates (Issue #696)", () => {
 });
 
 // @see https://github.com/remeda/remeda/issues/1075
-test("type-predicates with unbounded records (Issue #1075)", () => {
-  expectTypeOf(
-    pickBy({} as Record<string, number | null>, isNonNull),
-  ).toEqualTypeOf<Record<string, number>>();
+describe("unbounded records and narrowing predicates (Issue #1075)", () => {
+  test("simple case", () => {
+    expectTypeOf(
+      pickBy({} as Record<string, number | null>, isNonNull),
+    ).toEqualTypeOf<Record<string, number>>();
+  });
+
+  describe("union record types", () => {
+    test("disjoint value types", () => {
+      expectTypeOf(
+        pickBy(
+          {} as
+            | Record<string, string | null>
+            | Record<string, number | boolean>,
+          isString,
+        ),
+      ).toEqualTypeOf<Record<string, string> | Record<string, never>>();
+    });
+
+    test("shared filtered type", () => {
+      expectTypeOf(
+        pickBy(
+          {} as Record<string, number | null> | Record<string, string | null>,
+          isNonNull,
+        ),
+      ).toEqualTypeOf<Record<string, number> | Record<string, string>>();
+    });
+
+    test("shared remaining type", () => {
+      expectTypeOf(
+        pickBy(
+          {} as Record<string, string | number> | Record<string, string | null>,
+          isNonNull,
+        ),
+      ).toEqualTypeOf<
+        Record<string, string | number> | Record<string, string>
+      >();
+    });
+
+    test("same type after narrowing", () => {
+      expectTypeOf(
+        pickBy(
+          {} as Record<string, string | 123> | Record<string, string | 456>,
+          isString,
+        ),
+      ).toEqualTypeOf<Record<string, string>>();
+    });
+  });
 });

--- a/packages/remeda/src/pickBy.test-d.ts
+++ b/packages/remeda/src/pickBy.test-d.ts
@@ -144,6 +144,12 @@ test("works well with nullish type-guards", () => {
   }>();
 });
 
+test("narrowing correctly on unbounded records (Issue #1075)", () => {
+  expectTypeOf(
+    pickBy({} as Record<string, number | null>, isNonNull),
+  ).toEqualTypeOf<Record<string, number>>();
+});
+
 // @see https://github.com/remeda/remeda/issues/696
 describe("records with non-narrowing predicates (Issue #696)", () => {
   test("string keys", () => {

--- a/packages/remeda/src/pickBy.ts
+++ b/packages/remeda/src/pickBy.ts
@@ -19,6 +19,12 @@ type EnumeratedPartial<T> = T extends unknown
         {
           -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
         },
+        // For unbounded records (a simple Record with primitive `string` or
+        // `number` keys) the return type here could technically be T; but for
+        // cases where the record is unbounded but is more complex (like
+        // `symbol` keys) we want to "reconstruct" the record from just it's
+        // enumerable components (which are the ones accessible via
+        // `Object.entries`).
         Record<EnumerableStringKeyOf<T>, EnumerableStringKeyedValueOf<T>>
       >
     >
@@ -39,6 +45,9 @@ type EnumeratedPartialNarrowed<T, S> = T extends unknown
       IfBoundedRecord<
         T,
         ExactProps<T, S> & PartialProps<T, S>,
+        // For unbounded records we need to "reconstruct" the record and narrow
+        // the value types. Similar to the non-narrowed case, we need to also
+        // ignore `symbol` keys and any values that are only relevant to them.
         Record<
           EnumerableStringKeyOf<T>,
           Extract<EnumerableStringKeyedValueOf<T>, S>

--- a/packages/remeda/src/pickBy.ts
+++ b/packages/remeda/src/pickBy.ts
@@ -2,7 +2,6 @@ import type { IfNever, Simplify } from "type-fest";
 import type { EnumerableStringKeyOf } from "./internal/types/EnumerableStringKeyOf";
 import type { EnumerableStringKeyedValueOf } from "./internal/types/EnumerableStringKeyedValueOf";
 import type { IfBoundedRecord } from "./internal/types/IfBoundedRecord";
-import type { ReconstructedRecord } from "./internal/types/ReconstructedRecord";
 import { purry } from "./purry";
 
 // Because pickBy needs to iterate over all entries of the object, only
@@ -20,7 +19,7 @@ type EnumeratedPartial<T> = T extends unknown
         {
           -readonly [P in keyof T as EnumerableKey<P>]?: Required<T>[P];
         },
-        ReconstructedRecord<T>
+        Record<EnumerableStringKeyOf<T>, EnumerableStringKeyedValueOf<T>>
       >
     >
   : never;
@@ -40,7 +39,10 @@ type EnumeratedPartialNarrowed<T, S> = T extends unknown
       IfBoundedRecord<
         T,
         ExactProps<T, S> & PartialProps<T, S>,
-        Record<EnumerableStringKeyOf<T>, S>
+        Record<
+          EnumerableStringKeyOf<T>,
+          Extract<EnumerableStringKeyedValueOf<T>, S>
+        >
       >
     >
   : never;

--- a/packages/remeda/src/pickBy.ts
+++ b/packages/remeda/src/pickBy.ts
@@ -22,7 +22,7 @@ type EnumeratedPartial<T> = T extends unknown
         // For unbounded records (a simple Record with primitive `string` or
         // `number` keys) the return type here could technically be T; but for
         // cases where the record is unbounded but is more complex (like
-        // `symbol` keys) we want to "reconstruct" the record from just it's
+        // `symbol` keys) we want to "reconstruct" the record from just its
         // enumerable components (which are the ones accessible via
         // `Object.entries`).
         Record<EnumerableStringKeyOf<T>, EnumerableStringKeyedValueOf<T>>

--- a/packages/remeda/src/pickBy.ts
+++ b/packages/remeda/src/pickBy.ts
@@ -35,9 +35,15 @@ type EnumeratedPartial<T> = T extends unknown
 // are the "matches", which would not change the "optionality" of the input
 // object's props, and one for partial matches which would also make the props
 // optional (as they could have a value that would be filtered out).
-type EnumeratedPartialNarrowed<T, S> = Simplify<
-  ExactProps<T, S> & PartialProps<T, S>
->;
+type EnumeratedPartialNarrowed<T, S> = T extends unknown
+  ? Simplify<
+      IfBoundedRecord<
+        T,
+        ExactProps<T, S> & PartialProps<T, S>,
+        Record<EnumerableStringKeyOf<T>, S>
+      >
+    >
+  : never;
 
 // The exact case, props here would always be part of the output object
 type ExactProps<T, S> = {


### PR DESCRIPTION
We were handling unbounded records for the non-narrowing case, but didn't address the typing for unbounded records for the narrowing case. The solution is similar, where we need to reconstruct the record, but this time we also need to extract the narrowed type from the original type.

Fixes: #1075