### PR TITLE
chore(tests): lint upgrade follow-ups + even greater standardization of our tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22121,7 +22121,7 @@
         "tsup": "^8.5.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1",
-        "vitest": "^3.2.1"
+        "vitest": "^3.2.4"
       }
     },
     "packages/stackblitz-template": {

--- a/packages/remeda/.vscode/settings.json
+++ b/packages/remeda/.vscode/settings.json
@@ -4,5 +4,8 @@
   // several built-in patterns that are useful (like package-lock.json).
   "explorer.fileNesting.patterns": {
     "*.ts": "${capture}.*.ts"
+  },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always"
   }
 }

--- a/packages/remeda/.vscode/settings.json
+++ b/packages/remeda/.vscode/settings.json
@@ -4,8 +4,5 @@
   // several built-in patterns that are useful (like package-lock.json).
   "explorer.fileNesting.patterns": {
     "*.ts": "${capture}.*.ts"
-  },
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "always"
   }
 }

--- a/packages/remeda/eslint.config.ts
+++ b/packages/remeda/eslint.config.ts
@@ -439,11 +439,10 @@ export default tseslint.config(
         { ignoreTopLevelDescribe: true },
       ],
 
-      // I don't agree with this rule, `it` and `test` should be used based on
-      // the situation. Some times we are testing a specific behavior or trait,
-      // and sometimes we have a specific flow, input, or edge-case that needs
-      // to be tested against.
-      "vitest/consistent-test-it": "off",
+      // Makes everything consistent and clear... If someone wants to they can
+      // add the word 'it' to the beginning of the test name when if it makes
+      // sense.
+      "vitest/consistent-test-it": ["warn", { withinDescribe: "test" }],
 
       // This rule's docs don't provide justification for enabling it and what
       // value it adds. Going by the rule just adds another level of indentation

--- a/packages/remeda/eslint.config.ts
+++ b/packages/remeda/eslint.config.ts
@@ -463,11 +463,6 @@ export default tseslint.config(
       "vitest/prefer-to-be-truthy": "off",
       "vitest/prefer-to-be-falsy": "off",
 
-      // It's rare that hooks are even needed, but in those cases it's probably
-      // preferable to use them as they make it clear that the tests relies on
-      // some weird setup.
-      "vitest/no-hooks": "off",
-
       // TODO: This rule might be useful to guide people to break tests into smaller tests that only expect one thing, but there's no reasonable max value we can configure it to that won't end up feeling arbitrary and noisy.
       "vitest/max-expects": "off",
     },

--- a/packages/remeda/eslint.config.ts
+++ b/packages/remeda/eslint.config.ts
@@ -423,6 +423,7 @@ export default tseslint.config(
     },
   },
   {
+    // All Tests
     files: ["src/**/*.test.ts", "src/**/*.test-d.ts", "test/**/*.*"],
     plugins: {
       vitest,
@@ -455,6 +456,7 @@ export default tseslint.config(
     },
   },
   {
+    // Runtime Tests
     files: ["src/**/*.test.ts"],
     rules: {
       // The range of things that are acceptable for truthy and falsy is wider
@@ -483,11 +485,7 @@ export default tseslint.config(
       // the way of that.
       "@typescript-eslint/consistent-type-definitions": "off",
 
-      // A lot of our type tests use @ts-expect-error as the primary way to test
-      // that function params are typed correctly. This isn't detected properly
-      // by this rule and there's no way to configure it to work; so we disable
-      // it for now... There might be other ways to write the tests so that they
-      // conform to this rule.
+      // TODO: A lot of our type tests use @ts-expect-error as the primary way to test that function params are typed correctly. This isn't detected properly by this rule and there's no way to configure it to work; so we disable it for now... There might be other ways to write the tests so that they conform to this rule.
       "vitest/expect-expect": "off",
 
       // When testing type-predicates (guards) we need to test what happens to

--- a/packages/remeda/eslint.config.ts
+++ b/packages/remeda/eslint.config.ts
@@ -434,11 +434,6 @@ export default tseslint.config(
       // all the recommended ones...
       ...vitest.configs.recommended.rules,
 
-      "vitest/prefer-lowercase-title": [
-        "warn",
-        { ignoreTopLevelDescribe: true },
-      ],
-
       // Makes everything consistent and clear... If someone wants to they can
       // add the word 'it' to the beginning of the test name when if it makes
       // sense.

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -85,7 +85,7 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vitest": "^3.2.1"
+    "vitest": "^3.2.4"
   },
   "sideEffects": false
 }

--- a/packages/remeda/src/add.test.ts
+++ b/packages/remeda/src/add.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { add } from "./add";
 
 test("data-first", () => {

--- a/packages/remeda/src/addProp.test-d.ts
+++ b/packages/remeda/src/addProp.test-d.ts
@@ -1,31 +1,31 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { addProp } from "./addProp";
 
-it("allows redefining prop types", () => {
+test("allows redefining prop types", () => {
   const result = addProp({} as { a: string }, "a", 1);
 
   expectTypeOf(result).toEqualTypeOf<{ a: number }>();
 });
 
-it("makes optional fields required", () => {
+test("makes optional fields required", () => {
   const result = addProp({} as { a?: string }, "a", "hello");
 
   expectTypeOf(result).toEqualTypeOf<{ a: string }>();
 });
 
-it("allows setting an unknown prop", () => {
+test("allows setting an unknown prop", () => {
   const result = addProp({ a: "foo" }, "b", "bar");
 
   expectTypeOf(result).toEqualTypeOf<{ a: string; b: string }>();
 });
 
-it("sets literal unions as optional", () => {
+test("sets literal unions as optional", () => {
   const result = addProp({} as { a: string }, "b" as "b" | "c", 123);
 
   expectTypeOf(result).toEqualTypeOf<{ a: string; b?: number; c?: number }>();
 });
 
-it("keeps the prop optional when the key isn't literal", () => {
+test("keeps the prop optional when the key isn't literal", () => {
   const result = addProp(
     {} as { a?: string; b?: number },
     "a" as "a" | "b",
@@ -35,7 +35,7 @@ it("keeps the prop optional when the key isn't literal", () => {
   expectTypeOf(result).toEqualTypeOf<{ a?: string; b?: number | "foo" }>();
 });
 
-it("works on simple objects", () => {
+test("works on simple objects", () => {
   const result = addProp({} as Record<string, string>, "a", "foo" as const);
 
   expectTypeOf(result).toEqualTypeOf<{ [x: string]: string; a: "foo" }>();

--- a/packages/remeda/src/addProp.test-d.ts
+++ b/packages/remeda/src/addProp.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { addProp } from "./addProp";
 
 it("allows redefining prop types", () => {

--- a/packages/remeda/src/addProp.test.ts
+++ b/packages/remeda/src/addProp.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { addProp } from "./addProp";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/allPass.test.ts
+++ b/packages/remeda/src/allPass.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { allPass } from "./allPass";
 
 const fns = [(x: number) => x % 3 === 0, (x: number) => x % 4 === 0] as const;

--- a/packages/remeda/src/anyPass.test.ts
+++ b/packages/remeda/src/anyPass.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { anyPass } from "./anyPass";
 
 const fns = [(x: number) => x === 3, (x: number) => x === 4] as const;

--- a/packages/remeda/src/capitalize.test-d.ts
+++ b/packages/remeda/src/capitalize.test-d.ts
@@ -1,5 +1,6 @@
-import { pipe } from "./pipe";
+import { describe, expectTypeOf, test } from "vitest";
 import { capitalize } from "./capitalize";
+import { pipe } from "./pipe";
 
 describe("data-first", () => {
   test("on lower case", () => {

--- a/packages/remeda/src/capitalize.test.ts
+++ b/packages/remeda/src/capitalize.test.ts
@@ -1,5 +1,6 @@
-import { pipe } from "./pipe";
+import { describe, expect, test } from "vitest";
 import { capitalize } from "./capitalize";
+import { pipe } from "./pipe";
 
 describe("data-first", () => {
   test("empty string", () => {

--- a/packages/remeda/src/ceil.test.ts
+++ b/packages/remeda/src/ceil.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { ceil } from "./ceil";
 
 describe("data-first", () => {

--- a/packages/remeda/src/chunk.test-d.ts
+++ b/packages/remeda/src/chunk.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { chunk } from "./chunk";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 

--- a/packages/remeda/src/chunk.test.ts
+++ b/packages/remeda/src/chunk.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { chunk } from "./chunk";
 
 describe("data first", () => {
@@ -35,13 +35,13 @@ describe("data last", () => {
 });
 
 describe("edge-cases", () => {
-  it("throws on 0 size", () => {
+  test("throws on 0 size", () => {
     expect(() => chunk(["a", "b", "c", "d"], 0)).toThrow(
       "chunk: A chunk size of '0' would result in an infinite array",
     );
   });
 
-  it("throws on negative size", () => {
+  test("throws on negative size", () => {
     expect(() => chunk(["a", "b", "c", "d"], -10)).toThrow(
       "chunk: A chunk size of '-10' would result in an infinite array",
     );

--- a/packages/remeda/src/chunk.test.ts
+++ b/packages/remeda/src/chunk.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { chunk } from "./chunk";
 
 describe("data first", () => {

--- a/packages/remeda/src/clamp.test.ts
+++ b/packages/remeda/src/clamp.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { clamp } from "./clamp";
 
 it("min value", () => {

--- a/packages/remeda/src/clamp.test.ts
+++ b/packages/remeda/src/clamp.test.ts
@@ -1,14 +1,14 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { clamp } from "./clamp";
 
-it("min value", () => {
+test("min value", () => {
   expect(clamp(10, { min: 20 })).toBe(20);
 });
 
-it("max value", () => {
+test("max value", () => {
   expect(clamp(10, { max: 5 })).toBe(5);
 });
 
-it("ok value", () => {
+test("ok value", () => {
   expect(clamp(10, { max: 20, min: 5 })).toBe(10);
 });

--- a/packages/remeda/src/clone.test.ts
+++ b/packages/remeda/src/clone.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any */
 
+import { describe, expect, it, test } from "vitest";
 import { clone } from "./clone";
 
 describe("primitive types", () => {

--- a/packages/remeda/src/clone.test.ts
+++ b/packages/remeda/src/clone.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any */
 
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { clone } from "./clone";
 
 describe("primitive types", () => {
@@ -24,7 +24,7 @@ describe("primitive types", () => {
 });
 
 describe("objects", () => {
-  it("clones shallow object", () => {
+  test("clones shallow object", () => {
     const obj = { a: 1, b: "foo", c: true, d: new Date(2013, 11, 25) };
     const cloned = clone(obj);
 
@@ -42,7 +42,7 @@ describe("objects", () => {
     });
   });
 
-  it("clones deep object", () => {
+  test("clones deep object", () => {
     const obj = { a: { b: { c: "foo" } } };
     const cloned = clone(obj);
 
@@ -54,7 +54,7 @@ describe("objects", () => {
     expect(cloned).toStrictEqual({ a: { b: { c: "foo" } } });
   });
 
-  it("clones objects with circular references", () => {
+  test("clones objects with circular references", () => {
     const x: any = { c: null };
     const y = { a: x };
     const z = { b: y };
@@ -83,7 +83,7 @@ describe("objects", () => {
 });
 
 describe("arrays", () => {
-  it("clones shallow arrays", () => {
+  test("clones shallow arrays", () => {
     const list = [1, 2, 3];
     const cloned = clone(list);
 
@@ -96,7 +96,7 @@ describe("arrays", () => {
     expect(cloned).toStrictEqual([1, 2, 3]);
   });
 
-  it("clones deep arrays", () => {
+  test("clones deep arrays", () => {
     const list: any = [1, [1, 2, 3], [[[5]]]];
     const cloned = clone(list);
 
@@ -114,7 +114,7 @@ describe("arrays", () => {
 });
 
 describe("functions", () => {
-  it("keep reference to function", () => {
+  test("keep reference to function", () => {
     const list = [{ a: (x: number): number => x + x }] as const;
     const cloned = clone(list);
 
@@ -127,7 +127,7 @@ describe("functions", () => {
 });
 
 describe("built-in types", () => {
-  it("clones Date object", () => {
+  test("clones Date object", () => {
     const date = new Date(2014, 10, 14, 23, 59, 59, 999);
 
     const cloned = clone(date);
@@ -138,7 +138,7 @@ describe("built-in types", () => {
     expect(cloned.getDay()).toBe(5); // friday
   });
 
-  it.each([
+  test.each([
     /x/u,
     /x/gu,
     /x/iu,
@@ -164,7 +164,7 @@ describe("built-in types", () => {
 });
 
 describe("nested mixed objects", () => {
-  it("clones array with objects", () => {
+  test("clones array with objects", () => {
     const list: any = [{ a: { b: 1 } }, [{ c: { d: 1 } }]];
     const cloned = clone(list);
     list[1][0] = null;
@@ -181,7 +181,7 @@ describe("nested mixed objects", () => {
       expect(cloned).toStrictEqual([[1], [[3]]]);
     });
 
-    it("clones array with mutual ref object", () => {
+    test("clones array with mutual ref object", () => {
       const obj = { a: 1 };
       const list = [{ b: obj }, { b: obj }];
       const cloned = clone(list);

--- a/packages/remeda/src/concat.test.ts
+++ b/packages/remeda/src/concat.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { concat } from "./concat";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/conditional.test-d.ts
+++ b/packages/remeda/src/conditional.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { conditional } from "./conditional";
 import { constant } from "./constant";
 import { firstBy } from "./firstBy";
@@ -10,7 +10,7 @@ import { pipe } from "./pipe";
 import { prop } from "./prop";
 
 describe("data-first", () => {
-  it("narrows types in the transformers", () => {
+  test("narrows types in the transformers", () => {
     const data = 3 as number | string;
 
     conditional(
@@ -49,7 +49,7 @@ describe("data-first", () => {
   });
 
   // https://github.com/remeda/remeda/issues/675
-  it("narrows types when using `isNullish`/`isNonNullish` with complex data", () => {
+  test("narrows types when using `isNullish`/`isNonNullish` with complex data", () => {
     const data = firstBy(
       [{ x: 10 }, { x: 20 }] as Array<{ x: number }>,
       prop("x"),
@@ -74,7 +74,7 @@ describe("data-first", () => {
     );
   });
 
-  it("passes the trivial defaultCase's type to the output", () => {
+  test("passes the trivial defaultCase's type to the output", () => {
     expectTypeOf(
       conditional(
         "Jokic",
@@ -93,7 +93,7 @@ describe("data-first", () => {
     ).toEqualTypeOf<"hello" | undefined>();
   });
 
-  it("passes the defaultCase's type to the output", () => {
+  test("passes the defaultCase's type to the output", () => {
     expectTypeOf(
       conditional(
         "Jokic",
@@ -114,7 +114,7 @@ describe("data-first", () => {
 });
 
 describe("data-last", () => {
-  it("narrows types in the transformers", () => {
+  test("narrows types in the transformers", () => {
     const data = 3 as number | string;
 
     pipe(
@@ -155,7 +155,7 @@ describe("data-last", () => {
   });
 
   // https://github.com/remeda/remeda/issues/675
-  it("narrows types when using `isNullish`/`isNonNullish` with complex data", () => {
+  test("narrows types when using `isNullish`/`isNonNullish` with complex data", () => {
     pipe(
       [{ x: 10 }, { x: 20 }],
       firstBy(prop("x")),
@@ -178,7 +178,7 @@ describe("data-last", () => {
     );
   });
 
-  it("passes the trivial defaultCase's type to the output", () => {
+  test("passes the trivial defaultCase's type to the output", () => {
     expectTypeOf(
       pipe(
         "Jokic",
@@ -198,7 +198,7 @@ describe("data-last", () => {
     ).toEqualTypeOf<"hello" | undefined>();
   });
 
-  it("passes the defaultCase's type to the output", () => {
+  test("passes the defaultCase's type to the output", () => {
     expectTypeOf(
       pipe(
         "Jokic",

--- a/packages/remeda/src/conditional.test-d.ts
+++ b/packages/remeda/src/conditional.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { conditional } from "./conditional";
 import { constant } from "./constant";
 import { firstBy } from "./firstBy";

--- a/packages/remeda/src/conditional.test.ts
+++ b/packages/remeda/src/conditional.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { conditional } from "./conditional";
 import { constant } from "./constant";
 import { isDeepEqual } from "./isDeepEqual";
 import { pipe } from "./pipe";
 
 describe("runtime (dataFirst)", () => {
-  it("accepts and runs a default/fallback case", () => {
+  test("accepts and runs a default/fallback case", () => {
     expect(
       conditional(
         "Jokic",
@@ -23,7 +23,7 @@ describe("runtime (dataFirst)", () => {
     ).toBeUndefined();
   });
 
-  it("falls back to our default", () => {
+  test("falls back to our default", () => {
     expect(
       conditional(
         "Jokic",
@@ -41,13 +41,13 @@ describe("runtime (dataFirst)", () => {
     ).toBe("hello");
   });
 
-  it("works with a single case", () => {
+  test("works with a single case", () => {
     expect(conditional("Jokic", [isDeepEqual("Jokic"), () => "center"])).toBe(
       "center",
     );
   });
 
-  it("works with two cases", () => {
+  test("works with two cases", () => {
     expect(
       conditional(
         "Jokic",
@@ -57,7 +57,7 @@ describe("runtime (dataFirst)", () => {
     ).toBe("center");
   });
 
-  it("picks the first matching case", () => {
+  test("picks the first matching case", () => {
     expect(
       conditional(
         "Jokic",
@@ -67,7 +67,7 @@ describe("runtime (dataFirst)", () => {
     ).toBe("center");
   });
 
-  it("throws when no matching case", () => {
+  test("throws when no matching case", () => {
     expect(() =>
       conditional("Jokic", [() => false, () => "world"]),
     ).toThrowErrorMatchingInlineSnapshot(

--- a/packages/remeda/src/conditional.test.ts
+++ b/packages/remeda/src/conditional.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { conditional } from "./conditional";
 import { constant } from "./constant";
 import { isDeepEqual } from "./isDeepEqual";

--- a/packages/remeda/src/constant.test-d.ts
+++ b/packages/remeda/src/constant.test-d.ts
@@ -1,3 +1,4 @@
+import { test } from "vitest";
 import { constant } from "./constant";
 
 test("supported in any api", () => {

--- a/packages/remeda/src/constant.test.ts
+++ b/packages/remeda/src/constant.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { map } from "./map";

--- a/packages/remeda/src/countBy.test-d.ts
+++ b/packages/remeda/src/countBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { countBy } from "./countBy";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/countBy.test.ts
+++ b/packages/remeda/src/countBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { countBy } from "./countBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/debounce.test-d.ts
+++ b/packages/remeda/src/debounce.test-d.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-deprecated -- We know! */
 
-import { expectTypeOf, it, test } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { debounce } from "./debounce";
 import { identity } from "./identity";
 
-it("returns undefined on 'trailing' timing", () => {
+test("returns undefined on 'trailing' timing", () => {
   const debouncer = debounce(() => "Hello, World!", {
     waitMs: 32,
     timing: "trailing",
@@ -14,7 +14,7 @@ it("returns undefined on 'trailing' timing", () => {
   expectTypeOf(result).toEqualTypeOf<string | undefined>();
 });
 
-it("doesn't return undefined on 'leading' timing", () => {
+test("doesn't return undefined on 'leading' timing", () => {
   const debouncer = debounce(() => "Hello, World!", {
     waitMs: 32,
     timing: "leading",
@@ -24,7 +24,7 @@ it("doesn't return undefined on 'leading' timing", () => {
   expectTypeOf(result).toEqualTypeOf<string>();
 });
 
-it("doesn't return undefined on 'both' timing", () => {
+test("doesn't return undefined on 'both' timing", () => {
   const debouncer = debounce(() => "Hello, World!", {
     waitMs: 32,
     timing: "both",
@@ -113,7 +113,7 @@ test("argument typing to be good (with rest param)", () => {
   debouncer.call("a", true, false);
 });
 
-it("doesn't accept maxWaitMs when timing is 'leading'", () => {
+test("doesn't accept maxWaitMs when timing is 'leading'", () => {
   debounce(identity(), { timing: "trailing", maxWaitMs: 32 });
   debounce(identity(), { timing: "both", maxWaitMs: 32 });
   // @ts-expect-error [ts2769]: maxWaitMs not supported!

--- a/packages/remeda/src/debounce.test-d.ts
+++ b/packages/remeda/src/debounce.test-d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-deprecated -- We know! */
 
+import { expectTypeOf, it, test } from "vitest";
 import { debounce } from "./debounce";
 import { identity } from "./identity";
 

--- a/packages/remeda/src/debounce.test.ts
+++ b/packages/remeda/src/debounce.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-deprecated -- We know! */
 
+import { describe, expect, it, vi } from "vitest";
 import { constant } from "./constant";
 import { debounce } from "./debounce";
 import { identity } from "./identity";

--- a/packages/remeda/src/debounce.test.ts
+++ b/packages/remeda/src/debounce.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-deprecated -- We know! */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { constant } from "./constant";
 import { debounce } from "./debounce";
 import { identity } from "./identity";
 
 describe("main functionality", () => {
-  it("should debounce a function", async () => {
+  test("should debounce a function", async () => {
     const mockFn = vi.fn<(x: string) => string>(identity());
 
     const debouncer = debounce(mockFn, { waitMs: 32 });
@@ -33,7 +33,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("subsequent debounced calls return the last `func` result", async () => {
+  test("subsequent debounced calls return the last `func` result", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
     debouncer.call("a");
 
@@ -46,7 +46,7 @@ describe("main functionality", () => {
     expect(debouncer.call("c")).toBe("b");
   });
 
-  it("should not immediately call `func` when `wait` is `0`", async () => {
+  test("should not immediately call `func` when `wait` is `0`", async () => {
     const mockFn = vi.fn<() => void>();
 
     const debouncer = debounce(mockFn, {});
@@ -61,7 +61,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should apply default options", async () => {
+  test("should apply default options", async () => {
     const mockFn = vi.fn<() => void>();
 
     const debouncer = debounce(mockFn, { waitMs: 32 });
@@ -75,7 +75,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should support a `leading` option", async () => {
+  test("should support a `leading` option", async () => {
     const leadingMockFn = vi.fn<() => void>();
     const bothMockFn = vi.fn<() => void>();
 
@@ -107,7 +107,7 @@ describe("main functionality", () => {
     expect(leadingMockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("subsequent leading debounced calls return the last `func` result", async () => {
+  test("subsequent leading debounced calls return the last `func` result", async () => {
     const debouncer = debounce(identity(), { waitMs: 32, timing: "leading" });
 
     expect([debouncer.call("a"), debouncer.call("b")]).toStrictEqual([
@@ -123,7 +123,7 @@ describe("main functionality", () => {
     ]);
   });
 
-  it("should support a `trailing` option", async () => {
+  test("should support a `trailing` option", async () => {
     const mockFn = vi.fn<() => void>();
 
     const withTrailing = debounce(mockFn, { waitMs: 32, timing: "trailing" });
@@ -139,7 +139,7 @@ describe("main functionality", () => {
 });
 
 describe("optional param maxWaitMs", () => {
-  it("should support a `maxWait` option", async () => {
+  test("should support a `maxWait` option", async () => {
     const mockFn = vi.fn<(x: string) => void>();
 
     const debouncer = debounce(mockFn, { waitMs: 32, maxWaitMs: 64 });
@@ -163,7 +163,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should support `maxWait` in a tight loop", async () => {
+  test("should support `maxWait` in a tight loop", async () => {
     const withMockFn = vi.fn<() => void>();
     const withoutMockFn = vi.fn<() => void>();
 
@@ -182,7 +182,7 @@ describe("optional param maxWaitMs", () => {
     expect(withMockFn).not.toHaveBeenCalledTimes(0);
   });
 
-  it("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
+  test("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
     const mockFn = vi.fn<() => void>();
 
     const debouncer = debounce(mockFn, { waitMs: 200, maxWaitMs: 200 });
@@ -204,7 +204,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should cancel `maxDelayed` when `delayed` is invoked", async () => {
+  test("should cancel `maxDelayed` when `delayed` is invoked", async () => {
     const mockFn = vi.fn<() => void>();
 
     const debouncer = debounce(mockFn, { waitMs: 32, maxWaitMs: 64 });
@@ -221,7 +221,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("works like a leaky bucket when only maxWaitMs is set", async () => {
+  test("works like a leaky bucket when only maxWaitMs is set", async () => {
     const mockFn = vi.fn<() => void>();
 
     const debouncer = debounce(mockFn, { maxWaitMs: 32 });
@@ -245,7 +245,7 @@ describe("optional param maxWaitMs", () => {
 });
 
 describe("additional functionality", () => {
-  it("can cancel before the timer starts", async () => {
+  test("can cancel before the timer starts", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(() => {
@@ -259,7 +259,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBe("hello");
   });
 
-  it("can cancel the timer", async () => {
+  test("can cancel the timer", async () => {
     const mockFn = vi.fn<() => string>(constant("Hello, World!"));
     const debouncer = debounce(mockFn, { waitMs: 32 });
 
@@ -284,7 +284,7 @@ describe("additional functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("can cancel after the timer ends", async () => {
+  test("can cancel after the timer ends", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -297,7 +297,7 @@ describe("additional functionality", () => {
     }).not.toThrow();
   });
 
-  it("can cancel maxWait timer", async () => {
+  test("can cancel maxWait timer", async () => {
     const debouncer = debounce(identity(), { waitMs: 16, maxWaitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -310,7 +310,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBeUndefined();
   });
 
-  it("can return a cached value", () => {
+  test("can return a cached value", () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
 
     expect(debouncer.cachedValue).toBeUndefined();
@@ -318,7 +318,7 @@ describe("additional functionality", () => {
     expect(debouncer.cachedValue).toBe("hello");
   });
 
-  it("can check for inflight timers (trailing)", async () => {
+  test("can check for inflight timers (trailing)", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.isPending).toBe(false);
@@ -335,7 +335,7 @@ describe("additional functionality", () => {
     expect(debouncer.isPending).toBe(false);
   });
 
-  it("can check for inflight timers (leading)", async () => {
+  test("can check for inflight timers (leading)", async () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
 
     expect(debouncer.isPending).toBe(false);
@@ -352,7 +352,7 @@ describe("additional functionality", () => {
     expect(debouncer.isPending).toBe(false);
   });
 
-  it("can flush before a cool-down", async () => {
+  test("can flush before a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.flush()).toBeUndefined();
@@ -364,7 +364,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBe("hello");
   });
 
-  it("can flush during a cool-down", async () => {
+  test("can flush during a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -378,7 +378,7 @@ describe("additional functionality", () => {
     expect(debouncer.flush()).toBe("world");
   });
 
-  it("can flush after a cool-down", async () => {
+  test("can flush after a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -390,7 +390,7 @@ describe("additional functionality", () => {
 });
 
 describe("errors", () => {
-  it("prevents maxWaitMs to be less then waitMs", () => {
+  test("prevents maxWaitMs to be less then waitMs", () => {
     expect(() => debounce(identity(), { waitMs: 32, maxWaitMs: 16 })).toThrow(
       "debounce: maxWaitMs (16) cannot be less than waitMs (32)",
     );

--- a/packages/remeda/src/difference.test.ts
+++ b/packages/remeda/src/difference.test.ts
@@ -1,19 +1,19 @@
-import { expect, it, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 import { difference } from "./difference";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { take } from "./take";
 
-it("returns empty array on empty input", () => {
+test("returns empty array on empty input", () => {
   expect(difference([], [1, 2, 3])).toStrictEqual([]);
 });
 
-it("removes nothing on empty other array", () => {
+test("removes nothing on empty other array", () => {
   expect(difference([1, 2, 3], [])).toStrictEqual([1, 2, 3]);
 });
 
-it("returns a shallow clone when nothing is removed", () => {
+test("returns a shallow clone when nothing is removed", () => {
   const data = [1, 2, 3];
   const result = difference(data, [4, 5, 6]);
 
@@ -21,37 +21,37 @@ it("returns a shallow clone when nothing is removed", () => {
   expect(result).not.toBe(data);
 });
 
-it("removes an item that is in the input", () => {
+test("removes an item that is in the input", () => {
   expect(difference([1], [1])).toStrictEqual([]);
 });
 
-it("doesn't remove items that are not in the other array", () => {
+test("doesn't remove items that are not in the other array", () => {
   expect(difference([1], [2])).toStrictEqual([1]);
 });
 
-it("maintains multi-set semantics (removes only one copy)", () => {
+test("maintains multi-set semantics (removes only one copy)", () => {
   expect(difference([1, 1, 2, 2], [1])).toStrictEqual([1, 2, 2]);
 });
 
-it("works if the other array has more copies than the input", () => {
+test("works if the other array has more copies than the input", () => {
   expect(difference([1], [1, 1])).toStrictEqual([]);
 });
 
-it("preserves the original order in source array", () => {
+test("preserves the original order in source array", () => {
   expect(difference([3, 1, 2, 2, 4], [2])).toStrictEqual([3, 1, 2, 4]);
 });
 
-it("accounts and removes multiple copies", () => {
+test("accounts and removes multiple copies", () => {
   expect(difference([1, 2, 3, 1, 2, 3, 1, 2, 3], [1, 2, 1, 2])).toStrictEqual([
     3, 3, 1, 2, 3,
   ]);
 });
 
-it("works with strings", () => {
+test("works with strings", () => {
   expect(difference(["a", "b", "c"], ["b"])).toStrictEqual(["a", "c"]);
 });
 
-it("works with objects", () => {
+test("works with objects", () => {
   const item = { a: 2 };
 
   expect(difference([item, { b: 3 }, item], [item, item])).toStrictEqual([
@@ -59,7 +59,7 @@ it("works with objects", () => {
   ]);
 });
 
-it("compares objects by reference", () => {
+test("compares objects by reference", () => {
   expect(difference([{ a: 2 }, { b: 3 }], [{ a: 2 }])).toStrictEqual([
     { a: 2 },
     { b: 3 },

--- a/packages/remeda/src/difference.test.ts
+++ b/packages/remeda/src/difference.test.ts
@@ -1,3 +1,4 @@
+import { expect, it, test, vi } from "vitest";
 import { difference } from "./difference";
 import { identity } from "./identity";
 import { map } from "./map";

--- a/packages/remeda/src/differenceWith.test.ts
+++ b/packages/remeda/src/differenceWith.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { differenceWith } from "./differenceWith";
 import { isDeepEqual } from "./isDeepEqual";

--- a/packages/remeda/src/divide.test.ts
+++ b/packages/remeda/src/divide.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { divide } from "./divide";
 
 test("data-first", () => {

--- a/packages/remeda/src/doNothing.test-d.ts
+++ b/packages/remeda/src/doNothing.test-d.ts
@@ -1,3 +1,4 @@
+import { test } from "vitest";
 import { doNothing } from "./doNothing";
 
 test("supported in any api", () => {

--- a/packages/remeda/src/doNothing.test.ts
+++ b/packages/remeda/src/doNothing.test.ts
@@ -1,9 +1,9 @@
 //! IMPORTANT: It's impossible to verify that a function does nothing without checking it's implementation, so there aren't any obvious way to expect some result. This clashes with the expectations of the vitest eslint plugin rule vitest/valid-expect. To work around this we wrapped all our calls and expect them not to throw. It doesn't mean we think this function would throw in **any** case!
 
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { doNothing } from "./doNothing";
 
-it("does nothing when called with no arguments", () => {
+test("does nothing when called with no arguments", () => {
   const doesNothing = doNothing();
 
   expect(() => {
@@ -11,7 +11,7 @@ it("does nothing when called with no arguments", () => {
   }).not.toThrow();
 });
 
-it("ignores any parameters sent to the function", () => {
+test("ignores any parameters sent to the function", () => {
   const doesNothing = doNothing();
 
   expect(() => {

--- a/packages/remeda/src/doNothing.test.ts
+++ b/packages/remeda/src/doNothing.test.ts
@@ -1,5 +1,6 @@
 //! IMPORTANT: It's impossible to verify that a function does nothing without checking it's implementation, so there aren't any obvious way to expect some result. This clashes with the expectations of the vitest eslint plugin rule vitest/valid-expect. To work around this we wrapped all our calls and expect them not to throw. It doesn't mean we think this function would throw in **any** case!
 
+import { expect, it } from "vitest";
 import { doNothing } from "./doNothing";
 
 it("does nothing when called with no arguments", () => {

--- a/packages/remeda/src/drop.test-d.ts
+++ b/packages/remeda/src/drop.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { drop } from "./drop";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/drop.test.ts
+++ b/packages/remeda/src/drop.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { drop } from "./drop";
 import { map } from "./map";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/drop.test.ts
+++ b/packages/remeda/src/drop.test.ts
@@ -1,23 +1,23 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { drop } from "./drop";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { take } from "./take";
 
 describe("data first", () => {
-  it("works on regular inputs", () => {
+  test("works on regular inputs", () => {
     expect(drop([1, 2, 3, 4, 5], 2)).toStrictEqual([3, 4, 5]);
   });
 
-  it("works trivially on empty arrays", () => {
+  test("works trivially on empty arrays", () => {
     expect(drop([], 2)).toStrictEqual([]);
   });
 
-  it("works trivially with negative numbers", () => {
+  test("works trivially with negative numbers", () => {
     expect(drop([1, 2, 3, 4, 5], -1)).toStrictEqual([1, 2, 3, 4, 5]);
   });
 
-  it("works when dropping more than the length of the array", () => {
+  test("works when dropping more than the length of the array", () => {
     expect(drop([1, 2, 3, 4, 5], 10)).toStrictEqual([]);
   });
 
@@ -31,19 +31,19 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("works on regular inputs", () => {
+  test("works on regular inputs", () => {
     expect(pipe([1, 2, 3, 4, 5], drop(2))).toStrictEqual([3, 4, 5]);
   });
 
-  it("works trivially on empty arrays", () => {
+  test("works trivially on empty arrays", () => {
     expect(pipe([], drop(2))).toStrictEqual([]);
   });
 
-  it("works trivially with negative numbers", () => {
+  test("works trivially with negative numbers", () => {
     expect(pipe([1, 2, 3, 4, 5], drop(-1))).toStrictEqual([1, 2, 3, 4, 5]);
   });
 
-  it("works when dropping more than the length of the array", () => {
+  test("works when dropping more than the length of the array", () => {
     expect(pipe([1, 2, 3, 4, 5], drop(10))).toStrictEqual([]);
   });
 

--- a/packages/remeda/src/dropFirstBy.test.ts
+++ b/packages/remeda/src/dropFirstBy.test.ts
@@ -1,34 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { dropFirstBy } from "./dropFirstBy";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
 
 describe("runtime (dataFirst)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(dropFirstBy(data, 2, identity())).toStrictEqual([5, 6, 4, 3, 7]);
   });
 
-  it("handles empty arrays gracefully", () => {
+  test("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
 
     expect(dropFirstBy(data, 1, identity())).toHaveLength(0);
   });
 
-  it("handles negative numbers gracefully", () => {
+  test("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(dropFirstBy(data, -3, identity())).toHaveLength(data.length);
   });
 
-  it("handles overflowing numbers gracefully", () => {
+  test("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(dropFirstBy(data, 100, identity())).toHaveLength(0);
   });
 
-  it("clones the input when needed", () => {
+  test("clones the input when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = dropFirstBy(data, 0, identity());
 
@@ -36,7 +36,7 @@ describe("runtime (dataFirst)", () => {
     expect(result).toStrictEqual(data);
   });
 
-  it("works with complex compare rules", () => {
+  test("works with complex compare rules", () => {
     const data = [
       "a",
       "aaa",
@@ -63,7 +63,7 @@ describe("runtime (dataFirst)", () => {
 });
 
 describe("runtime (dataLast)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -74,7 +74,7 @@ describe("runtime (dataLast)", () => {
     ).toStrictEqual([5, 6, 4, 3, 7]);
   });
 
-  it("handles empty arrays gracefully", () => {
+  test("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
 
     expect(
@@ -85,7 +85,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(0);
   });
 
-  it("handles negative numbers gracefully", () => {
+  test("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -96,7 +96,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(data.length);
   });
 
-  it("handles overflowing numbers gracefully", () => {
+  test("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -107,7 +107,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(0);
   });
 
-  it("clones the data when needed", () => {
+  test("clones the data when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = pipe(
       data,
@@ -118,7 +118,7 @@ describe("runtime (dataLast)", () => {
     expect(result).toStrictEqual(data);
   });
 
-  it("works with complex compare rules", () => {
+  test("works with complex compare rules", () => {
     const data = [
       "a",
       "aaa",

--- a/packages/remeda/src/dropFirstBy.test.ts
+++ b/packages/remeda/src/dropFirstBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { dropFirstBy } from "./dropFirstBy";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/dropLast.test-d.ts
+++ b/packages/remeda/src/dropLast.test-d.ts
@@ -1,5 +1,6 @@
-import { pipe } from "./pipe";
+import { describe, expectTypeOf, test } from "vitest";
 import { dropLast } from "./dropLast";
+import { pipe } from "./pipe";
 
 describe("data-first", () => {
   test("empty array", () => {

--- a/packages/remeda/src/dropLast.test.ts
+++ b/packages/remeda/src/dropLast.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { dropLast } from "./dropLast";
 
 test("empty array", () => {

--- a/packages/remeda/src/dropLastWhile.test-d.ts
+++ b/packages/remeda/src/dropLastWhile.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { dropLastWhile } from "./dropLastWhile";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/dropLastWhile.test.ts
+++ b/packages/remeda/src/dropLastWhile.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { dropLastWhile } from "./dropLastWhile";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/dropLastWhile.test.ts
+++ b/packages/remeda/src/dropLastWhile.test.ts
@@ -1,25 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { dropLastWhile } from "./dropLastWhile";
 import { pipe } from "./pipe";
 
 describe("data first", () => {
-  it("should return items until the last predicate failure", () => {
+  test("should return items until the last predicate failure", () => {
     expect(dropLastWhile([1, 2, 3, 4], (n) => n !== 2)).toStrictEqual([1, 2]);
   });
 
-  it("should return an empty array when all items pass the predicate", () => {
+  test("should return an empty array when all items pass the predicate", () => {
     expect(dropLastWhile([1, 2, 3, 4], (n) => n > 0)).toStrictEqual([]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(dropLastWhile([], (n) => n > 0)).toStrictEqual([]);
   });
 
-  it("should return first item when first item fails the predicate", () => {
+  test("should return first item when first item fails the predicate", () => {
     expect(dropLastWhile([1, 2, 3, 4], (n) => n !== 1)).toStrictEqual([1]);
   });
 
-  it("should return a copy of the array when the last item fails the predicate", () => {
+  test("should return a copy of the array when the last item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = dropLastWhile(data, (n) => n !== 4);
 
@@ -29,7 +29,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("should return items until the last predicate failure", () => {
+  test("should return items until the last predicate failure", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -38,7 +38,7 @@ describe("data last", () => {
     ).toStrictEqual([1, 2]);
   });
 
-  it("should return an empty array when all items pass the predicate", () => {
+  test("should return an empty array when all items pass the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -47,7 +47,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(
       pipe(
         [],
@@ -56,7 +56,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return first item when first item fails the predicate", () => {
+  test("should return first item when first item fails the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -65,7 +65,7 @@ describe("data last", () => {
     ).toStrictEqual([1]);
   });
 
-  it("should return a copy of the array when the last item fails the predicate", () => {
+  test("should return a copy of the array when the last item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = pipe(
       data,

--- a/packages/remeda/src/dropWhile.test-d.ts
+++ b/packages/remeda/src/dropWhile.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { dropWhile } from "./dropWhile";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/dropWhile.test.ts
+++ b/packages/remeda/src/dropWhile.test.ts
@@ -1,25 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { dropWhile } from "./dropWhile";
 import { pipe } from "./pipe";
 
 describe("data first", () => {
-  it("should return items starting from the first predicate failure", () => {
+  test("should return items starting from the first predicate failure", () => {
     expect(dropWhile([1, 2, 3, 4], (n) => n !== 3)).toStrictEqual([3, 4]);
   });
 
-  it("should return an empty array when all items pass the predicate", () => {
+  test("should return an empty array when all items pass the predicate", () => {
     expect(dropWhile([1, 2, 3, 4], (n) => n > 0)).toStrictEqual([]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(dropWhile([], (n) => n > 0)).toStrictEqual([]);
   });
 
-  it("should return last item when last item fails the predicate", () => {
+  test("should return last item when last item fails the predicate", () => {
     expect(dropWhile([1, 2, 3, 4], (n) => n !== 4)).toStrictEqual([4]);
   });
 
-  it("should return a copy of the array when the first item fails the predicate", () => {
+  test("should return a copy of the array when the first item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = dropWhile(data, (n) => n !== 1);
 
@@ -29,7 +29,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("should return items starting from the first predicate failure", () => {
+  test("should return items starting from the first predicate failure", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -38,7 +38,7 @@ describe("data last", () => {
     ).toStrictEqual([3, 4]);
   });
 
-  it("should return an empty array when all items pass the predicate", () => {
+  test("should return an empty array when all items pass the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -47,7 +47,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -56,7 +56,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return last item when last item fails the predicate", () => {
+  test("should return last item when last item fails the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -65,7 +65,7 @@ describe("data last", () => {
     ).toStrictEqual([4]);
   });
 
-  it("should return a copy of the array when the first item fails the predicate", () => {
+  test("should return a copy of the array when the first item fails the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = pipe(
       data,

--- a/packages/remeda/src/dropWhile.test.ts
+++ b/packages/remeda/src/dropWhile.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { dropWhile } from "./dropWhile";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/endsWith.test-d.ts
+++ b/packages/remeda/src/endsWith.test-d.ts
@@ -1,5 +1,6 @@
-import { partition } from "./partition";
+import { describe, expectTypeOf, test } from "vitest";
 import { endsWith } from "./endsWith";
+import { partition } from "./partition";
 
 describe("data-first", () => {
   test("doesn't narrow on 'string' prefix", () => {

--- a/packages/remeda/src/endsWith.test.ts
+++ b/packages/remeda/src/endsWith.test.ts
@@ -1,5 +1,6 @@
-import { pipe } from "./pipe";
+import { expect, test } from "vitest";
 import { endsWith } from "./endsWith";
+import { pipe } from "./pipe";
 
 test("empty data", () => {
   expect(endsWith("", "")).toBe(true);

--- a/packages/remeda/src/entries.test-d.ts
+++ b/packages/remeda/src/entries.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { entries } from "./entries";
 
 test("with known properties", () => {

--- a/packages/remeda/src/entries.test.ts
+++ b/packages/remeda/src/entries.test.ts
@@ -1,7 +1,7 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { entries } from "./entries";
 
-it("should return pairs", () => {
+test("should return pairs", () => {
   expect(entries({ a: 1, b: 2, c: 3 })).toStrictEqual([
     ["a", 1],
     ["b", 2],
@@ -9,21 +9,21 @@ it("should return pairs", () => {
   ]);
 });
 
-it("should ignore symbol keys", () => {
+test("should ignore symbol keys", () => {
   expect(entries({ [Symbol("a")]: 1 })).toStrictEqual([]);
 });
 
-it("should turn numbers to strings", () => {
+test("should turn numbers to strings", () => {
   expect(entries({ 1: "hello" })).toStrictEqual([["1", "hello"]]);
 });
 
-it("returns symbol values", () => {
+test("returns symbol values", () => {
   const mySymbol = Symbol("hello");
 
   expect(entries({ a: mySymbol })).toStrictEqual([["a", mySymbol]]);
 });
 
-it("works with complex objects as values", () => {
+test("works with complex objects as values", () => {
   const complexObject = { a: { b: { c: [{ d: true }, { d: false }] } } };
 
   expect(entries({ a: complexObject })).toStrictEqual([["a", complexObject]]);

--- a/packages/remeda/src/entries.test.ts
+++ b/packages/remeda/src/entries.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { entries } from "./entries";
 
 it("should return pairs", () => {

--- a/packages/remeda/src/evolve.test-d.ts
+++ b/packages/remeda/src/evolve.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { add } from "./add";
 import { evolve } from "./evolve";
 import { identity } from "./identity";

--- a/packages/remeda/src/evolve.test-d.ts
+++ b/packages/remeda/src/evolve.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { add } from "./add";
 import { evolve } from "./evolve";
 import { identity } from "./identity";
@@ -10,7 +10,7 @@ import { reduce } from "./reduce";
 import { set } from "./set";
 
 describe("data first", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
+  test("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     const result = evolve(
       {
         id: 1,
@@ -31,13 +31,13 @@ describe("data first", () => {
     }>();
   });
 
-  it("is not destructive and is immutable", () => {
+  test("is not destructive and is immutable", () => {
     const result = evolve({ n: 100 }, { n: add(1) });
 
     expectTypeOf(result).toEqualTypeOf<{ n: number }>();
   });
 
-  it("is recursive", () => {
+  test("is recursive", () => {
     const result = evolve(
       { first: 1, nested: { second: 2, third: 3 } },
       { nested: { second: add(-1), third: add(1) } },
@@ -49,7 +49,7 @@ describe("data first", () => {
     }>();
   });
 
-  it("can handle data that is complex nested objects", () => {
+  test("can handle data that is complex nested objects", () => {
     const result = evolve(
       {
         array: ["1", "2", "3"],
@@ -74,7 +74,7 @@ describe("data first", () => {
   });
 
   describe("type reflection", (): void => {
-    it("can reflect type of data to function of evolver object", () => {
+    test("can reflect type of data to function of evolver object", () => {
       const result = evolve(
         {
           id: 1,
@@ -101,7 +101,7 @@ describe("data first", () => {
       }>();
     });
 
-    it("can reflect type of data to function of nested evolver object", () => {
+    test("can reflect type of data to function of nested evolver object", () => {
       const result = evolve(
         {
           id: 1,
@@ -129,7 +129,7 @@ describe("data first", () => {
     });
   });
 
-  it("can detect mismatch of parameters and arguments", () => {
+  test("can detect mismatch of parameters and arguments", () => {
     evolve(
       {
         number: "1",
@@ -153,7 +153,7 @@ describe("data first", () => {
     );
   });
 
-  it("does not accept function that require multiple arguments", () => {
+  test("does not accept function that require multiple arguments", () => {
     evolve(
       { requiring2Args: 1, requiring3Args: 1 },
       {
@@ -166,7 +166,7 @@ describe("data first", () => {
     );
   });
 
-  it("accept function whose second and subsequent arguments are optional", () => {
+  test("accept function whose second and subsequent arguments are optional", () => {
     const result = evolve(
       { arg2Optional: 1, arg2arg3Optional: 1 },
       {
@@ -182,7 +182,7 @@ describe("data first", () => {
     }>();
   });
 
-  it("can not handle function arrays.", () => {
+  test("can not handle function arrays.", () => {
     evolve(
       { quartile: [1, 2] },
       {
@@ -192,7 +192,7 @@ describe("data first", () => {
     );
   });
 
-  it("doesn't provide typing for symbol key evolvers", () => {
+  test("doesn't provide typing for symbol key evolvers", () => {
     const mySymbol = Symbol("a");
     evolve(
       { [mySymbol]: "hello" },
@@ -205,7 +205,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
+  test("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     const result = pipe(
       {
         id: 1,
@@ -226,13 +226,13 @@ describe("data last", () => {
     }>();
   });
 
-  it("is not destructive and is immutable", () => {
+  test("is not destructive and is immutable", () => {
     const result = pipe({ n: 100 }, evolve({ n: add(1) }));
 
     expectTypeOf(result).toEqualTypeOf<{ n: number }>();
   });
 
-  it("is recursive", () => {
+  test("is recursive", () => {
     const result = pipe(
       { first: 1, nested: { second: 2, third: 3 } },
       evolve({ nested: { second: add(-1), third: add(1) } }),
@@ -244,13 +244,13 @@ describe("data last", () => {
     }>();
   });
 
-  it("ignores undefined transformations", () => {
+  test("ignores undefined transformations", () => {
     const result = pipe({ n: 0 }, evolve({}));
 
     expectTypeOf(result).toEqualTypeOf<{ n: number }>();
   });
 
-  it("can handle data that is complex nested objects", () => {
+  test("can handle data that is complex nested objects", () => {
     const result = pipe(
       {
         array: ["1", "2", "3"],
@@ -275,7 +275,7 @@ describe("data last", () => {
   });
 
   describe("it can detect mismatch of parameters and arguments", () => {
-    it('detect property "number" are incompatible', () => {
+    test('detect property "number" are incompatible', () => {
       pipe(
         { number: "1", array: ["1", "2", "3"] },
         // @ts-expect-error [ts2345] - Evolver isn't the right type.
@@ -287,7 +287,7 @@ describe("data last", () => {
       );
     });
 
-    it('detect property "array" are incompatible', () => {
+    test('detect property "array" are incompatible', () => {
       pipe(
         { number: 1, array: ["1", "2", "3"] },
         // @ts-expect-error [ts2345] - Evolver isn't the right type.
@@ -300,7 +300,7 @@ describe("data last", () => {
     });
   });
 
-  it("does not accept function that require multiple arguments", () => {
+  test("does not accept function that require multiple arguments", () => {
     pipe(
       { requiring2Args: 1 },
       // @ts-expect-error [ts2345] - Type '{ requiring2Args: any; }' provides no match for the signature '(input: { requiring2Args: number; }): unknown'.
@@ -311,7 +311,7 @@ describe("data last", () => {
     );
   });
 
-  it("accept function whose second and subsequent arguments are optional", () => {
+  test("accept function whose second and subsequent arguments are optional", () => {
     const result = pipe(
       { arg2Optional: 1, arg2arg3Optional: 1 },
       evolve({
@@ -327,7 +327,7 @@ describe("data last", () => {
     }>();
   });
 
-  it("can not handle function arrays.", () => {
+  test("can not handle function arrays.", () => {
     pipe(
       { quartile: [1, 2] },
       // @ts-expect-error [ts2345] - Type '{ quartile: ((value: number) => number)[]; }' provides no match for the signature '(input: { quartile: number[]; }): unknown'.

--- a/packages/remeda/src/evolve.test.ts
+++ b/packages/remeda/src/evolve.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { evolve } from "./evolve";
@@ -12,7 +12,7 @@ import { set } from "./set";
 const sum = reduce((a, b: number) => add(a, b), 0);
 
 describe("data first", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
+  test("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     expect(
       evolve(
         {
@@ -33,11 +33,11 @@ describe("data first", () => {
     });
   });
 
-  it("does not invoke function if `data` does not contain the key", () => {
+  test("does not invoke function if `data` does not contain the key", () => {
     expect(evolve({} as { id?: number }, { id: add(1) })).toStrictEqual({});
   });
 
-  it("is not destructive and is immutable", () => {
+  test("is not destructive and is immutable", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = evolve(data, { n: add(1) });
@@ -47,7 +47,7 @@ describe("data first", () => {
     expect(result).not.toBe(expected);
   });
 
-  it("is recursive", () => {
+  test("is recursive", () => {
     expect(
       evolve(
         { first: 1, nested: { second: 2, third: 3 } },
@@ -56,11 +56,11 @@ describe("data first", () => {
     ).toStrictEqual({ first: 1, nested: { second: 1, third: 4 } });
   });
 
-  it("ignores undefined transformations", () => {
+  test("ignores undefined transformations", () => {
     expect(evolve({ n: 0 }, {})).toStrictEqual({ n: 0 });
   });
 
-  it("can handle data that is complex nested objects", () => {
+  test("can handle data that is complex nested objects", () => {
     expect(
       evolve(
         {
@@ -84,7 +84,7 @@ describe("data first", () => {
     });
   });
 
-  it("accept function whose second and subsequent arguments are optional", () => {
+  test("accept function whose second and subsequent arguments are optional", () => {
     expect(
       evolve(
         { arg2Optional: 1, arg2arg3Optional: 1 },
@@ -97,7 +97,7 @@ describe("data first", () => {
     ).toStrictEqual({ arg2Optional: true, arg2arg3Optional: true });
   });
 
-  it("doesn't evolve symbol keys", () => {
+  test("doesn't evolve symbol keys", () => {
     const mock = vi.fn<(x: string) => unknown>();
     const mySymbol = Symbol("a");
     // @ts-expect-error [ts2418] - We want to test the runtime even if the typing prevents it.
@@ -106,7 +106,7 @@ describe("data first", () => {
     expect(mock).toHaveBeenCalledTimes(0);
   });
 
-  it("ignore transformers for non-object values", () => {
+  test("ignore transformers for non-object values", () => {
     expect(
       evolve({ a: "hello" } as { a: string | { b: string } }, {
         a: { b: constant(3) },
@@ -116,7 +116,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("creates a new object by evolving the `data` according to the `transformation` functions", () => {
+  test("creates a new object by evolving the `data` according to the `transformation` functions", () => {
     expect(
       pipe(
         {
@@ -137,13 +137,13 @@ describe("data last", () => {
     });
   });
 
-  it("does not invoke function if `data` does not contain the key", () => {
+  test("does not invoke function if `data` does not contain the key", () => {
     expect(pipe({} as { id?: number }, evolve({ id: add(1) }))).toStrictEqual(
       {},
     );
   });
 
-  it("is not destructive and is immutable", () => {
+  test("is not destructive and is immutable", () => {
     const data = { n: 100 };
     const expected = { n: 101 };
     const result = pipe(data, evolve({ n: add(1) }));
@@ -153,7 +153,7 @@ describe("data last", () => {
     expect(result).not.toBe(expected);
   });
 
-  it("is recursive", () => {
+  test("is recursive", () => {
     expect(
       pipe(
         { first: 1, nested: { second: 2, third: 3 } },
@@ -162,11 +162,11 @@ describe("data last", () => {
     ).toStrictEqual({ first: 1, nested: { second: 1, third: 4 } });
   });
 
-  it("ignores undefined transformations", () => {
+  test("ignores undefined transformations", () => {
     expect(pipe({ n: 0 }, evolve({}))).toStrictEqual({ n: 0 });
   });
 
-  it("can handle data that is complex nested objects", () => {
+  test("can handle data that is complex nested objects", () => {
     expect(
       pipe(
         {
@@ -190,7 +190,7 @@ describe("data last", () => {
     });
   });
 
-  it("accept function whose second and subsequent arguments are optional", () => {
+  test("accept function whose second and subsequent arguments are optional", () => {
     expect(
       pipe(
         { arg2Optional: 1, arg2arg3Optional: 1 },

--- a/packages/remeda/src/evolve.test.ts
+++ b/packages/remeda/src/evolve.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { evolve } from "./evolve";

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { filter } from "./filter";
 import { isDefined } from "./isDefined";

--- a/packages/remeda/src/filter.test.ts
+++ b/packages/remeda/src/filter.test.ts
@@ -1,23 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { identity } from "./identity";
 import { map } from "./map";
 import { pipe } from "./pipe";
 
 describe("data_first", () => {
-  it("filter", () => {
+  test("filter", () => {
     const result = filter([1, 2, 3], (x) => x % 2 === 1);
 
     expect(result).toStrictEqual([1, 3]);
   });
 
-  it("data_first with typescript guard", () => {
+  test("data_first with typescript guard", () => {
     const result = filter([1, 2, 3, "abc", true], isNumber);
 
     expect(result).toStrictEqual([1, 2, 3]);
   });
 
-  it("filter indexed", () => {
+  test("filter indexed", () => {
     const result = filter([1, 2, 3], (x, i) => x % 2 === 1 && i !== 1);
 
     expect(result).toStrictEqual([1, 3]);
@@ -25,7 +25,7 @@ describe("data_first", () => {
 });
 
 describe("data_last", () => {
-  it("filter", () => {
+  test("filter", () => {
     const counter = vi.fn<(x: number) => number>(identity());
     const result = pipe(
       [1, 2, 3],
@@ -37,7 +37,7 @@ describe("data_last", () => {
     expect(result).toStrictEqual([1, 3]);
   });
 
-  it("filter with typescript guard", () => {
+  test("filter with typescript guard", () => {
     const counter = vi.fn<(x: number) => number>(identity());
     const result = pipe(
       [1, 2, 3, false, "text"],
@@ -49,7 +49,7 @@ describe("data_last", () => {
     expect(result).toStrictEqual([1, 2, 3]);
   });
 
-  it("filter indexed", () => {
+  test("filter indexed", () => {
     const counter = vi.fn<(x: number) => void>(identity());
     const result = pipe(
       [1, 2, 3],

--- a/packages/remeda/src/filter.test.ts
+++ b/packages/remeda/src/filter.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { filter } from "./filter";
 import { identity } from "./identity";
 import { map } from "./map";

--- a/packages/remeda/src/find.test-d.ts
+++ b/packages/remeda/src/find.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { find } from "./find";
 import { isString } from "./isString";
 

--- a/packages/remeda/src/find.test.ts
+++ b/packages/remeda/src/find.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from "vitest";
 import { find } from "./find";
 import { identity } from "./identity";
 import { map } from "./map";

--- a/packages/remeda/src/findIndex.test.ts
+++ b/packages/remeda/src/findIndex.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { findIndex } from "./findIndex";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/findLast.test.ts
+++ b/packages/remeda/src/findLast.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { findLast } from "./findLast";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/findLastIndex.test.ts
+++ b/packages/remeda/src/findLastIndex.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { findLastIndex } from "./findLastIndex";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/first.test-d.ts
+++ b/packages/remeda/src/first.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { first } from "./first";
 
 test("simple empty array", () => {

--- a/packages/remeda/src/first.test.ts
+++ b/packages/remeda/src/first.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { filter } from "./filter";
 import { first } from "./first";

--- a/packages/remeda/src/firstBy.test-d.ts
+++ b/packages/remeda/src/firstBy.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { firstBy } from "./firstBy";
 import { identity } from "./identity";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";

--- a/packages/remeda/src/firstBy.test-d.ts
+++ b/packages/remeda/src/firstBy.test-d.ts
@@ -1,23 +1,23 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { firstBy } from "./firstBy";
 import { identity } from "./identity";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 
-it("can return undefined on arrays", () => {
+test("can return undefined on arrays", () => {
   const data: ReadonlyArray<number> = [1, 2, 3];
   const result = firstBy(data, identity());
 
   expectTypeOf(result).toBeNullable();
 });
 
-it("can't return undefined on non-empty array", () => {
+test("can't return undefined on non-empty array", () => {
   const data: NonEmptyArray<number> = [1, 2, 3];
   const result = firstBy(data, identity());
 
   expectTypeOf(result).not.toBeNullable();
 });
 
-it("only returns null on the empty array", () => {
+test("only returns null on the empty array", () => {
   const data = [] as const;
   const result = firstBy(data, identity());
 

--- a/packages/remeda/src/firstBy.test.ts
+++ b/packages/remeda/src/firstBy.test.ts
@@ -1,38 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { firstBy } from "./firstBy";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
 
 describe("runtime (dataFirst)", () => {
-  it("returns undefined on empty", () => {
+  test("returns undefined on empty", () => {
     expect(firstBy([], identity())).toBeUndefined();
   });
 
-  it("returns the item on a single item array", () => {
+  test("returns the item on a single item array", () => {
     expect(firstBy([1], identity())).toBe(1);
   });
 
-  it("finds the minimum", () => {
+  test("finds the minimum", () => {
     expect(firstBy([2, 1, 4, 3, 5], identity())).toBe(1);
   });
 
-  it("finds the minimum with a non-trivial order rule", () => {
+  test("finds the minimum with a non-trivial order rule", () => {
     expect(firstBy(["aa", "a", "aaaa", "aaa", "aaaaa"], (x) => x.length)).toBe(
       "a",
     );
   });
 
-  it("finds the max with 'desc' order rules", () => {
+  test("finds the max with 'desc' order rules", () => {
     expect(firstBy([2, 1, 4, 3, 5], [identity(), "desc"])).toBe(5);
   });
 
-  it("finds the max with non-trivial 'desc' order rules", () => {
+  test("finds the max with non-trivial 'desc' order rules", () => {
     expect(
       firstBy(["aa", "a", "aaaa", "aaa", "aaaaa"], [identity(), "desc"]),
     ).toBe("aaaaa");
   });
 
-  it("breaks ties with multiple order rules", () => {
+  test("breaks ties with multiple order rules", () => {
     const data = ["a", "bb", "b", "aaaa", "bbb", "aa", "aaa", "bbbb"];
 
     expect(firstBy(data, (x) => x.length, identity())).toBe("a");
@@ -43,19 +43,19 @@ describe("runtime (dataFirst)", () => {
     );
   });
 
-  it("can compare strings", () => {
+  test("can compare strings", () => {
     expect(firstBy(["b", "a", "c"], identity())).toBe("a");
   });
 
-  it("can compare numbers", () => {
+  test("can compare numbers", () => {
     expect(firstBy([2, 1, 3], identity())).toBe(1);
   });
 
-  it("can compare booleans", () => {
+  test("can compare booleans", () => {
     expect(firstBy([true, false, true, true, false], identity())).toBe(false);
   });
 
-  it("can compare valueOfs", () => {
+  test("can compare valueOfs", () => {
     expect(
       firstBy([new Date(), new Date(1), new Date(2)], identity()),
     ).toStrictEqual(new Date(1));
@@ -63,19 +63,19 @@ describe("runtime (dataFirst)", () => {
 });
 
 describe("runtime (dataLast)", () => {
-  it("returns undefined on empty", () => {
+  test("returns undefined on empty", () => {
     expect(pipe([], firstBy(identity()))).toBeUndefined();
   });
 
-  it("returns the item on a single item array", () => {
+  test("returns the item on a single item array", () => {
     expect(pipe([1], firstBy(identity()))).toBe(1);
   });
 
-  it("finds the minimum", () => {
+  test("finds the minimum", () => {
     expect(pipe([2, 1, 4, 3, 5], firstBy(identity()))).toBe(1);
   });
 
-  it("finds the minimum with a non-trivial order rule", () => {
+  test("finds the minimum with a non-trivial order rule", () => {
     expect(
       pipe(
         ["aa", "a", "aaaa", "aaa", "aaaaa"],
@@ -84,17 +84,17 @@ describe("runtime (dataLast)", () => {
     ).toBe("a");
   });
 
-  it("finds the max with 'desc' order rules", () => {
+  test("finds the max with 'desc' order rules", () => {
     expect(pipe([2, 1, 4, 3, 5], firstBy([identity(), "desc"]))).toBe(5);
   });
 
-  it("finds the max with non-trivial 'desc' order rules", () => {
+  test("finds the max with non-trivial 'desc' order rules", () => {
     expect(
       pipe(["aa", "a", "aaaa", "aaa", "aaaaa"], firstBy([identity(), "desc"])),
     ).toBe("aaaaa");
   });
 
-  it("breaks ties with multiple order rules", () => {
+  test("breaks ties with multiple order rules", () => {
     const data = ["a", "bb", "b", "aaaa", "bbb", "aa", "aaa", "bbbb"];
 
     expect(
@@ -120,21 +120,21 @@ describe("runtime (dataLast)", () => {
     ).toBe("bbbb");
   });
 
-  it("can compare strings", () => {
+  test("can compare strings", () => {
     expect(pipe(["b", "a", "c"], firstBy(identity()))).toBe("a");
   });
 
-  it("can compare numbers", () => {
+  test("can compare numbers", () => {
     expect(pipe([2, 1, 3], firstBy(identity()))).toBe(1);
   });
 
-  it("can compare booleans", () => {
+  test("can compare booleans", () => {
     expect(pipe([true, false, true, true, false], firstBy(identity()))).toBe(
       false,
     );
   });
 
-  it("can compare valueOfs", () => {
+  test("can compare valueOfs", () => {
     expect(
       pipe([new Date(), new Date(1), new Date(2)], firstBy(identity())),
     ).toStrictEqual(new Date(1));

--- a/packages/remeda/src/firstBy.test.ts
+++ b/packages/remeda/src/firstBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { firstBy } from "./firstBy";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/flat.test-d.ts
+++ b/packages/remeda/src/flat.test-d.ts
@@ -1,26 +1,26 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { flat } from "./flat";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 
-it("works on empty arrays", () => {
+test("works on empty arrays", () => {
   const result = flat([], 1);
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("works on already-flat arrays", () => {
+test("works on already-flat arrays", () => {
   const result = flat([] as Array<string>, 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("works on a single level of nesting", () => {
+test("works on a single level of nesting", () => {
   const result = flat([] as Array<Array<string>>, 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("stops after the first level of nesting (depth === 1)", () => {
+test("stops after the first level of nesting (depth === 1)", () => {
   const threeDeepResult = flat([] as Array<Array<Array<string>>>, 1);
 
   expectTypeOf(threeDeepResult).toEqualTypeOf<Array<Array<string>>>();
@@ -30,37 +30,37 @@ it("stops after the first level of nesting (depth === 1)", () => {
   expectTypeOf(fourDeepResult).toEqualTypeOf<Array<Array<Array<string>>>>();
 });
 
-it("works with mixed types", () => {
+test("works with mixed types", () => {
   const result = flat([] as Array<Array<number> | Array<string>>, 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("works with mixed levels of nesting", () => {
+test("works with mixed levels of nesting", () => {
   const result = flat([] as Array<Array<number> | string>, 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("works when depth is deeper than the array", () => {
+test("works when depth is deeper than the array", () => {
   const result = flat([] as Array<string>, 10);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("works when depth is really really really really big", () => {
+test("works when depth is really really really really big", () => {
   const result = flat([] as Array<string>, 9_999_999);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("keeps the typing of trivial tuples", () => {
+test("keeps the typing of trivial tuples", () => {
   const result = flat([1, 2] as const, 1);
 
   expectTypeOf(result).toEqualTypeOf<[1, 2]>();
 });
 
-it("works on simple tuples", () => {
+test("works on simple tuples", () => {
   const result = flat(
     [
       [1, 2],
@@ -72,67 +72,67 @@ it("works on simple tuples", () => {
   expectTypeOf(result).toEqualTypeOf<[1, 2, 3, 4]>();
 });
 
-it("works on tuples with different levels of nesting", () => {
+test("works on tuples with different levels of nesting", () => {
   const result = flat([1, [2, 3], [4, [5, 6]]] as const, 1);
 
   expectTypeOf(result).toEqualTypeOf<[1, 2, 3, 4, readonly [5, 6]]>();
 });
 
-it("works on tuples with depth>1", () => {
+test("works on tuples with depth>1", () => {
   const result = flat([1, [2, 3], [4, [5, 6]]] as const, 2);
 
   expectTypeOf(result).toEqualTypeOf<[1, 2, 3, 4, 5, 6]>();
 });
 
-it("works with tuples with a lot of nesting", () => {
+test("works with tuples with a lot of nesting", () => {
   const result = flat([[[[1]], [[[[2]]]]], [[[[3, 4], 5]]]] as const, 10);
 
   expectTypeOf(result).toEqualTypeOf<[1, 2, 3, 4, 5]>();
 });
 
-it("works with a mix of simple arrays and tuples", () => {
+test("works with a mix of simple arrays and tuples", () => {
   const result = flat([[]] as [Array<string>], 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("works with multiple types nested in a tuple", () => {
+test("works with multiple types nested in a tuple", () => {
   const result = flat([[], []] as [Array<string>, Array<number>], 1);
 
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("works with a tuple with mixed array and non array items", () => {
+test("works with a tuple with mixed array and non array items", () => {
   const result = flat([1, []] as [number, Array<string>], 1);
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<string>]>();
 });
 
-it("works with a tuple with mixed array and non array items, deeply", () => {
+test("works with a tuple with mixed array and non array items, deeply", () => {
   const result = flat([[1], []] as [[number], Array<Array<string>>], 2);
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<string>]>();
 });
 
-it("works on non-empty arrays", () => {
+test("works on non-empty arrays", () => {
   const result = flat([[1]] as NonEmptyArray<NonEmptyArray<number>>, 1);
 
   expectTypeOf(result).toEqualTypeOf<NonEmptyArray<number>>();
 });
 
-it("works on tuples inside arrays", () => {
+test("works on tuples inside arrays", () => {
   const result = flat([] as Array<[Array<string>, Array<number>]>, 2);
 
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("works on arrays inside tuples", () => {
+test("works on arrays inside tuples", () => {
   const result = flat([1, [], 4] as [1, Array<[2, 3]>, 4], 2);
 
   expectTypeOf(result).toEqualTypeOf<[1, ...Array<2 | 3>, 4]>();
 });
 
-it("works with depths beyond 20", () => {
+test("works with depths beyond 20", () => {
   // The built-in type for `Array.prototype.flat` only goes up to 20.
 
   const result = flat(
@@ -143,12 +143,12 @@ it("works with depths beyond 20", () => {
   expectTypeOf(result).toEqualTypeOf<[1]>();
 });
 
-it("doesn't accept non-literal depths", () => {
+test("doesn't accept non-literal depths", () => {
   // @ts-expect-error [ts2345] - non-literal numbers can't be used as depth.
   flat([], 1 as number);
 });
 
-it("doesn't accept built-in 'infinite' numbers", () => {
+test("doesn't accept built-in 'infinite' numbers", () => {
   // They are all typed as `number` by typescript's libs.
 
   // @ts-expect-error [ts2345] - Infinity is typed as a non-literal number. - https://github.com/microsoft/TypeScript/blob/main/src/lib/es5.d.ts#L9

--- a/packages/remeda/src/flat.test-d.ts
+++ b/packages/remeda/src/flat.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { flat } from "./flat";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 

--- a/packages/remeda/src/flat.test.ts
+++ b/packages/remeda/src/flat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter.js";
 import { find } from "./find";
 import { flat } from "./flat";
@@ -7,37 +7,37 @@ import { map } from "./map";
 import { pipe } from "./pipe";
 
 describe("dataFirst", () => {
-  it("works on empty arrays", () => {
+  test("works on empty arrays", () => {
     expect(flat([], 1)).toStrictEqual([]);
   });
 
-  it("works on flat arrays", () => {
+  test("works on flat arrays", () => {
     expect(flat([1, 2, 3], 1)).toStrictEqual([1, 2, 3]);
   });
 
-  it("flattens shallow nested arrays", () => {
+  test("flattens shallow nested arrays", () => {
     expect(flat([[1, 2], [3, 4], [5], [6]], 1)).toStrictEqual([
       1, 2, 3, 4, 5, 6,
     ]);
   });
 
-  it("stops at the given depth", () => {
+  test("stops at the given depth", () => {
     expect(flat([[[[[[[[[1]]]]]]]]], 3)).toStrictEqual([[[[[[1]]]]]]);
   });
 
-  it("works with deeper depth", () => {
+  test("works with deeper depth", () => {
     expect(flat([1], 10)).toStrictEqual([1]);
   });
 
-  it("handles optional depth as if it was 1", () => {
+  test("handles optional depth as if it was 1", () => {
     expect(flat([1, [2, 3], [[4]]])).toStrictEqual([1, 2, 3, [4]]);
   });
 
-  it("handles objects", () => {
+  test("handles objects", () => {
     expect(flat([{ a: 1 }, [{ b: 3 }]], 1)).toStrictEqual([{ a: 1 }, { b: 3 }]);
   });
 
-  it("clones the array on depth 0", () => {
+  test("clones the array on depth 0", () => {
     const data = [1, 2, 3];
     const result = flat(data, 0);
 
@@ -45,7 +45,7 @@ describe("dataFirst", () => {
     expect(result).not.toBe(data);
   });
 
-  it("clones the array when no nested items", () => {
+  test("clones the array when no nested items", () => {
     const data = [1, 2, 3];
     const result = flat(data, 1);
 
@@ -55,40 +55,40 @@ describe("dataFirst", () => {
 });
 
 describe("dataLast", () => {
-  it("works on empty arrays", () => {
+  test("works on empty arrays", () => {
     expect(pipe([], flat(1))).toStrictEqual([]);
   });
 
-  it("works on flat arrays", () => {
+  test("works on flat arrays", () => {
     expect(pipe([1, 2, 3], flat(1))).toStrictEqual([1, 2, 3]);
   });
 
-  it("flattens shallow nested arrays", () => {
+  test("flattens shallow nested arrays", () => {
     expect(pipe([[1, 2], [3, 4], [5], [6]], flat(1))).toStrictEqual([
       1, 2, 3, 4, 5, 6,
     ]);
   });
 
-  it("stops at the given depth", () => {
+  test("stops at the given depth", () => {
     expect(pipe([[[[[[[[[1]]]]]]]]], flat(3))).toStrictEqual([[[[[[1]]]]]]);
   });
 
-  it("works with deeper depth", () => {
+  test("works with deeper depth", () => {
     expect(pipe([1], flat(10))).toStrictEqual([1]);
   });
 
-  it("handles optional depth as if it was 1", () => {
+  test("handles optional depth as if it was 1", () => {
     expect(pipe([1, [2, 3], [[4]]], flat())).toStrictEqual([1, 2, 3, [4]]);
   });
 
-  it("handles objects", () => {
+  test("handles objects", () => {
     expect(pipe([{ a: 1 }, [{ b: 3 }]], flat(1))).toStrictEqual([
       { a: 1 },
       { b: 3 },
     ]);
   });
 
-  it("works lazily (shallow)", () => {
+  test("works lazily (shallow)", () => {
     // eslint-disable-next-line vitest/require-mock-type-parameters -- TODO: It's hard to type this correctly taking into account the deep structure of the array. We might be able to work around that if we pull the array out and use it's type (e.g. typeof) to build the type for the function here...
     const beforeMock = vi.fn(identity());
     const afterMock = vi.fn<(x: number) => number>(identity());
@@ -105,7 +105,7 @@ describe("dataLast", () => {
     expect(result).toBe(3);
   });
 
-  it("works lazily (deep)", () => {
+  test("works lazily (deep)", () => {
     // eslint-disable-next-line vitest/require-mock-type-parameters -- TODO: It's hard to type this correctly taking into account the deep structure of the array. We might be able to work around that if we pull the array out and use it's type (e.g. typeof) to build the type for the function here...
     const beforeMock = vi.fn(identity());
     const afterMock = vi.fn<(x: number) => number>(identity());
@@ -122,7 +122,7 @@ describe("dataLast", () => {
     expect(result).toBe(3);
   });
 
-  it("works lazily with trivial depth === 0", () => {
+  test("works lazily with trivial depth === 0", () => {
     const data = [1, [2, 3], [4, [5, 6], [7, [8, 9], [[10]]]]];
     const result = pipe(data, flat(0));
 
@@ -131,7 +131,7 @@ describe("dataLast", () => {
   });
 });
 
-it("can go very very deep", () => {
+test("can go very very deep", () => {
   expect(
     flat([[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[1]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]], 99),
   ).toStrictEqual([1]);

--- a/packages/remeda/src/flat.test.ts
+++ b/packages/remeda/src/flat.test.ts
@@ -137,11 +137,8 @@ test("can go very very deep", () => {
   ).toStrictEqual([1]);
 });
 
-// These tests are copied from an previous implementations of the same concept
-// as flat that existed in previous versions of Remeda. We copy the tests so
-// that we can ensure that the new function is equivalent. In the future these
-// can be deleted.
-describe("LEGACY", () => {
+// TODO: [>3]: These tests are copied from an previous implementations of the same concept as flat that existed in previous versions of Remeda. We copy the tests so that we can ensure that the new function is equivalent. In the future these can be deleted.
+describe("legacy", () => {
   describe("`flatten` equivalent (depth = 1)", () => {
     test("flatten", () => {
       expect(flat([[1, 2], 3, [4, 5]])).toStrictEqual([1, 2, 3, 4, 5]);

--- a/packages/remeda/src/flat.test.ts
+++ b/packages/remeda/src/flat.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter.js";
 import { find } from "./find";
 import { flat } from "./flat";

--- a/packages/remeda/src/flatMap.test.ts
+++ b/packages/remeda/src/flatMap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { add } from "./add";
 import { find } from "./find";
@@ -6,13 +6,13 @@ import { flatMap } from "./flatMap";
 import { pipe } from "./pipe";
 
 describe("dataFirst", () => {
-  it("flatMap", () => {
+  test("flatMap", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3]);
 
     expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
-  it("should accept fn returning a readonly array", () => {
+  test("should accept fn returning a readonly array", () => {
     const result = flatMap([1, 2] as const, (x) => [x * 2, x * 3] as const);
 
     expect(result).toStrictEqual([2, 3, 4, 6]);
@@ -20,13 +20,13 @@ describe("dataFirst", () => {
 });
 
 describe("dataLast", () => {
-  it("flatMap", () => {
+  test("flatMap", () => {
     const result = flatMap((x: number) => [x * 2, x * 3])([1, 2]);
 
     expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
-  it("should accept fn returning a readonly array", () => {
+  test("should accept fn returning a readonly array", () => {
     const result = flatMap((x: number) => [x * 2, x * 3] as const)([
       1, 2,
     ] as const);
@@ -34,7 +34,7 @@ describe("dataLast", () => {
     expect(result).toStrictEqual([2, 3, 4, 6]);
   });
 
-  it("works with non array outputs", () => {
+  test("works with non array outputs", () => {
     expect(pipe([1, 2, 3], flatMap(add(1)))).toStrictEqual([2, 3, 4]);
   });
 

--- a/packages/remeda/src/flatMap.test.ts
+++ b/packages/remeda/src/flatMap.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { add } from "./add";
 import { find } from "./find";

--- a/packages/remeda/src/floor.test.ts
+++ b/packages/remeda/src/floor.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { floor } from "./floor";
 
 describe("data-first", () => {

--- a/packages/remeda/src/forEach.test-d.ts
+++ b/packages/remeda/src/forEach.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { doNothing } from "./doNothing";
 import { forEach } from "./forEach";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/forEach.test-d.ts
+++ b/packages/remeda/src/forEach.test-d.ts
@@ -1,16 +1,16 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { doNothing } from "./doNothing";
 import { forEach } from "./forEach";
 import { pipe } from "./pipe";
 
-it("doesn't return anything on dataFirst invocations", () => {
+test("doesn't return anything on dataFirst invocations", () => {
   const result = forEach([1, 2, 3], doNothing());
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- Intentionally
   expectTypeOf(result).toEqualTypeOf<void>();
 });
 
-it("passes the item type to the callback", () => {
+test("passes the item type to the callback", () => {
   pipe(
     [1, 2, 3] as const,
     forEach((x) => {
@@ -19,7 +19,7 @@ it("passes the item type to the callback", () => {
   );
 });
 
-it("maintains the array shape", () => {
+test("maintains the array shape", () => {
   const data = [1, "a"] as [1 | 2, "a" | "b", ...Array<boolean>];
 
   pipe(data, forEach(doNothing()), (x) => {
@@ -27,7 +27,7 @@ it("maintains the array shape", () => {
   });
 });
 
-it("makes the result mutable", () => {
+test("makes the result mutable", () => {
   const data = [] as ReadonlyArray<number>;
 
   pipe(data, forEach(doNothing()), (x) => {

--- a/packages/remeda/src/forEach.test.ts
+++ b/packages/remeda/src/forEach.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, vi } from "vitest";
 import { forEach } from "./forEach";
 import { pipe } from "./pipe";
 import { take } from "./take";

--- a/packages/remeda/src/forEachObj.test-d.ts
+++ b/packages/remeda/src/forEachObj.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { forEachObj } from "./forEachObj";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/forEachObj.test.ts
+++ b/packages/remeda/src/forEachObj.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, vi } from "vitest";
 import { forEachObj } from "./forEachObj";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/fromEntries.test-d.ts
+++ b/packages/remeda/src/fromEntries.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { fromEntries } from "./fromEntries";
 
 describe("readonly inputs", () => {

--- a/packages/remeda/src/fromEntries.test.ts
+++ b/packages/remeda/src/fromEntries.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { fromEntries } from "./fromEntries";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/fromKeys.test-d.ts
+++ b/packages/remeda/src/fromKeys.test-d.ts
@@ -1,4 +1,5 @@
 import type { Simplify } from "type-fest";
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { fromKeys } from "./fromKeys";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/fromKeys.test.ts
+++ b/packages/remeda/src/fromKeys.test.ts
@@ -1,21 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { add } from "./add";
 import { fromKeys } from "./fromKeys";
 import { pipe } from "./pipe";
 
-it("works on trivially empty arrays", () => {
+test("works on trivially empty arrays", () => {
   expect(fromKeys([] as Array<string>, (item) => `${item}_`)).toStrictEqual({});
 });
 
-it("works on regular arrays", () => {
+test("works on regular arrays", () => {
   expect(fromKeys(["a"], (item) => `${item}_`)).toStrictEqual({ a: "a_" });
 });
 
-it("works with duplicates", () => {
+test("works with duplicates", () => {
   expect(fromKeys(["a", "a"], (item) => `${item}_`)).toStrictEqual({ a: "a_" });
 });
 
-it("uses the last value", () => {
+test("uses the last value", () => {
   let counter = 0;
 
   expect(
@@ -26,17 +26,17 @@ it("uses the last value", () => {
   ).toStrictEqual({ a: 2 });
 });
 
-it("works with number keys", () => {
+test("works with number keys", () => {
   expect(fromKeys([123], add(1))).toStrictEqual({ 123: 124 });
 });
 
-it("works with symbols", () => {
+test("works with symbols", () => {
   const symbol = Symbol("a");
 
   expect(fromKeys([symbol], () => 1)).toStrictEqual({ [symbol]: 1 });
 });
 
-it("works with a mix of key types", () => {
+test("works with a mix of key types", () => {
   const symbol = Symbol("a");
 
   expect(fromKeys(["a", 123, symbol], (item) => typeof item)).toStrictEqual({
@@ -47,7 +47,7 @@ it("works with a mix of key types", () => {
 });
 
 describe("dataLast", () => {
-  it("works on trivially empty arrays", () => {
+  test("works on trivially empty arrays", () => {
     expect(
       pipe(
         [] as Array<string>,
@@ -56,7 +56,7 @@ describe("dataLast", () => {
     ).toStrictEqual({});
   });
 
-  it("works on regular arrays", () => {
+  test("works on regular arrays", () => {
     expect(
       pipe(
         ["a"],
@@ -65,7 +65,7 @@ describe("dataLast", () => {
     ).toStrictEqual({ a: "a_" });
   });
 
-  it("works with duplicates", () => {
+  test("works with duplicates", () => {
     expect(
       pipe(
         ["a", "a"],
@@ -74,7 +74,7 @@ describe("dataLast", () => {
     ).toStrictEqual({ a: "a_" });
   });
 
-  it("uses the last value", () => {
+  test("uses the last value", () => {
     let counter = 0;
 
     expect(
@@ -88,11 +88,11 @@ describe("dataLast", () => {
     ).toStrictEqual({ a: 2 });
   });
 
-  it("works with number keys", () => {
+  test("works with number keys", () => {
     expect(pipe([123], fromKeys(add(1)))).toStrictEqual({ 123: 124 });
   });
 
-  it("works with symbols", () => {
+  test("works with symbols", () => {
     const symbol = Symbol("a");
 
     expect(
@@ -103,7 +103,7 @@ describe("dataLast", () => {
     ).toStrictEqual({ [symbol]: 1 });
   });
 
-  it("works with a mix of key types", () => {
+  test("works with a mix of key types", () => {
     const symbol = Symbol("a");
 
     expect(

--- a/packages/remeda/src/fromKeys.test.ts
+++ b/packages/remeda/src/fromKeys.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { add } from "./add";
 import { fromKeys } from "./fromKeys";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -2,7 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";
@@ -110,7 +110,7 @@ function debounceWithCachedValue<F extends (...args: any) => any>(
 const UT = 16;
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () => {
-  it("should debounce a function", async () => {
+  test("should debounce a function", async () => {
     const mockFn = vi.fn<(x: string) => string>(identity());
     const debounced = debounceWithCachedValue(mockFn, UT);
 
@@ -132,7 +132,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("subsequent debounced calls return the last `func` result", async () => {
+  test("subsequent debounced calls return the last `func` result", async () => {
     const debounced = debounceWithCachedValue(identity(), UT);
     debounced("a");
     await sleep(2 * UT);
@@ -144,7 +144,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(debounced("c")).not.toBe("c");
   });
 
-  it("subsequent leading debounced calls return the last `func` result", async () => {
+  test("subsequent leading debounced calls return the last `func` result", async () => {
     const debounced = debounceWithCachedValue(identity(), UT, {
       leading: true,
       trailing: false,
@@ -159,7 +159,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(debounced("d")).toBe("c");
   });
 
-  it("should invoke the trailing call with the correct arguments and `this` binding", async () => {
+  test("should invoke the trailing call with the correct arguments and `this` binding", async () => {
     const DATA = {};
     const mockFn = vi.fn<(a: object, b: string) => boolean>(constant(false));
 
@@ -185,7 +185,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
 });
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", () => {
-  it("should reset `lastCalled` after cancelling", async () => {
+  test("should reset `lastCalled` after cancelling", async () => {
     let callCount = 0;
     const debounced = debounceWithCachedValue(
       () => {
@@ -208,7 +208,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(callCount).toBe(3);
   });
 
-  it("should support flushing delayed calls", async () => {
+  test("should support flushing delayed calls", async () => {
     let callCount = 0;
     const debounced = debounceWithCachedValue(
       () => {
@@ -227,7 +227,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(callCount).toBe(1);
   });
 
-  it("should noop `cancel` and `flush` when nothing is queued", async () => {
+  test("should noop `cancel` and `flush` when nothing is queued", async () => {
     const mockFn = vi.fn<() => string>(constant("hello"));
     const debounced = debounceWithCachedValue(mockFn, UT);
     debounced.cancel();
@@ -241,7 +241,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
 });
 
 describe("Features not tested by Lodash", () => {
-  it("does nothing when neither leading nor trailing are enabled", async () => {
+  test("does nothing when neither leading nor trailing are enabled", async () => {
     const debounced = debounceWithCachedValue(identity(), UT, {
       leading: false,
       trailing: false,

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -240,7 +240,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
   });
 });
 
-describe("Features not tested by Lodash", () => {
+describe("features not tested by Lodash", () => {
   test("does nothing when neither leading nor trailing are enabled", async () => {
     const debounced = debounceWithCachedValue(identity(), UT, {
       leading: false,

--- a/packages/remeda/src/funnel.lodash-debounce.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce.test.ts
@@ -2,7 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { funnel } from "./funnel";
 
@@ -97,7 +97,7 @@ function debounce<F extends (...args: any) => void>(
 const UT = 16;
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () => {
-  it("should debounce a function", async () => {
+  test("should debounce a function", async () => {
     const mockFn = vi.fn<(x: string) => void>();
     const debounced = debounce(mockFn, UT);
     debounced("a");
@@ -122,7 +122,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should not immediately call `func` when `wait` is `0`", async () => {
+  test("should not immediately call `func` when `wait` is `0`", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, 0);
     debounced();
@@ -135,7 +135,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should apply default options", async () => {
+  test("should apply default options", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, {});
     debounced();
@@ -147,7 +147,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should support a `leading` option", async () => {
+  test("should support a `leading` option", async () => {
     const mockWithLeading = vi.fn<() => void>();
     const mockWithLeadingAndTrailing = vi.fn<() => void>();
     const withLeading = debounce(mockWithLeading, UT, {
@@ -180,7 +180,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockWithLeading).toHaveBeenCalledTimes(2);
   });
 
-  it("should support a `trailing` option", async () => {
+  test("should support a `trailing` option", async () => {
     const mockWith = vi.fn<() => void>();
     const mockWithout = vi.fn<() => void>();
     const withTrailing = debounce(mockWith, UT, { trailing: true });
@@ -203,7 +203,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockWithout).toHaveBeenCalledTimes(0);
   });
 
-  it("should support a `maxWait` option", async () => {
+  test("should support a `maxWait` option", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, { maxWait: 2 * UT });
     debounced();
@@ -225,7 +225,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should support `maxWait` in a tight loop", async () => {
+  test("should support `maxWait` in a tight loop", async () => {
     const mockWith = vi.fn<() => void>();
     const mockWithout = vi.fn<() => void>();
     const withMaxWait = debounce(mockWith, 2 * UT, { maxWait: 4 * UT });
@@ -256,7 +256,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockWith).toHaveBeenCalledTimes(1);
   });
 
-  it("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
+  test("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, 6 * UT, { maxWait: 6 * UT });
     debounced();
@@ -271,7 +271,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should cancel `maxDelayed` when `delayed` is invoked", async () => {
+  test("should cancel `maxDelayed` when `delayed` is invoked", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, { maxWait: 2 * UT });
     debounced();
@@ -285,7 +285,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should invoke the trailing call with the correct arguments and `this` binding", async () => {
+  test("should invoke the trailing call with the correct arguments and `this` binding", async () => {
     const mockFn = vi.fn<(a: object, b: string) => void>();
     const DATA = {};
     const debounced = debounce(mockFn, UT, {
@@ -305,7 +305,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187", () 
 });
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", () => {
-  it("should use a default `wait` of `0`", async () => {
+  test("should use a default `wait` of `0`", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn);
     debounced();
@@ -315,7 +315,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("supports recursive calls", async () => {
+  test("supports recursive calls", async () => {
     const actual = [] as Array<string>;
     const queue = ["a", "b", "c"];
     const debounced = debounce((chr: string) => {
@@ -334,7 +334,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(actual).toStrictEqual(["a", "b", "c"]);
   });
 
-  it("should support cancelling delayed calls", async () => {
+  test("should support cancelling delayed calls", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, { leading: false });
     debounced();
@@ -344,7 +344,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(0);
   });
 
-  it("should reset `lastCalled` after cancelling", async () => {
+  test("should reset `lastCalled` after cancelling", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, { leading: true });
     debounced();
@@ -362,7 +362,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
 
-  it("should support flushing delayed calls", async () => {
+  test("should support flushing delayed calls", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT, { leading: false });
     debounced();
@@ -375,7 +375,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should noop `cancel` and `flush` when nothing is queued", async () => {
+  test("should noop `cancel` and `flush` when nothing is queued", async () => {
     const mockFn = vi.fn<() => void>();
     const debounced = debounce(mockFn, UT);
     debounced.cancel();

--- a/packages/remeda/src/funnel.lodash-debounce.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { funnel } from "./funnel";
 

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -211,7 +211,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
   });
 });
 
-describe("Features not tested by Lodash", () => {
+describe("features not tested by Lodash", () => {
   test("does nothing when neither leading nor trailing are enabled", async () => {
     const throttled = throttleWithCachedValue(identity(), UT, {
       leading: false,

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -2,7 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";
@@ -105,7 +105,7 @@ function throttleWithCachedValue<F extends (...args: any) => any>(
 const UT = 16;
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", () => {
-  it("subsequent calls should return the result of the first call", async () => {
+  test("subsequent calls should return the result of the first call", async () => {
     const throttled = throttleWithCachedValue(identity(), UT);
 
     expect(throttled("a")).toBe("a");
@@ -121,7 +121,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(resultD).toBeDefined();
   });
 
-  it("should support a `leading` option", () => {
+  test("should support a `leading` option", () => {
     const withLeading = throttleWithCachedValue(identity(), UT, {
       leading: true,
     });
@@ -133,7 +133,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(withoutLeading("a")).toBeUndefined();
   });
 
-  it("should support a `trailing` option", async () => {
+  test("should support a `trailing` option", async () => {
     const mockWith = vi.fn<<T>(x: T) => T>(identity());
     const mockWithout = vi.fn<<T>(x: T) => T>(identity());
     const withTrailing = throttleWithCachedValue(mockWith, 2 * UT, {
@@ -156,7 +156,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
 });
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", () => {
-  it("should reset `lastCalled` after cancelling", async () => {
+  test("should reset `lastCalled` after cancelling", async () => {
     let callCount = 0;
     const throttled = throttleWithCachedValue(
       () => {
@@ -179,7 +179,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(callCount).toBe(3);
   });
 
-  it("should support flushing delayed calls", async () => {
+  test("should support flushing delayed calls", async () => {
     let callCount = 0;
     const throttled = throttleWithCachedValue(
       () => {
@@ -198,7 +198,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(callCount).toBe(1);
   });
 
-  it("should noop `cancel` and `flush` when nothing is queued", async () => {
+  test("should noop `cancel` and `flush` when nothing is queued", async () => {
     const mockFn = vi.fn<() => string>(constant("hello"));
     const throttled = throttleWithCachedValue(mockFn, UT);
     throttled.cancel();
@@ -212,7 +212,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
 });
 
 describe("Features not tested by Lodash", () => {
-  it("does nothing when neither leading nor trailing are enabled", async () => {
+  test("does nothing when neither leading nor trailing are enabled", async () => {
     const throttled = throttleWithCachedValue(identity(), UT, {
       leading: false,
       trailing: false,

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";

--- a/packages/remeda/src/funnel.lodash-throttle.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle.test.ts
@@ -2,7 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { funnel } from "./funnel";
 
@@ -91,7 +91,7 @@ function throttle<F extends (...args: any) => void>(
 const UT = 16;
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", () => {
-  it("should throttle a function", async () => {
+  test("should throttle a function", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT);
     throttled();
@@ -106,7 +106,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn.mock.calls.length).toBeGreaterThan(callCount);
   });
 
-  it("should clear timeout when `func` is called", async () => {
+  test("should clear timeout when `func` is called", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT);
     throttled();
@@ -120,7 +120,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should not trigger a trailing call when invoked once", async () => {
+  test("should not trigger a trailing call when invoked once", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT);
     throttled();
@@ -132,7 +132,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should trigger a call when invoked repeatedly", () => {
+  test("should trigger a call when invoked repeatedly", () => {
     const mockFn = vi.fn<() => void>();
 
     const throttled = throttle(mockFn, UT);
@@ -145,7 +145,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledWith();
   });
 
-  it("should trigger a call when invoked repeatedly and `leading` is `false`", async () => {
+  test("should trigger a call when invoked repeatedly and `leading` is `false`", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: false });
     const end = Date.now() + 10 * UT;
@@ -158,7 +158,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledWith();
   });
 
-  it("should trigger a second throttled call as soon as possible", async () => {
+  test("should trigger a second throttled call as soon as possible", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, 4 * UT, { leading: false });
     throttled();
@@ -176,7 +176,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should apply default options", async () => {
+  test("should apply default options", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, {});
     throttled();
@@ -189,7 +189,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should support a `leading` option", () => {
+  test("should support a `leading` option", () => {
     const mockWith = vi.fn<() => void>();
     const mockWithout = vi.fn<() => void>();
     const withLeading = throttle(mockWith, UT, { leading: true });
@@ -202,7 +202,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockWithout).toHaveBeenCalledTimes(0);
   });
 
-  it("should support a `trailing` option", async () => {
+  test("should support a `trailing` option", async () => {
     const mockWith = vi.fn<(x: string) => void>();
     const mockWithout = vi.fn<(x: string) => void>();
     const withTrailing = throttle(mockWith, 2 * UT, { trailing: true });
@@ -223,7 +223,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
     expect(mockWithout).toHaveBeenCalledTimes(1);
   });
 
-  it("should not update `lastCalled`, at the end of the timeout, when `trailing` is `false`", async () => {
+  test("should not update `lastCalled`, at the end of the timeout, when `trailing` is `false`", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, 64, { trailing: false });
     throttled();
@@ -238,7 +238,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768", ()
 });
 
 describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", () => {
-  it("should use a default `wait` of `0`", async () => {
+  test("should use a default `wait` of `0`", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn);
     throttled();
@@ -248,7 +248,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("supports recursive calls", async () => {
+  test("supports recursive calls", async () => {
     const actual = [] as Array<string>;
     const queue = ["a", "b", "c"];
     const throttled = throttle((chr: string) => {
@@ -267,7 +267,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(actual).toStrictEqual(["a", "b", "c"]);
   });
 
-  it("should support cancelling delayed calls", async () => {
+  test("should support cancelling delayed calls", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: false });
     throttled();
@@ -277,7 +277,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(0);
   });
 
-  it("should reset `lastCalled` after cancelling", async () => {
+  test("should reset `lastCalled` after cancelling", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: true });
     throttled();
@@ -295,7 +295,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
 
-  it("should support flushing delayed calls", async () => {
+  test("should support flushing delayed calls", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: false });
     throttled();
@@ -308,7 +308,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should noop `cancel` and `flush` when nothing is queued", async () => {
+  test("should noop `cancel` and `flush` when nothing is queued", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT);
     throttled.cancel();
@@ -323,7 +323,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
 });
 
 describe("Not tested by Lodash", () => {
-  it("should do nothing when `leading` and `trailing` are both `disabled`", async () => {
+  test("should do nothing when `leading` and `trailing` are both `disabled`", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: false, trailing: false });
     throttled();

--- a/packages/remeda/src/funnel.lodash-throttle.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation for a legacy library!
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { funnel } from "./funnel";
 

--- a/packages/remeda/src/funnel.lodash-throttle.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle.test.ts
@@ -322,7 +322,7 @@ describe("https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L23038", ()
   });
 });
 
-describe("Not tested by Lodash", () => {
+describe("not tested by Lodash", () => {
   test("should do nothing when `leading` and `trailing` are both `disabled`", async () => {
     const mockFn = vi.fn<() => void>();
     const throttled = throttle(mockFn, UT, { leading: false, trailing: false });

--- a/packages/remeda/src/funnel.reference-batch.test.ts
+++ b/packages/remeda/src/funnel.reference-batch.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation!
  */
 
+import { describe, expect, test, vi } from "vitest";
 import { doNothing } from "./doNothing";
 import { fromKeys } from "./fromKeys";
 import { funnel } from "./funnel";

--- a/packages/remeda/src/funnel.remeda-debounce.test.ts
+++ b/packages/remeda/src/funnel.remeda-debounce.test.ts
@@ -2,7 +2,7 @@
  * These aren't useful for a reference implementation!
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";
@@ -110,7 +110,7 @@ function debounce<F extends (...args: any) => any>(
 }
 
 describe("main functionality", () => {
-  it("should debounce a function", async () => {
+  test("should debounce a function", async () => {
     const mockFn = vi.fn<(x: string) => string>(identity());
     const debouncer = debounce(mockFn, { waitMs: 32 });
 
@@ -136,7 +136,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("subsequent debounced calls return the last `func` result", async () => {
+  test("subsequent debounced calls return the last `func` result", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
     debouncer.call("a");
     await sleep(64);
@@ -148,7 +148,7 @@ describe("main functionality", () => {
     expect(debouncer.call("c")).toBe("b");
   });
 
-  it("should not immediately call `func` when `wait` is `0`", async () => {
+  test("should not immediately call `func` when `wait` is `0`", async () => {
     const mockFn = vi.fn<() => void>();
     const debouncer = debounce(mockFn, {});
     debouncer.call();
@@ -161,7 +161,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should apply default options", async () => {
+  test("should apply default options", async () => {
     const mockFn = vi.fn<() => void>();
     const debouncer = debounce(mockFn, { waitMs: 32 });
     debouncer.call();
@@ -173,7 +173,7 @@ describe("main functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("should support a `leading` option", async () => {
+  test("should support a `leading` option", async () => {
     const leadingMockFn = vi.fn<() => void>();
     const bothMockFn = vi.fn<() => void>();
     const withLeading = debounce(leadingMockFn, {
@@ -202,7 +202,7 @@ describe("main functionality", () => {
     expect(leadingMockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("subsequent leading debounced calls return the last `func` result", async () => {
+  test("subsequent leading debounced calls return the last `func` result", async () => {
     const debouncer = debounce(identity(), { waitMs: 32, timing: "leading" });
 
     expect([debouncer.call("a"), debouncer.call("b")]).toStrictEqual([
@@ -218,7 +218,7 @@ describe("main functionality", () => {
     ]);
   });
 
-  it("should support a `trailing` option", async () => {
+  test("should support a `trailing` option", async () => {
     const mockFn = vi.fn<() => void>();
     const withTrailing = debounce(mockFn, { waitMs: 32, timing: "trailing" });
     withTrailing.call();
@@ -232,7 +232,7 @@ describe("main functionality", () => {
 });
 
 describe("optional param maxWaitMs", () => {
-  it("should support a `maxWait` option", async () => {
+  test("should support a `maxWait` option", async () => {
     const mockFn = vi.fn<(x: string) => void>();
     const debouncer = debounce(mockFn, { waitMs: 32, maxWaitMs: 64 });
     debouncer.call("a");
@@ -254,7 +254,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should support `maxWait` in a tight loop", async () => {
+  test("should support `maxWait` in a tight loop", async () => {
     const withMockFn = vi.fn<() => void>();
     const withoutMockFn = vi.fn<() => void>();
     const withMaxWait = debounce(withMockFn, { waitMs: 32, maxWaitMs: 128 });
@@ -270,7 +270,7 @@ describe("optional param maxWaitMs", () => {
     expect(withMockFn).not.toHaveBeenCalledTimes(0);
   });
 
-  it("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
+  test("should queue a trailing call for subsequent debounced calls after `maxWait`", async () => {
     const mockFn = vi.fn<() => void>();
     const debouncer = debounce(mockFn, { waitMs: 200, maxWaitMs: 200 });
     debouncer.call();
@@ -288,7 +288,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("should cancel `maxDelayed` when `delayed` is invoked", async () => {
+  test("should cancel `maxDelayed` when `delayed` is invoked", async () => {
     const mockFn = vi.fn<() => void>();
     const debouncer = debounce(mockFn, { waitMs: 32, maxWaitMs: 64 });
     debouncer.call();
@@ -302,7 +302,7 @@ describe("optional param maxWaitMs", () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  it("works like a leaky bucket when only maxWaitMs is set", async () => {
+  test("works like a leaky bucket when only maxWaitMs is set", async () => {
     const mockFn = vi.fn<() => void>();
     const debouncer = debounce(mockFn, { maxWaitMs: 32 });
     debouncer.call();
@@ -323,7 +323,7 @@ describe("optional param maxWaitMs", () => {
 });
 
 describe("additional functionality", () => {
-  it("can cancel before the timer starts", async () => {
+  test("can cancel before the timer starts", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(() => {
@@ -336,7 +336,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBe("hello");
   });
 
-  it("can cancel the timer", async () => {
+  test("can cancel the timer", async () => {
     const mockFn = vi.fn<() => string>(constant("Hello, World!"));
     const debouncer = debounce(mockFn, { waitMs: 32 });
 
@@ -360,7 +360,7 @@ describe("additional functionality", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it("can cancel after the timer ends", async () => {
+  test("can cancel after the timer ends", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -373,7 +373,7 @@ describe("additional functionality", () => {
     }).not.toThrow();
   });
 
-  it("can cancel maxWait timer", async () => {
+  test("can cancel maxWait timer", async () => {
     const debouncer = debounce(identity(), { waitMs: 16, maxWaitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -385,7 +385,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBeUndefined();
   });
 
-  it("can return a cached value", () => {
+  test("can return a cached value", () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
 
     expect(debouncer.cachedValue).toBeUndefined();
@@ -393,7 +393,7 @@ describe("additional functionality", () => {
     expect(debouncer.cachedValue).toBe("hello");
   });
 
-  it("can check for inflight timers (trailing)", async () => {
+  test("can check for inflight timers (trailing)", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.isPending).toBe(false);
@@ -409,7 +409,7 @@ describe("additional functionality", () => {
     expect(debouncer.isPending).toBe(false);
   });
 
-  it("can check for inflight timers (leading)", async () => {
+  test("can check for inflight timers (leading)", async () => {
     const debouncer = debounce(identity(), { timing: "leading", waitMs: 32 });
 
     expect(debouncer.isPending).toBe(false);
@@ -425,7 +425,7 @@ describe("additional functionality", () => {
     expect(debouncer.isPending).toBe(false);
   });
 
-  it("can flush before a cool-down", async () => {
+  test("can flush before a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.flush()).toBeUndefined();
@@ -436,7 +436,7 @@ describe("additional functionality", () => {
     expect(debouncer.call("world")).toBe("hello");
   });
 
-  it("can flush during a cool-down", async () => {
+  test("can flush during a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -450,7 +450,7 @@ describe("additional functionality", () => {
     expect(debouncer.flush()).toBe("world");
   });
 
-  it("can flush after a cool-down", async () => {
+  test("can flush after a cool-down", async () => {
     const debouncer = debounce(identity(), { waitMs: 32 });
 
     expect(debouncer.call("hello")).toBeUndefined();
@@ -462,7 +462,7 @@ describe("additional functionality", () => {
 });
 
 describe("errors", () => {
-  it("prevents maxWaitMs to be less then waitMs", () => {
+  test("prevents maxWaitMs to be less then waitMs", () => {
     expect(() => debounce(identity(), { waitMs: 32, maxWaitMs: 16 })).toThrow(
       "debounce: maxWaitMs (16) cannot be less than waitMs (32)",
     );

--- a/packages/remeda/src/funnel.remeda-debounce.test.ts
+++ b/packages/remeda/src/funnel.remeda-debounce.test.ts
@@ -2,6 +2,7 @@
  * These aren't useful for a reference implementation!
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { funnel } from "./funnel";

--- a/packages/remeda/src/funnel.test-d.ts
+++ b/packages/remeda/src/funnel.test-d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars -- We just want to build types, we don't care about using the params... */
 
+import { describe, expectTypeOf, test } from "vitest";
 import { doNothing } from "./doNothing";
 import { funnel } from "./funnel";
 

--- a/packages/remeda/src/funnel.test.ts
+++ b/packages/remeda/src/funnel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { doNothing } from "./doNothing";
@@ -46,7 +46,7 @@ describe("without a reducer", () => {
 });
 
 describe("reducer behavior", () => {
-  it("passes the reduced arg to the executor", () => {
+  test("passes the reduced arg to the executor", () => {
     const mockFn = vi.fn<(x: string) => void>();
     const foo = funnel(mockFn, {
       reducer: constant("hello world"),
@@ -59,7 +59,7 @@ describe("reducer behavior", () => {
     expect(mockFn).toHaveBeenLastCalledWith("hello world");
   });
 
-  it("reduces call args", async () => {
+  test("reduces call args", async () => {
     const mockFn = vi.fn<(x: number) => void>();
 
     const foo = funnel(mockFn, {
@@ -80,7 +80,7 @@ describe("reducer behavior", () => {
     expect(mockFn).toHaveBeenLastCalledWith(21 /* 1 + 2 + ... + 6 */);
   });
 
-  it("does not invoke if reduceArgs returns undefined", async () => {
+  test("does not invoke if reduceArgs returns undefined", async () => {
     const mockFn = vi.fn<(x: unknown) => void>();
     const foo = funnel(mockFn, {
       reducer: constant(undefined),
@@ -93,7 +93,7 @@ describe("reducer behavior", () => {
     expect(mockFn).toHaveBeenCalledTimes(0);
   });
 
-  it("supports multiple arguments", () => {
+  test("supports multiple arguments", () => {
     const mockFn = vi.fn<(x: unknown) => void>();
     const foo = funnel(mockFn, {
       reducer: (ret: unknown, a: number, b: string, c: boolean) => [

--- a/packages/remeda/src/funnel.test.ts
+++ b/packages/remeda/src/funnel.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
 import { doNothing } from "./doNothing";

--- a/packages/remeda/src/groupBy.test-d.ts
+++ b/packages/remeda/src/groupBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { groupBy } from "./groupBy";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 import { prop } from "./prop";

--- a/packages/remeda/src/groupBy.test.ts
+++ b/packages/remeda/src/groupBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { groupBy } from "./groupBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/groupByProp.test-d.ts
+++ b/packages/remeda/src/groupByProp.test-d.ts
@@ -2,6 +2,7 @@
  * The autofixer for this rule is breaking our tests!
  */
 
+import { describe, expectTypeOf, test } from "vitest";
 import { groupByProp } from "./groupByProp";
 
 const SYMBOL = Symbol("sym");

--- a/packages/remeda/src/groupByProp.test.ts
+++ b/packages/remeda/src/groupByProp.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { groupByProp } from "./groupByProp";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/groupByProp.test.ts
+++ b/packages/remeda/src/groupByProp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { groupByProp } from "./groupByProp";
 import { pipe } from "./pipe";
 
@@ -9,7 +9,7 @@ test("empty array", () => {
 });
 
 describe("data first", () => {
-  it("must be grouped correctly by string", () => {
+  test("must be grouped correctly by string", () => {
     expect(
       groupByProp(
         [
@@ -30,7 +30,7 @@ describe("data first", () => {
     });
   });
 
-  it("must be grouped correctly by number", () => {
+  test("must be grouped correctly by number", () => {
     expect(
       groupByProp(
         [
@@ -53,7 +53,7 @@ describe("data first", () => {
     });
   });
 
-  it("must be grouped correctly by Symbol", () => {
+  test("must be grouped correctly by Symbol", () => {
     expect(
       groupByProp(
         [
@@ -78,7 +78,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("must be grouped correctly by string", () => {
+  test("must be grouped correctly by string", () => {
     expect(
       pipe(
         [
@@ -99,7 +99,7 @@ describe("data last", () => {
     });
   });
 
-  it("must be grouped correctly by number", () => {
+  test("must be grouped correctly by number", () => {
     expect(
       pipe(
         [
@@ -122,7 +122,7 @@ describe("data last", () => {
     });
   });
 
-  it("must be grouped correctly by Symbol", () => {
+  test("must be grouped correctly by Symbol", () => {
     expect(
       pipe(
         [
@@ -146,7 +146,7 @@ describe("data last", () => {
   });
 });
 
-it("handles undefined as optional elements", () => {
+test("handles undefined as optional elements", () => {
   expect(
     groupByProp(
       // @ts-expect-error [ts2352] -- When `exactOptionalPropertyTypes` isn't enabled in tsconfig.json this isn't an error and would be acceptable as input, so we want to also test this case and make sure we don't cause issues. In our project the settings is enabled so we have to suppress the error.

--- a/packages/remeda/src/hasAtLeast.test-d.ts
+++ b/packages/remeda/src/hasAtLeast.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { hasAtLeast } from "./hasAtLeast";
 
 describe("dataFirst", () => {

--- a/packages/remeda/src/hasAtLeast.test-d.ts
+++ b/packages/remeda/src/hasAtLeast.test-d.ts
@@ -1,22 +1,22 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { hasAtLeast } from "./hasAtLeast";
 
 describe("dataFirst", () => {
-  it("narrows on empty checks", () => {
+  test("narrows on empty checks", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(array, 0)) {
       expectTypeOf(array).toEqualTypeOf<Array<number>>();
     }
   });
 
-  it("narrows on non-empty checks", () => {
+  test("narrows on non-empty checks", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(array, 1)) {
       expectTypeOf(array).toEqualTypeOf<[number, ...Array<number>]>();
     }
   });
 
-  it("narrows on large numbers", () => {
+  test("narrows on large numbers", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(array, 10)) {
       expectTypeOf(array).toEqualTypeOf<
@@ -39,21 +39,21 @@ describe("dataFirst", () => {
 });
 
 describe("dataLast", () => {
-  it("narrows on empty checks", () => {
+  test("narrows on empty checks", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(0)(array)) {
       expectTypeOf(array).toEqualTypeOf<Array<number>>();
     }
   });
 
-  it("narrows on non-empty checks", () => {
+  test("narrows on non-empty checks", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(1)(array)) {
       expectTypeOf(array).toEqualTypeOf<[number, ...Array<number>]>();
     }
   });
 
-  it("narrows on large numbers", () => {
+  test("narrows on large numbers", () => {
     const array = [] as Array<number>;
     if (hasAtLeast(10)(array)) {
       expectTypeOf(array).toEqualTypeOf<
@@ -74,7 +74,7 @@ describe("dataLast", () => {
     }
   });
 
-  it("creates narrowing utility functions", () => {
+  test("creates narrowing utility functions", () => {
     const hasADozen = hasAtLeast(12);
     const numbersArray = [] as Array<number>;
     if (hasADozen(numbersArray)) {
@@ -120,14 +120,14 @@ describe("dataLast", () => {
   });
 });
 
-it("fails on N > array length", () => {
+test("fails on N > array length", () => {
   const array = ["hello", "world"] as const;
   if (hasAtLeast(array, 3)) {
     expectTypeOf(array).toBeNever();
   }
 });
 
-it("works with interesting tuples", () => {
+test("works with interesting tuples", () => {
   const array = ["hello", "world", true, 456, 123, "cat"] as [
     "hello",
     string,
@@ -153,7 +153,7 @@ it("works with interesting tuples", () => {
   }
 });
 
-it("maintains readonly-ness", () => {
+test("maintains readonly-ness", () => {
   const array = [] as ReadonlyArray<string>;
   if (hasAtLeast(array, 3)) {
     expectTypeOf(array).toEqualTypeOf<
@@ -162,7 +162,7 @@ it("maintains readonly-ness", () => {
   }
 });
 
-it("only narrows on literal numbers", () => {
+test("only narrows on literal numbers", () => {
   const array = [] as Array<number>;
   if (hasAtLeast(array, 3 as number)) {
     expectTypeOf(array).toEqualTypeOf<Array<number>>();
@@ -171,7 +171,7 @@ it("only narrows on literal numbers", () => {
   }
 });
 
-it("can narrow on a literal union", () => {
+test("can narrow on a literal union", () => {
   const array = [] as Array<number>;
   if (hasAtLeast(array, 3 as 3 | 4)) {
     // The narrowing would result in taking the minimum

--- a/packages/remeda/src/hasAtLeast.test.ts
+++ b/packages/remeda/src/hasAtLeast.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { hasAtLeast } from "./hasAtLeast";
 
 describe("dataFirst", () => {

--- a/packages/remeda/src/hasAtLeast.test.ts
+++ b/packages/remeda/src/hasAtLeast.test.ts
@@ -1,19 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { hasAtLeast } from "./hasAtLeast";
 
 describe("dataFirst", () => {
-  it("works on empty arrays", () => {
+  test("works on empty arrays", () => {
     expect(hasAtLeast([], 0)).toBe(true);
     expect(hasAtLeast([], 10)).toBe(false);
   });
 
-  it("works on single item arrays", () => {
+  test("works on single item arrays", () => {
     expect(hasAtLeast([1], 0)).toBe(true);
     expect(hasAtLeast([1], 1)).toBe(true);
     expect(hasAtLeast([1], 2)).toBe(false);
   });
 
-  it("works on large arrays", () => {
+  test("works on large arrays", () => {
     const array = Array.from({ length: 1000 }, (_, i) => i);
 
     expect(hasAtLeast(array, 0)).toBe(true);
@@ -22,7 +22,7 @@ describe("dataFirst", () => {
     expect(hasAtLeast(array, 1001)).toBe(false);
   });
 
-  it("works on sparse arrays", () => {
+  test("works on sparse arrays", () => {
     const array = Array.from({ length: 1000 });
 
     expect(hasAtLeast(array, 0)).toBe(true);
@@ -33,18 +33,18 @@ describe("dataFirst", () => {
 });
 
 describe("dataLast", () => {
-  it("works on empty arrays", () => {
+  test("works on empty arrays", () => {
     expect(hasAtLeast(0)([])).toBe(true);
     expect(hasAtLeast(10)([])).toBe(false);
   });
 
-  it("works on single item arrays", () => {
+  test("works on single item arrays", () => {
     expect(hasAtLeast(0)([1])).toBe(true);
     expect(hasAtLeast(1)([1])).toBe(true);
     expect(hasAtLeast(2)([1])).toBe(false);
   });
 
-  it("works on large arrays", () => {
+  test("works on large arrays", () => {
     const array = Array.from({ length: 1000 }, (_, i) => i);
 
     expect(hasAtLeast(0)(array)).toBe(true);
@@ -53,7 +53,7 @@ describe("dataLast", () => {
     expect(hasAtLeast(1001)(array)).toBe(false);
   });
 
-  it("works on sparse arrays", () => {
+  test("works on sparse arrays", () => {
     const array = Array.from({ length: 1000 });
 
     expect(hasAtLeast(0)(array)).toBe(true);

--- a/packages/remeda/src/hasSubObject.test-d.ts
+++ b/packages/remeda/src/hasSubObject.test-d.ts
@@ -1,18 +1,18 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 
 describe("data-first", () => {
-  it("returns boolean", () => {
+  test("returns boolean", () => {
     expectTypeOf(hasSubObject({ a: 2 }, { a: 1 })).toEqualTypeOf<boolean>();
   });
 
-  it("doesn't require sub-object to have all keys", () => {
+  test("doesn't require sub-object to have all keys", () => {
     // ok
     hasSubObject({ a: 1, b: 2 }, { b: 2 });
   });
 
-  it("doesn't allow sub-object to have distinct keys from super-object", () => {
+  test("doesn't allow sub-object to have distinct keys from super-object", () => {
     // @ts-expect-error [ts2322] - non-matching key
     hasSubObject({ b: 2 }, { a: 1 });
 
@@ -20,7 +20,7 @@ describe("data-first", () => {
     hasSubObject({ b: 2 }, { b: 2, a: 1 });
   });
 
-  it("doesn't allow keys to have different types", () => {
+  test("doesn't allow keys to have different types", () => {
     // @ts-expect-error [ts2322] - `number` isn't assignable to `string`
     hasSubObject({ a: "a" }, { a: 1 });
 
@@ -31,7 +31,7 @@ describe("data-first", () => {
     hasSubObject({ a: { b: 2 } }, { a: "a" });
   });
 
-  it("allows keys to have different types when types are overlapping", () => {
+  test("allows keys to have different types when types are overlapping", () => {
     // ok - union type in super-object
     hasSubObject({ a: "a" as number | string }, { a: 1 });
 
@@ -42,12 +42,12 @@ describe("data-first", () => {
     hasSubObject({ a: "a" as number | string }, { a: 1 as boolean | number });
   });
 
-  it("allows const types", () => {
+  test("allows const types", () => {
     // ok - const value
     hasSubObject({ a: 2, b: 2 }, { a: 1 } as const);
   });
 
-  it("only allows valid objects to be passed", () => {
+  test("only allows valid objects to be passed", () => {
     // @ts-expect-error [ts2345] - only allow valid objects to be passed
     hasSubObject({ a: 2 } as unknown, { a: 1 });
 
@@ -55,7 +55,7 @@ describe("data-first", () => {
     hasSubObject({ a: 2 }, { a: 1 } as unknown);
   });
 
-  it("allows nested objects", () => {
+  test("allows nested objects", () => {
     // ok - nested objects
     hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1, c: 2 } });
 
@@ -73,7 +73,7 @@ describe("data-first", () => {
     });
   });
 
-  it("doesn't allow nested objects to have missing keys", () => {
+  test("doesn't allow nested objects to have missing keys", () => {
     // @ts-expect-error [ts2322] - nested sub-object doesn't have `c` key
     hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1 } });
 
@@ -83,7 +83,7 @@ describe("data-first", () => {
     });
   });
 
-  it("doesn't allow nested objects to have extra keys", () => {
+  test("doesn't allow nested objects to have extra keys", () => {
     // @ts-expect-error [ts2322] - nested sub-object has extra key `c`
     hasSubObject({ a: { b: 1 } }, { a: { b: 1, c: 2 } });
 
@@ -93,7 +93,7 @@ describe("data-first", () => {
     });
   });
 
-  it("doesn't allow nested objects keys to have different types", () => {
+  test("doesn't allow nested objects keys to have different types", () => {
     // @ts-expect-error [ts2322] - nested sub-object has wrong value types
     hasSubObject({ a: { b: 4, c: "c" } }, { a: { b: 1, c: 2 } });
 
@@ -107,7 +107,7 @@ describe("data-first", () => {
     hasSubObject({ a: { b: { c: 2 } } }, { a: { b: "a" } });
   });
 
-  it("allows nested objects keys to have different types when types are overlapping", () => {
+  test("allows nested objects keys to have different types when types are overlapping", () => {
     // ok - union type in nested super-object
     hasSubObject({ a: { b: 1 as number | string } }, { a: { b: 1 } });
 
@@ -121,7 +121,7 @@ describe("data-first", () => {
     );
   });
 
-  it("allows interfaces", () => {
+  test("allows interfaces", () => {
     interface AB {
       a: number;
       b: number;
@@ -136,7 +136,7 @@ describe("data-first", () => {
     ).toEqualTypeOf<boolean>();
   });
 
-  it("narrows with empty object", () => {
+  test("narrows with empty object", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject(obj, {})) {
@@ -146,7 +146,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows with same object", () => {
+  test("narrows with same object", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject(obj, obj)) {
@@ -156,7 +156,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows optional field to required", () => {
+  test("narrows optional field to required", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject(obj, { a: "a" })) {
@@ -166,7 +166,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows field to constant type", () => {
+  test("narrows field to constant type", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject(obj, { a: "a" } as const)) {
@@ -176,7 +176,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows with sub-object union type field", () => {
+  test("narrows with sub-object union type field", () => {
     const obj: { a?: string; b?: number; c?: boolean } = {};
 
     if (hasSubObject(obj, { c: true as boolean | number })) {
@@ -194,7 +194,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows union types", () => {
+  test("narrows union types", () => {
     const obj: { a?: string; b?: number; c?: number | string } = {};
 
     if (hasSubObject(obj, { c: true } as { c?: boolean | number })) {
@@ -212,7 +212,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows nested fields with sub-object union types", () => {
+  test("narrows nested fields with sub-object union types", () => {
     const obj = {
       a: { foo: "test", bar: true },
       b: { foo: "test", bar: true },
@@ -236,7 +236,7 @@ describe("data-first", () => {
     }
   });
 
-  it("narrows nested fields with union types", () => {
+  test("narrows nested fields with union types", () => {
     const obj = {
       a: { foo: "test" as number | string, bar: true },
       b: { foo: "test", bar: true as boolean | number },
@@ -262,20 +262,20 @@ describe("data-first", () => {
 });
 
 describe("data-last", () => {
-  it("returns boolean", () => {
+  test("returns boolean", () => {
     expectTypeOf(
       pipe({ a: 2 }, hasSubObject({ a: 1 })),
     ).toEqualTypeOf<boolean>();
   });
 
-  it("doesn't require sub-object to have all keys", () => {
+  test("doesn't require sub-object to have all keys", () => {
     // ok
     hasSubObject({ b: 2 })({ a: 1, b: 2 });
     // ok
     pipe({ a: 1, b: 2 }, hasSubObject({ b: 2 }));
   });
 
-  it("doesn't allow sub-object to have distinct keys from super-object", () => {
+  test("doesn't allow sub-object to have distinct keys from super-object", () => {
     // @ts-expect-error [ts2353] - non-matching key
     hasSubObject({ a: 1 })({ b: 2 });
     // @ts-expect-error [ts2345] - non-matching key
@@ -287,7 +287,7 @@ describe("data-last", () => {
     pipe({ b: 2 }, hasSubObject({ b: 2, a: 1 }));
   });
 
-  it("doesn't allow keys to have different types", () => {
+  test("doesn't allow keys to have different types", () => {
     // @ts-expect-error [ts2322] - `string` isn't assignable to `number`
     hasSubObject({ a: 1 })({ a: "a" });
     // @ts-expect-error [ts2345] - `string` isn't assignable to `number`
@@ -304,7 +304,7 @@ describe("data-last", () => {
     pipe({ a: { b: 2 } }, hasSubObject({ a: "a" }));
   });
 
-  it("allows keys to have different types when types are overlapping", () => {
+  test("allows keys to have different types when types are overlapping", () => {
     // ok - union type in super-object
     hasSubObject({ a: 1 })({ a: "a" as number | string });
     pipe({ a: "a" as number | string }, hasSubObject({ a: 1 }));
@@ -323,19 +323,19 @@ describe("data-last", () => {
     );
   });
 
-  it("allows const types", () => {
+  test("allows const types", () => {
     // ok - const value
     pipe({ a: 2, b: 2 }, hasSubObject({ a: 1 } as const));
   });
 
-  it("only allows valid objects to be passed", () => {
+  test("only allows valid objects to be passed", () => {
     // @ts-expect-error [ts2345] - only allow valid objects to be passed
     hasSubObject({ a: 1 })({ a: 2 } as unknown);
     // @ts-expect-error [ts2345] - only allow valid objects to be passed
     pipe({ a: 2 } as unknown, hasSubObject({ a: 1 }));
   });
 
-  it("allows nested objects", () => {
+  test("allows nested objects", () => {
     // ok - nested objects
     hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 1, c: 2 } });
     pipe({ a: { b: 1, c: 2 } }, hasSubObject({ a: { b: 1, c: 2 } }));
@@ -359,7 +359,7 @@ describe("data-last", () => {
     );
   });
 
-  it("doesn't allow nested objects to have missing keys", () => {
+  test("doesn't allow nested objects to have missing keys", () => {
     // @ts-expect-error [ts2322] - nested sub-object doesn't have `c` key
     hasSubObject({ a: { b: 1 } })({ a: { b: 1, c: 2 } });
     // @ts-expect-error [ts2345] - nested sub-object doesn't have `c` key
@@ -376,7 +376,7 @@ describe("data-last", () => {
     );
   });
 
-  it("doesn't allow nested objects to have extra keys", () => {
+  test("doesn't allow nested objects to have extra keys", () => {
     // @ts-expect-error [ts2322] - nested sub-object has extra key `c`
     hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 1 } });
     // @ts-expect-error [ts2345] - nested sub-object has extra key `c`
@@ -393,7 +393,7 @@ describe("data-last", () => {
     );
   });
 
-  it("doesn't allow nested objects keys to have different types", () => {
+  test("doesn't allow nested objects keys to have different types", () => {
     // @ts-expect-error [ts2322] - nested sub-object has wrong value types
     hasSubObject({ a: { b: 1, c: 2 } })({ a: { b: 4, c: "c" } });
     // @ts-expect-error [ts2345] - nested sub-object has wrong value types
@@ -415,7 +415,7 @@ describe("data-last", () => {
     pipe({ a: { b: { c: 2 } } }, hasSubObject({ a: { b: "a" } }));
   });
 
-  it("allows nested objects keys to have different types when types are overlapping", () => {
+  test("allows nested objects keys to have different types when types are overlapping", () => {
     // ok - union type in nested super-object
     hasSubObject({ a: { b: 1 } })({ a: { b: 1 as number | string } });
     pipe({ a: { b: 1 as number | string } }, hasSubObject({ a: { b: 1 } }));
@@ -436,7 +436,7 @@ describe("data-last", () => {
     );
   });
 
-  it("allows interfaces", () => {
+  test("allows interfaces", () => {
     interface AB {
       a: number;
       b: number;
@@ -450,7 +450,7 @@ describe("data-last", () => {
     pipe({ a: 1, b: 2 } as AB, hasSubObject({ a: 1 } as A));
   });
 
-  it("narrows with empty object", () => {
+  test("narrows with empty object", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject({})(obj)) {
@@ -460,7 +460,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows with same object", () => {
+  test("narrows with same object", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject(obj)(obj)) {
@@ -470,7 +470,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows optional field to required", () => {
+  test("narrows optional field to required", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject({ a: "a" })(obj)) {
@@ -480,7 +480,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows field to constant type", () => {
+  test("narrows field to constant type", () => {
     const obj = {} as { a?: string; b?: number };
 
     if (hasSubObject({ a: "a" } as const)(obj)) {
@@ -490,7 +490,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows with sub-object union type field", () => {
+  test("narrows with sub-object union type field", () => {
     const obj: { a?: string; b?: number; c?: boolean } = {};
 
     if (hasSubObject({ c: true as boolean | number })(obj)) {
@@ -508,7 +508,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows union types", () => {
+  test("narrows union types", () => {
     const obj: { a?: string; b?: number; c?: number | string } = {};
 
     if (hasSubObject({ c: true } as { c?: boolean | number })(obj)) {
@@ -526,7 +526,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows nested fields with sub-object union types", () => {
+  test("narrows nested fields with sub-object union types", () => {
     const obj = {
       a: { foo: "test", bar: true },
       b: { foo: "test", bar: true },
@@ -550,7 +550,7 @@ describe("data-last", () => {
     }
   });
 
-  it("narrows nested fields with union types", () => {
+  test("narrows nested fields with union types", () => {
     const obj = {
       a: { foo: "test" as number | string, bar: true },
       b: { foo: "test", bar: true as boolean | number },

--- a/packages/remeda/src/hasSubObject.test-d.ts
+++ b/packages/remeda/src/hasSubObject.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/hasSubObject.test.ts
+++ b/packages/remeda/src/hasSubObject.test.ts
@@ -1,20 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 
 describe("data first", () => {
-  it("works with empty sub-object", () => {
+  test("works with empty sub-object", () => {
     expect(hasSubObject({ a: 1, b: "b", c: 3 }, {})).toBe(true);
     expect(hasSubObject({}, {})).toBe(true);
   });
 
-  it("works with primitives", () => {
+  test("works with primitives", () => {
     expect(hasSubObject({ a: 1, b: "b", c: 3 }, { a: 1, b: "b" })).toBe(true);
     expect(hasSubObject({ a: 1, b: "c", c: 3 }, { a: 1, b: "b" })).toBe(false);
     expect(hasSubObject({ a: 2, b: "b", c: 3 }, { a: 1, b: "b" })).toBe(false);
   });
 
-  it("works with deep objects", () => {
+  test("works with deep objects", () => {
     expect(hasSubObject({ a: { b: 1, c: 2 } }, { a: { b: 1, c: 2 } })).toBe(
       true,
     );
@@ -23,7 +23,7 @@ describe("data first", () => {
     );
   });
 
-  it("checks for matching key", () => {
+  test("checks for matching key", () => {
     const data = {} as { a?: undefined };
 
     expect(hasSubObject(data, { a: undefined })).toBe(false);
@@ -31,12 +31,12 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("works with empty sub-object", () => {
+  test("works with empty sub-object", () => {
     expect(pipe({ a: 1, b: 2, c: 3 }, hasSubObject({}))).toBe(true);
     expect(pipe({}, hasSubObject({}))).toBe(true);
   });
 
-  it("works with primitives", () => {
+  test("works with primitives", () => {
     expect(pipe({ a: 1, b: "b", c: 3 }, hasSubObject({ a: 1, b: "b" }))).toBe(
       true,
     );
@@ -48,7 +48,7 @@ describe("data last", () => {
     );
   });
 
-  it("works with deep objects", () => {
+  test("works with deep objects", () => {
     expect(
       pipe({ a: { b: 1, c: 2 } }, hasSubObject({ a: { b: 1, c: 2 } })),
     ).toBe(true);

--- a/packages/remeda/src/hasSubObject.test.ts
+++ b/packages/remeda/src/hasSubObject.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { hasSubObject } from "./hasSubObject";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/identity.test-d.ts
+++ b/packages/remeda/src/identity.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { identity } from "./identity";
 
 test("normal values", () => {

--- a/packages/remeda/src/identity.test.ts
+++ b/packages/remeda/src/identity.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { add } from "./add";
 import { identity } from "./identity";
 import { map } from "./map";

--- a/packages/remeda/src/indexBy.test-d.ts
+++ b/packages/remeda/src/indexBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { indexBy } from "./indexBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/indexBy.test.ts
+++ b/packages/remeda/src/indexBy.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { indexBy } from "./indexBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/internal/binarySearchCutoffIndex.test.ts
+++ b/packages/remeda/src/internal/binarySearchCutoffIndex.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { binarySearchCutoffIndex } from "./binarySearchCutoffIndex";
 
 describe("runtime correctness", () => {

--- a/packages/remeda/src/internal/heap.test.ts
+++ b/packages/remeda/src/internal/heap.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { heapMaybeInsert } from "./heap";
 
 // TODO: This file only tests edge-cases which cannot be reached via the public functions that use the heap functions. We can expand the testing for heap so that we aren't dependant on those functions to test the core heap functionality.

--- a/packages/remeda/src/internal/purryFromLazy.test.ts
+++ b/packages/remeda/src/internal/purryFromLazy.test.ts
@@ -3,6 +3,7 @@
  * to write the tests.
  */
 
+import { expect, test } from "vitest";
 import { purryFromLazy } from "./purryFromLazy";
 import type { LazyEvaluator } from "./types/LazyEvaluator";
 

--- a/packages/remeda/src/internal/types/ArrayRequiredPrefix.test-d.ts
+++ b/packages/remeda/src/internal/types/ArrayRequiredPrefix.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import type { ArrayRequiredPrefix } from "./ArrayRequiredPrefix";
 import type { IterableContainer } from "./IterableContainer";
 

--- a/packages/remeda/src/internal/types/ArrayRequiredPrefix.test-d.ts
+++ b/packages/remeda/src/internal/types/ArrayRequiredPrefix.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import type { ArrayRequiredPrefix } from "./ArrayRequiredPrefix";
 import type { IterableContainer } from "./IterableContainer";
 
@@ -7,7 +7,7 @@ declare function arrayRequiredPrefix<
   Min extends number,
 >(data: T, min: Min): ArrayRequiredPrefix<T, Min>;
 
-it("synchronizes the tuple readonly modifier", () => {
+test("synchronizes the tuple readonly modifier", () => {
   expectTypeOf(arrayRequiredPrefix([] as Array<string>, 1)).toEqualTypeOf<
     [string, ...Array<string>]
   >();

--- a/packages/remeda/src/internal/types/Deduped.test-d.ts
+++ b/packages/remeda/src/internal/types/Deduped.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import type { Deduped } from "./Deduped";
 import type { IterableContainer } from "./IterableContainer";
 

--- a/packages/remeda/src/internal/types/DisjointUnionFields.test-d.ts
+++ b/packages/remeda/src/internal/types/DisjointUnionFields.test-d.ts
@@ -1,7 +1,7 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import type { DisjointUnionFields } from "./DisjointUnionFields";
 
-it("should have the complement of SharedUnionFields", () => {
+test("should have the complement of SharedUnionFields", () => {
   expectTypeOf<
     DisjointUnionFields<
       | { a: string; b: string; c: string }

--- a/packages/remeda/src/internal/types/DisjointUnionFields.test-d.ts
+++ b/packages/remeda/src/internal/types/DisjointUnionFields.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import type { DisjointUnionFields } from "./DisjointUnionFields";
 
 it("should have the complement of SharedUnionFields", () => {

--- a/packages/remeda/src/internal/types/EnumerableStringKeyOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyOf.test-d.ts
@@ -1,4 +1,5 @@
 import type { Tagged } from "type-fest";
+import { expectTypeOf, test } from "vitest";
 import type { EnumerableStringKeyOf } from "./EnumerableStringKeyOf";
 
 declare const SymbolFoo: unique symbol;

--- a/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyedValueOf.test-d.ts
@@ -1,4 +1,5 @@
 import type { EmptyObject } from "type-fest";
+import { expectTypeOf, test } from "vitest";
 import type { EnumerableStringKeyedValueOf } from "./EnumerableStringKeyedValueOf";
 
 declare function enumerableStringKeyedValueOf<const T>(

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import type { FilteredArray } from "./FilteredArray";
 import type { IterableContainer } from "./IterableContainer";
 

--- a/packages/remeda/src/internal/types/IfBoundedRecord.test-d.ts
+++ b/packages/remeda/src/internal/types/IfBoundedRecord.test-d.ts
@@ -1,4 +1,5 @@
 import type { Tagged } from "type-fest";
+import { expectTypeOf, test } from "vitest";
 import type { IfBoundedRecord } from "./IfBoundedRecord";
 
 declare const SymbolFoo: unique symbol;

--- a/packages/remeda/src/internal/types/NTuple.test-d.ts
+++ b/packages/remeda/src/internal/types/NTuple.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import type { NTuple } from "./NTuple";
 
 declare function nTuple<T, N extends number>(x: T, n: N): NTuple<T, N>;

--- a/packages/remeda/src/internal/types/TupleParts.test-d.ts
+++ b/packages/remeda/src/internal/types/TupleParts.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import type { IterableContainer } from "./IterableContainer";
 import type { TupleParts } from "./TupleParts";
 

--- a/packages/remeda/src/internal/types/TupleSplits.test-d.ts
+++ b/packages/remeda/src/internal/types/TupleSplits.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import type { IterableContainer } from "./IterableContainer";
 import type { TupleSplits } from "./TupleSplits";
 

--- a/packages/remeda/src/internal/withPrecision.test.ts
+++ b/packages/remeda/src/internal/withPrecision.test.ts
@@ -1,8 +1,8 @@
-import { expect, it, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 import { identity } from "../identity";
 import { withPrecision } from "./withPrecision";
 
-it("handles numbers that can only be printed in scientific notation", () => {
+test("handles numbers that can only be printed in scientific notation", () => {
   const mockRoundingFn = vi.fn<(input: number) => number>(identity());
   const roundingFn = withPrecision(mockRoundingFn);
   roundingFn(Number.parseFloat("1.23e+45"), 6);

--- a/packages/remeda/src/internal/withPrecision.test.ts
+++ b/packages/remeda/src/internal/withPrecision.test.ts
@@ -1,3 +1,4 @@
+import { expect, it, vi } from "vitest";
 import { identity } from "../identity";
 import { withPrecision } from "./withPrecision";
 

--- a/packages/remeda/src/internal/words.test.ts
+++ b/packages/remeda/src/internal/words.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { words } from "./words";
 
 describe("copied from the type-fest tests", () => {

--- a/packages/remeda/src/intersection.test-d.ts
+++ b/packages/remeda/src/intersection.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { intersection } from "./intersection";
 
 it("narrows the result type", () => {

--- a/packages/remeda/src/intersection.test-d.ts
+++ b/packages/remeda/src/intersection.test-d.ts
@@ -1,7 +1,7 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { intersection } from "./intersection";
 
-it("narrows the result type", () => {
+test("narrows the result type", () => {
   const result = intersection([1, 2, 3, "a", "b"], ["a", "b", true, false]);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();

--- a/packages/remeda/src/intersection.test.ts
+++ b/packages/remeda/src/intersection.test.ts
@@ -1,47 +1,47 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { identity } from "./identity";
 import { intersection } from "./intersection";
 import { map } from "./map";
 import { pipe } from "./pipe";
 
-it("returns empty array trivially", () => {
+test("returns empty array trivially", () => {
   expect(intersection([], [])).toStrictEqual([]);
 });
 
-it("returns empty array on empty input", () => {
+test("returns empty array on empty input", () => {
   expect(intersection([], [1, 2, 3])).toStrictEqual([]);
   expect(intersection([1, 2, 3], [])).toStrictEqual([]);
 });
 
-it("returns empty array on disjoint arrays", () => {
+test("returns empty array on disjoint arrays", () => {
   expect(intersection([1], [2])).toStrictEqual([]);
 });
 
-it("works trivially on a single item", () => {
+test("works trivially on a single item", () => {
   expect(intersection([1], [1])).toStrictEqual([1]);
 });
 
-it("maintains multi-set semantics (returns only one copy)", () => {
+test("maintains multi-set semantics (returns only one copy)", () => {
   expect(intersection([1, 1], [1])).toStrictEqual([1]);
   expect(intersection([1], [1, 1])).toStrictEqual([1]);
 });
 
-it("maintains multi-set semantics (returns as many copies as available)", () => {
+test("maintains multi-set semantics (returns as many copies as available)", () => {
   expect(intersection([1, 1, 1, 1, 1], [1, 1])).toStrictEqual([1, 1]);
   expect(intersection([1, 1], [1, 1, 1, 1, 1])).toStrictEqual([1, 1]);
 });
 
-it("preserves the original order in source array", () => {
+test("preserves the original order in source array", () => {
   expect(intersection([3, 2, 1], [1, 2, 3])).toStrictEqual([3, 2, 1]);
 });
 
-it("maintains order for multiple copies", () => {
+test("maintains order for multiple copies", () => {
   expect(intersection([3, 2, 2, 2, 2, 2, 1], [1, 2, 3])).toStrictEqual([
     3, 2, 1,
   ]);
 });
 
-it("returns a shallow copy even when all items match", () => {
+test("returns a shallow copy even when all items match", () => {
   const data = [1, 2, 3];
   const result = intersection(data, [1, 2, 3]);
 

--- a/packages/remeda/src/intersection.test.ts
+++ b/packages/remeda/src/intersection.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { identity } from "./identity";
 import { intersection } from "./intersection";
 import { map } from "./map";

--- a/packages/remeda/src/intersectionWith.test.ts
+++ b/packages/remeda/src/intersectionWith.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { intersectionWith } from "./intersectionWith";
 import { isDeepEqual } from "./isDeepEqual";

--- a/packages/remeda/src/intersectionWith.test.ts
+++ b/packages/remeda/src/intersectionWith.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { intersectionWith } from "./intersectionWith";
 import { isDeepEqual } from "./isDeepEqual";
@@ -26,7 +26,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("returns the new array of intersecting values based on a custom comparator", () => {
+  test("returns the new array of intersecting values based on a custom comparator", () => {
     expect(
       intersectionWith(
         other,
@@ -37,7 +37,7 @@ describe("data last", () => {
     ).toStrictEqual(expected);
   });
 
-  it("checks if items are equal based on remeda's imported util function as a comparator", () => {
+  test("checks if items are equal based on remeda's imported util function as a comparator", () => {
     expect(
       pipe(
         [
@@ -55,7 +55,7 @@ describe("data last", () => {
     ).toStrictEqual([{ x: 1, y: 2 }]);
   });
 
-  it("evaluates lazily", () => {
+  test("evaluates lazily", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }, { a: 6 }],

--- a/packages/remeda/src/invert.test-d.ts
+++ b/packages/remeda/src/invert.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { invert } from "./invert";
 
 test("simple string records", () => {

--- a/packages/remeda/src/invert.test.ts
+++ b/packages/remeda/src/invert.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { invert } from "./invert";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/isArray.test-d.ts
+++ b/packages/remeda/src/isArray.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isArray.test-d.ts
+++ b/packages/remeda/src/isArray.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it, test } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,7 +6,7 @@ import {
 } from "../test/typesDataProvider";
 import { isArray } from "./isArray";
 
-it("should infer ReadonlyArray<unknown> when given any", () => {
+test("should infer ReadonlyArray<unknown> when given any", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
   const data = [] as any;
   if (isArray(data)) {
@@ -15,7 +15,7 @@ it("should infer ReadonlyArray<unknown> when given any", () => {
   }
 });
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.array as AllTypesDataProviderTypes;
   if (isArray(data)) {
     expectTypeOf(data).toEqualTypeOf<
@@ -24,14 +24,14 @@ it("should work as type guard", () => {
   }
 });
 
-it("should infer ReadonlyArray<unknown> when given `unknown`", () => {
+test("should infer ReadonlyArray<unknown> when given `unknown`", () => {
   const data = TYPES_DATA_PROVIDER.array as unknown;
   if (isArray(data)) {
     expectTypeOf(data).toEqualTypeOf<ReadonlyArray<unknown>>();
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isArray);
 
   expectTypeOf(data).toEqualTypeOf<

--- a/packages/remeda/src/isArray.test.ts
+++ b/packages/remeda/src/isArray.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isArray } from "./isArray";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isArray(TYPES_DATA_PROVIDER.array)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isArray);
 
   expect(data.every((c) => Array.isArray(c))).toBe(true);

--- a/packages/remeda/src/isArray.test.ts
+++ b/packages/remeda/src/isArray.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isBigInt.test-d.ts
+++ b/packages/remeda/src/isBigInt.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,27 +6,27 @@ import {
 } from "../test/typesDataProvider";
 import { isBigInt } from "./isBigInt";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.bigint as AllTypesDataProviderTypes;
   if (isBigInt(data)) {
     expectTypeOf(data).toEqualTypeOf<1n>();
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBigInt);
 
   expectTypeOf(data).toEqualTypeOf<Array<1n>>();
 });
 
-it("should work even if data type is unknown", () => {
+test("should work even if data type is unknown", () => {
   const data = TYPES_DATA_PROVIDER.bigint as unknown;
   if (isBigInt(data)) {
     expectTypeOf(data).toEqualTypeOf<bigint>();
   }
 });
 
-it("should work with literal types", () => {
+test("should work with literal types", () => {
   const x = dataFunction();
   if (isBigInt(x)) {
     expectTypeOf(x).toEqualTypeOf<1n | 2n | 3n>(x);

--- a/packages/remeda/src/isBigInt.test-d.ts
+++ b/packages/remeda/src/isBigInt.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isBigInt.test.ts
+++ b/packages/remeda/src/isBigInt.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isBigInt } from "./isBigInt";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isBigInt(TYPES_DATA_PROVIDER.bigint)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBigInt);
 
   expect(data.every((c) => typeof c === "bigint")).toBe(true);

--- a/packages/remeda/src/isBigInt.test.ts
+++ b/packages/remeda/src/isBigInt.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isBoolean.test-d.ts
+++ b/packages/remeda/src/isBoolean.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isBoolean.test-d.ts
+++ b/packages/remeda/src/isBoolean.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,21 +6,21 @@ import {
 } from "../test/typesDataProvider";
 import { isBoolean } from "./isBoolean";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.boolean as AllTypesDataProviderTypes;
   if (isBoolean(data)) {
     expectTypeOf(data).toEqualTypeOf<boolean>();
   }
 });
 
-it("should narrow `unknown`", () => {
+test("should narrow `unknown`", () => {
   const data = TYPES_DATA_PROVIDER.boolean as unknown;
   if (isBoolean(data)) {
     expectTypeOf(data).toEqualTypeOf<boolean>();
   }
 });
 
-it("should narrow `any`", () => {
+test("should narrow `any`", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly testing `any`
   const data = TYPES_DATA_PROVIDER.boolean as any;
   if (isBoolean(data)) {
@@ -28,7 +28,7 @@ it("should narrow `any`", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBoolean);
 
   expectTypeOf(data).toEqualTypeOf<Array<boolean>>();

--- a/packages/remeda/src/isBoolean.test.ts
+++ b/packages/remeda/src/isBoolean.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isBoolean.test.ts
+++ b/packages/remeda/src/isBoolean.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isBoolean } from "./isBoolean";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isBoolean(TYPES_DATA_PROVIDER.boolean)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isBoolean);
 
   expect(data.every((c) => typeof c === "boolean")).toBe(true);

--- a/packages/remeda/src/isDate.test-d.ts
+++ b/packages/remeda/src/isDate.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isDate.test-d.ts
+++ b/packages/remeda/src/isDate.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,21 +6,21 @@ import {
 } from "../test/typesDataProvider";
 import { isDate } from "./isDate";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
   if (isDate(data)) {
     expectTypeOf(data).toEqualTypeOf<Date>();
   }
 });
 
-it("should narrow `unknown`", () => {
+test("should narrow `unknown`", () => {
   const data = TYPES_DATA_PROVIDER.date as unknown;
   if (isDate(data)) {
     expectTypeOf(data).toEqualTypeOf<Date>();
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDate);
 
   expectTypeOf(data).toEqualTypeOf<Array<Date>>();

--- a/packages/remeda/src/isDate.test.ts
+++ b/packages/remeda/src/isDate.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isDate.test.ts
+++ b/packages/remeda/src/isDate.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isDate } from "./isDate";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isDate(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDate);
 
   expect(data.every((c) => c instanceof Date)).toBe(true);

--- a/packages/remeda/src/isDeepEqual.test-d.ts
+++ b/packages/remeda/src/isDeepEqual.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isDeepEqual } from "./isDeepEqual";
 

--- a/packages/remeda/src/isDeepEqual.test-d.ts
+++ b/packages/remeda/src/isDeepEqual.test-d.ts
@@ -1,8 +1,8 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isDeepEqual } from "./isDeepEqual";
 
-it("narrows unions", () => {
+test("narrows unions", () => {
   const data = 1 as number | string;
 
   if (isDeepEqual(data, 1)) {
@@ -18,7 +18,7 @@ it("narrows unions", () => {
   }
 });
 
-it("narrows to literal", () => {
+test("narrows to literal", () => {
   const data = 1 as number;
   if (isDeepEqual(data, 1 as const)) {
     expectTypeOf(data).toEqualTypeOf<1>();
@@ -27,12 +27,12 @@ it("narrows to literal", () => {
   }
 });
 
-it("doesn't accept non-overlapping types", () => {
+test("doesn't accept non-overlapping types", () => {
   // @ts-expect-error [ts2345] - Checking against the wrong type should fail
   isDeepEqual(1 as number, true);
 });
 
-it("works deeply", () => {
+test("works deeply", () => {
   const data = [] as Array<
     { a: Array<number> | Array<string> } | { b: Array<boolean> }
   >;
@@ -52,7 +52,7 @@ it("works deeply", () => {
   }
 });
 
-it("doesn't narrow when comparing objects of the same type", () => {
+test("doesn't narrow when comparing objects of the same type", () => {
   const data1 = { a: 1 } as { a: number };
   const data2 = { a: 2 } as { a: number };
   if (isDeepEqual(data1, data2)) {
@@ -62,7 +62,7 @@ it("doesn't narrow when comparing objects of the same type", () => {
   }
 });
 
-it("headless usage can infer types", () => {
+test("headless usage can infer types", () => {
   // Tests the issue reported in: https://github.com/remeda/remeda/issues/641
   const result = differenceWith(["a", "b", "c"], ["a", "c", "d"], isDeepEqual);
 

--- a/packages/remeda/src/isDeepEqual.test.ts
+++ b/packages/remeda/src/isDeepEqual.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { isDeepEqual } from "./isDeepEqual";
 
 describe("scalars", () => {
@@ -235,7 +235,7 @@ describe("Arrays", () => {
 });
 
 describe("Maps", () => {
-  it("works on shallow equal maps", () => {
+  test("works on shallow equal maps", () => {
     expect(isDeepEqual(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(true);
   });
 
@@ -243,11 +243,11 @@ describe("Maps", () => {
     expect(isDeepEqual(new Map(), new Map())).toBe(true);
   });
 
-  it("two Maps with different size should not be equal", () => {
+  test("two Maps with different size should not be equal", () => {
     expect(isDeepEqual(new Map(), new Map([["a", 1]]))).toBe(false);
   });
 
-  it("two Maps with different keys shoud not be equal", () => {
+  test("two Maps with different keys shoud not be equal", () => {
     expect(
       isDeepEqual(
         new Map([
@@ -262,7 +262,7 @@ describe("Maps", () => {
     ).toBe(false);
   });
 
-  it("two maps with the same keys but with different values should not be equal", () => {
+  test("two maps with the same keys but with different values should not be equal", () => {
     expect(
       isDeepEqual(
         new Map([
@@ -279,7 +279,7 @@ describe("Maps", () => {
     ).toBe(false);
   });
 
-  it("two Maps with the same non primitives data should be equal", () => {
+  test("two Maps with the same non primitives data should be equal", () => {
     expect(
       isDeepEqual(
         new Map([

--- a/packages/remeda/src/isDeepEqual.test.ts
+++ b/packages/remeda/src/isDeepEqual.test.ts
@@ -75,7 +75,7 @@ describe("scalars", () => {
   });
 });
 
-describe("Objects", () => {
+describe("objects", () => {
   test("empty objects are equal", () => {
     expect(isDeepEqual({}, {})).toBe(true);
   });
@@ -153,7 +153,7 @@ describe("Objects", () => {
   });
 });
 
-describe("Sets", () => {
+describe("sets", () => {
   test("two empty sets should be equal", () => {
     expect(isDeepEqual(new Set(), new Set())).toBe(true);
   });
@@ -200,7 +200,7 @@ describe("Sets", () => {
   });
 });
 
-describe("Arrays", () => {
+describe("arrays", () => {
   test("two empty arrays are equal", () => {
     expect(isDeepEqual([], [])).toBe(true);
   });
@@ -234,7 +234,7 @@ describe("Arrays", () => {
   });
 });
 
-describe("Maps", () => {
+describe("maps", () => {
   test("works on shallow equal maps", () => {
     expect(isDeepEqual(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(true);
   });
@@ -297,7 +297,7 @@ describe("Maps", () => {
   });
 });
 
-describe("Dates", () => {
+describe("dates", () => {
   test("equal date objects", () => {
     expect(
       isDeepEqual(
@@ -332,7 +332,7 @@ describe("Dates", () => {
   });
 });
 
-describe("RegExp", () => {
+describe("regular expressions", () => {
   test("equal RegExp objects", () => {
     expect(isDeepEqual(/foo/u, /foo/u)).toBe(true);
   });

--- a/packages/remeda/src/isDeepEqual.test.ts
+++ b/packages/remeda/src/isDeepEqual.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { isDeepEqual } from "./isDeepEqual";
 
 describe("scalars", () => {

--- a/packages/remeda/src/isDefined.test-d.ts
+++ b/packages/remeda/src/isDefined.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -8,7 +8,7 @@ import {
 } from "../test/typesDataProvider";
 import { isDefined } from "./isDefined";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
   if (isDefined(data)) {
     expectTypeOf(data).toEqualTypeOf<
@@ -34,7 +34,7 @@ it("should work as type guard", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDefined);
 
   expectTypeOf(data).toEqualTypeOf<

--- a/packages/remeda/src/isDefined.test-d.ts
+++ b/packages/remeda/src/isDefined.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isDefined.test.ts
+++ b/packages/remeda/src/isDefined.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isDefined.test.ts
+++ b/packages/remeda/src/isDefined.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isDefined } from "./isDefined";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isDefined(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isDefined);
 
   expect(data).toHaveLength(18);

--- a/packages/remeda/src/isEmpty.test-d.ts
+++ b/packages/remeda/src/isEmpty.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { isEmpty } from "./isEmpty";
 
 describe("invalid types", () => {

--- a/packages/remeda/src/isEmpty.test.ts
+++ b/packages/remeda/src/isEmpty.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { isEmpty } from "./isEmpty";
 
 test("returns true for an empty array", () => {

--- a/packages/remeda/src/isError.test-d.ts
+++ b/packages/remeda/src/isError.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isError.test-d.ts
+++ b/packages/remeda/src/isError.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -13,7 +13,7 @@ class MyError extends Error {
   }
 }
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.error as AllTypesDataProviderTypes;
   if (isError(data)) {
     expectTypeOf(data).toEqualTypeOf<Error>();
@@ -25,7 +25,7 @@ it("should work as type guard", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isError);
 
   expectTypeOf(data).toEqualTypeOf<Array<Error>>();

--- a/packages/remeda/src/isError.test.ts
+++ b/packages/remeda/src/isError.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isError.test.ts
+++ b/packages/remeda/src/isError.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isError } from "./isError";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isError(TYPES_DATA_PROVIDER.error)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isError);
 
   expect(data.every((c) => c instanceof Error)).toBe(true);

--- a/packages/remeda/src/isFunction.test-d.ts
+++ b/packages/remeda/src/isFunction.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isFunction.test-d.ts
+++ b/packages/remeda/src/isFunction.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,7 +6,7 @@ import {
 } from "../test/typesDataProvider";
 import { isFunction } from "./isFunction";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.function as AllTypesDataProviderTypes;
   if (isFunction(data)) {
     expectTypeOf(data).toEqualTypeOf<() => void>();
@@ -20,7 +20,7 @@ it("should work as type guard", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isFunction);
 
   expectTypeOf(data).toEqualTypeOf<Array<() => void>>();

--- a/packages/remeda/src/isFunction.test.ts
+++ b/packages/remeda/src/isFunction.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isFunction.test.ts
+++ b/packages/remeda/src/isFunction.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isFunction } from "./isFunction";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isFunction(TYPES_DATA_PROVIDER.function)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isFunction);
 
   expect(data.every((c) => typeof c === "function")).toBe(true);

--- a/packages/remeda/src/isIncludedIn.test-d.ts
+++ b/packages/remeda/src/isIncludedIn.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { isIncludedIn } from "./isIncludedIn";
 
 it("throws on bad value types", () => {

--- a/packages/remeda/src/isIncludedIn.test-d.ts
+++ b/packages/remeda/src/isIncludedIn.test-d.ts
@@ -1,12 +1,12 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { isIncludedIn } from "./isIncludedIn";
 
-it("throws on bad value types", () => {
+test("throws on bad value types", () => {
   // @ts-expect-error [ts2322] - strings are not numbers
   isIncludedIn(1, ["yes", "no"]);
 });
 
-it("throws on non-overlapping (e.g. typo-proof)", () => {
+test("throws on non-overlapping (e.g. typo-proof)", () => {
   const myEnum = "cat" as "cat" | "dog";
   // @ts-expect-error [ts2322] - "doog" is a typo
   isIncludedIn(myEnum, ["doog"]);

--- a/packages/remeda/src/isIncludedIn.test.ts
+++ b/packages/remeda/src/isIncludedIn.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { filter } from "./filter";
 import { isIncludedIn } from "./isIncludedIn";
 import { isNot } from "./isNot";

--- a/packages/remeda/src/isIncludedIn.test.ts
+++ b/packages/remeda/src/isIncludedIn.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { isIncludedIn } from "./isIncludedIn";
 import { isNot } from "./isNot";
@@ -19,18 +19,18 @@ describe("dataFirst", () => {
     expect(isIncludedIn(4, [1, 2, 3])).toBe(false);
   });
 
-  it("works with strings", () => {
+  test("works with strings", () => {
     expect(isIncludedIn("b", ["a", "b", "c"])).toBe(true);
   });
 
-  it("only tests reference equality: (arrays)", () => {
+  test("only tests reference equality: (arrays)", () => {
     const arr = [1];
 
     expect(isIncludedIn([1], [arr])).toBe(false);
     expect(isIncludedIn(arr, [arr])).toBe(true);
   });
 
-  it("only tests reference equality: (objects)", () => {
+  test("only tests reference equality: (objects)", () => {
     const obj = { a: 1 };
 
     expect(isIncludedIn({ a: 1 }, [obj])).toBe(false);
@@ -51,18 +51,18 @@ describe("dataLast", () => {
     expect(pipe(4, isIncludedIn([1, 2, 3]))).toBe(false);
   });
 
-  it("works with strings", () => {
+  test("works with strings", () => {
     expect(pipe("b", isIncludedIn(["a", "b", "c"]))).toBe(true);
   });
 
-  it("only tests reference equality: (arrays)", () => {
+  test("only tests reference equality: (arrays)", () => {
     const arr = [1];
 
     expect(pipe([1], isIncludedIn([arr]))).toBe(false);
     expect(pipe(arr, isIncludedIn([arr]))).toBe(true);
   });
 
-  it("only tests reference equality: (objects)", () => {
+  test("only tests reference equality: (objects)", () => {
     const obj = { a: 1 };
 
     expect(pipe({ a: 1 }, isIncludedIn([obj]))).toBe(false);
@@ -70,14 +70,14 @@ describe("dataLast", () => {
   });
 
   describe("dataLast memoization", () => {
-    it("returns correct result when called multiple times with the same container", () => {
+    test("returns correct result when called multiple times with the same container", () => {
       const isIncludedInContainer = isIncludedIn([1, 2, 3]);
 
       expect(isIncludedInContainer(2)).toBe(true);
       expect(isIncludedInContainer(4)).toBe(false);
     });
 
-    it("returns correct result when called with different containers", () => {
+    test("returns correct result when called with different containers", () => {
       const isIncludedInContainer1 = isIncludedIn([1, 2, 3]);
       const isIncludedInContainer2 = isIncludedIn([4, 5, 6]);
 
@@ -87,7 +87,7 @@ describe("dataLast", () => {
       expect(isIncludedInContainer2(4)).toBe(true);
     });
 
-    it("does not leak information between invocations", () => {
+    test("does not leak information between invocations", () => {
       const container = [1, 2, 3];
 
       const isIncludedInContainer = isIncludedIn(container);

--- a/packages/remeda/src/isNonNull.test-d.ts
+++ b/packages/remeda/src/isNonNull.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNonNull.test.ts
+++ b/packages/remeda/src/isNonNull.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNonNullish.test-d.ts
+++ b/packages/remeda/src/isNonNullish.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNonNullish.test-d.ts
+++ b/packages/remeda/src/isNonNullish.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -8,7 +8,7 @@ import {
 } from "../test/typesDataProvider";
 import { isNonNullish } from "./isNonNullish";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.date as AllTypesDataProviderTypes;
   if (isNonNullish(data)) {
     expectTypeOf(data).toEqualTypeOf<
@@ -33,7 +33,7 @@ it("should work as type guard", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNonNullish);
 
   expectTypeOf(data).toEqualTypeOf<

--- a/packages/remeda/src/isNonNullish.test.ts
+++ b/packages/remeda/src/isNonNullish.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNonNullish.test.ts
+++ b/packages/remeda/src/isNonNullish.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isNonNullish } from "./isNonNullish";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isNonNullish(TYPES_DATA_PROVIDER.date)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNonNullish);
 
   expect(data).toHaveLength(17);

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -10,7 +10,7 @@ import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
   if (isNot(isString)(data)) {
     expectTypeOf(data).toEqualTypeOf<
@@ -36,7 +36,7 @@ it("should work as type guard", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNot(isPromise));
 
   expectTypeOf(data).toEqualTypeOf<

--- a/packages/remeda/src/isNot.test.ts
+++ b/packages/remeda/src/isNot.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNot.test.ts
+++ b/packages/remeda/src/isNot.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -7,11 +7,11 @@ import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isNot(isString)(TYPES_DATA_PROVIDER.promise)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNot(isPromise));
 
   expect(data.some((c) => c instanceof Promise)).toBe(false);

--- a/packages/remeda/src/isNullish.test-d.ts
+++ b/packages/remeda/src/isNullish.test-d.ts
@@ -1,4 +1,5 @@
 import type { IsEqual, IsUnknown, Or } from "type-fest";
+import { expectTypeOf, it } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER } from "../test/typesDataProvider";
 import { isNullish } from "./isNullish";
 

--- a/packages/remeda/src/isNullish.test-d.ts
+++ b/packages/remeda/src/isNullish.test-d.ts
@@ -1,9 +1,9 @@
 import type { IsEqual, IsUnknown, Or } from "type-fest";
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER } from "../test/typesDataProvider";
 import { isNullish } from "./isNullish";
 
-it("narrows nulls", () => {
+test("narrows nulls", () => {
   const data = 123 as number | null;
   if (isNullish(data)) {
     expectTypeOf(data).toBeNull();
@@ -12,7 +12,7 @@ it("narrows nulls", () => {
   }
 });
 
-it("narrows undefined", () => {
+test("narrows undefined", () => {
   const data = 123 as number | undefined;
   if (isNullish(data)) {
     expectTypeOf(data).toBeUndefined();
@@ -21,7 +21,7 @@ it("narrows undefined", () => {
   }
 });
 
-it("narrows on both", () => {
+test("narrows on both", () => {
   const data = 123 as number | null | undefined;
   if (isNullish(data)) {
     expectTypeOf(data).toEqualTypeOf<null | undefined>();
@@ -30,7 +30,7 @@ it("narrows on both", () => {
   }
 });
 
-it("doesn't narrow non-nullables", () => {
+test("doesn't narrow non-nullables", () => {
   const data = 123;
   if (isNullish(data)) {
     expectTypeOf(data).toBeNever();
@@ -39,7 +39,7 @@ it("doesn't narrow non-nullables", () => {
   }
 });
 
-it("narrows unknowns", () => {
+test("narrows unknowns", () => {
   const data = 123 as unknown;
   if (isNullish(data)) {
     expectTypeOf(data).toEqualTypeOf<null | undefined>();
@@ -55,7 +55,7 @@ it("narrows unknowns", () => {
   }
 });
 
-it("narrows any", () => {
+test("narrows any", () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
   const data = 123 as any;
   if (isNullish(data)) {
@@ -65,7 +65,7 @@ it("narrows any", () => {
   }
 });
 
-it("doesn't expand narrow types", () => {
+test("doesn't expand narrow types", () => {
   const data = "cat" as "cat" | "dog" | null | undefined;
   if (isNullish(data)) {
     expectTypeOf(data).toEqualTypeOf<null | undefined>();
@@ -74,7 +74,7 @@ it("doesn't expand narrow types", () => {
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const result = ALL_TYPES_DATA_PROVIDER.filter(isNullish);
 
   expectTypeOf(result).toEqualTypeOf<Array<null | undefined>>();

--- a/packages/remeda/src/isNullish.test.ts
+++ b/packages/remeda/src/isNullish.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER } from "../test/typesDataProvider";
 import { isNullish } from "./isNullish";
 

--- a/packages/remeda/src/isNullish.test.ts
+++ b/packages/remeda/src/isNullish.test.ts
@@ -1,16 +1,16 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER } from "../test/typesDataProvider";
 import { isNullish } from "./isNullish";
 
-it("accepts nulls", () => {
+test("accepts nulls", () => {
   expect(isNullish(null)).toBe(true);
 });
 
-it("accepts undefined", () => {
+test("accepts undefined", () => {
   expect(isNullish(undefined)).toBe(true);
 });
 
-it("rejects anything else", () => {
+test("rejects anything else", () => {
   for (const data of ALL_TYPES_DATA_PROVIDER) {
     if (data === null || data === undefined) {
       continue;

--- a/packages/remeda/src/isNumber.test-d.ts
+++ b/packages/remeda/src/isNumber.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNumber.test-d.ts
+++ b/packages/remeda/src/isNumber.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,27 +6,27 @@ import {
 } from "../test/typesDataProvider";
 import { isNumber } from "./isNumber";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.number as AllTypesDataProviderTypes;
   if (isNumber(data)) {
     expectTypeOf(data).toEqualTypeOf<number>();
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNumber);
 
   expectTypeOf(data).toEqualTypeOf<Array<number>>();
 });
 
-it("should work even if data type is unknown", () => {
+test("should work even if data type is unknown", () => {
   const data = TYPES_DATA_PROVIDER.number as unknown;
   if (isNumber(data)) {
     expectTypeOf(data).toEqualTypeOf<number>();
   }
 });
 
-it("should work with literal types", () => {
+test("should work with literal types", () => {
   const x = dataFunction();
   if (isNumber(x)) {
     expectTypeOf(x).toEqualTypeOf<1 | 2 | 3>(x);

--- a/packages/remeda/src/isNumber.test.ts
+++ b/packages/remeda/src/isNumber.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isNumber.test.ts
+++ b/packages/remeda/src/isNumber.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isNumber } from "./isNumber";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isNumber(TYPES_DATA_PROVIDER.number)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isNumber);
 
   expect(data.every((c) => typeof c === "number")).toBe(true);

--- a/packages/remeda/src/isObjectType.test-d.ts
+++ b/packages/remeda/src/isObjectType.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isObjectType.test.ts
+++ b/packages/remeda/src/isObjectType.test.ts
@@ -1,3 +1,4 @@
+import { expect, it, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isObjectType } from "./isObjectType";
 

--- a/packages/remeda/src/isObjectType.test.ts
+++ b/packages/remeda/src/isObjectType.test.ts
@@ -1,32 +1,32 @@
-import { expect, it, test } from "vitest";
+import { expect, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isObjectType } from "./isObjectType";
 
-it("accepts simple objects", () => {
+test("accepts simple objects", () => {
   expect(isObjectType({ a: 123 })).toBe(true);
 });
 
-it("accepts trivial empty objects", () => {
+test("accepts trivial empty objects", () => {
   expect(isObjectType({})).toBe(true);
 });
 
-it("rejects strings", () => {
+test("rejects strings", () => {
   expect(isObjectType("asd")).toBe(false);
 });
 
-it("rejects null", () => {
+test("rejects null", () => {
   expect(isObjectType(null)).toBe(false);
 });
 
-it("accepts arrays", () => {
+test("accepts arrays", () => {
   expect(isObjectType([1, 2, 3])).toBe(true);
 });
 
-it("accepts classes", () => {
+test("accepts classes", () => {
   expect(isObjectType(new TestClass())).toBe(true);
 });
 
-it("accepts null prototypes", () => {
+test("accepts null prototypes", () => {
   expect(isObjectType(Object.create(null))).toBe(true);
 });
 

--- a/packages/remeda/src/isPlainObject.test-d.ts
+++ b/packages/remeda/src/isPlainObject.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isPlainObject.test.ts
+++ b/packages/remeda/src/isPlainObject.test.ts
@@ -1,3 +1,4 @@
+import { expect, it, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isPlainObject } from "./isPlainObject";
 

--- a/packages/remeda/src/isPlainObject.test.ts
+++ b/packages/remeda/src/isPlainObject.test.ts
@@ -1,28 +1,28 @@
-import { expect, it, test } from "vitest";
+import { expect, test } from "vitest";
 import { ALL_TYPES_DATA_PROVIDER, TestClass } from "../test/typesDataProvider";
 import { isPlainObject } from "./isPlainObject";
 
-it("accepts simple objects", () => {
+test("accepts simple objects", () => {
   expect(isPlainObject({ a: 123 })).toBe(true);
 });
 
-it("accepts trivial empty objects", () => {
+test("accepts trivial empty objects", () => {
   expect(isPlainObject({})).toBe(true);
 });
 
-it("rejects strings", () => {
+test("rejects strings", () => {
   expect(isPlainObject("asd")).toBe(false);
 });
 
-it("rejects arrays", () => {
+test("rejects arrays", () => {
   expect(isPlainObject([1, 2, 3])).toBe(false);
 });
 
-it("rejects classes", () => {
+test("rejects classes", () => {
   expect(isPlainObject(new TestClass())).toBe(false);
 });
 
-it("accepts null prototypes", () => {
+test("accepts null prototypes", () => {
   expect(isPlainObject(Object.create(null))).toBe(true);
 });
 

--- a/packages/remeda/src/isPromise.test-d.ts
+++ b/packages/remeda/src/isPromise.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,14 +6,14 @@ import {
 } from "../test/typesDataProvider";
 import { isPromise } from "./isPromise";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
   if (isPromise(data)) {
     expectTypeOf(data).toEqualTypeOf<Promise<number>>();
   }
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isPromise);
 
   expectTypeOf(data).toEqualTypeOf<Array<Promise<number>>>();

--- a/packages/remeda/src/isPromise.test-d.ts
+++ b/packages/remeda/src/isPromise.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isPromise.test.ts
+++ b/packages/remeda/src/isPromise.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isPromise } from "./isPromise";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isPromise(TYPES_DATA_PROVIDER.promise)).toBe(true);
 });
 
-it("should work as type guard in filter", () => {
+test("should work as type guard in filter", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isPromise);
 
   expect(data.every((c) => c instanceof Promise)).toBe(true);

--- a/packages/remeda/src/isPromise.test.ts
+++ b/packages/remeda/src/isPromise.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isShallowEqual.test-d.ts
+++ b/packages/remeda/src/isShallowEqual.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isShallowEqual } from "./isShallowEqual";
 

--- a/packages/remeda/src/isShallowEqual.test-d.ts
+++ b/packages/remeda/src/isShallowEqual.test-d.ts
@@ -1,8 +1,8 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isShallowEqual } from "./isShallowEqual";
 
-it("narrows unions", () => {
+test("narrows unions", () => {
   const data = 1 as number | string;
 
   if (isShallowEqual(data, 1)) {
@@ -18,7 +18,7 @@ it("narrows unions", () => {
   }
 });
 
-it("narrows to literal", () => {
+test("narrows to literal", () => {
   const data = 1 as number;
   if (isShallowEqual(data, 1 as const)) {
     expectTypeOf(data).toEqualTypeOf<1>();
@@ -27,12 +27,12 @@ it("narrows to literal", () => {
   }
 });
 
-it("doesn't accept non-overlapping types", () => {
+test("doesn't accept non-overlapping types", () => {
   // @ts-expect-error [ts2345] - Checking against the wrong type should fail
   isShallowEqual(1 as number, true);
 });
 
-it("works deeply", () => {
+test("works deeply", () => {
   const data = [] as Array<
     { a: Array<number> | Array<string> } | { b: Array<boolean> }
   >;
@@ -52,7 +52,7 @@ it("works deeply", () => {
   }
 });
 
-it("doesn't narrow when comparing objects of the same type", () => {
+test("doesn't narrow when comparing objects of the same type", () => {
   const data1 = { a: 1 } as { a: number };
   const data2 = { a: 2 } as { a: number };
   if (isShallowEqual(data1, data2)) {
@@ -62,7 +62,7 @@ it("doesn't narrow when comparing objects of the same type", () => {
   }
 });
 
-it("headless usage can infer types", () => {
+test("headless usage can infer types", () => {
   // Tests the issue reported in: https://github.com/remeda/remeda/issues/641
   const result = differenceWith(
     ["a", "b", "c"],

--- a/packages/remeda/src/isShallowEqual.test.ts
+++ b/packages/remeda/src/isShallowEqual.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { isShallowEqual } from "./isShallowEqual";
 
 describe("primitives", () => {

--- a/packages/remeda/src/isStrictEqual.test-d.ts
+++ b/packages/remeda/src/isStrictEqual.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isStrictEqual } from "./isStrictEqual";
 

--- a/packages/remeda/src/isStrictEqual.test-d.ts
+++ b/packages/remeda/src/isStrictEqual.test-d.ts
@@ -1,8 +1,8 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { differenceWith } from "./differenceWith";
 import { isStrictEqual } from "./isStrictEqual";
 
-it("narrows unions", () => {
+test("narrows unions", () => {
   const data = 1 as number | string;
 
   if (isStrictEqual(data, 1)) {
@@ -18,7 +18,7 @@ it("narrows unions", () => {
   }
 });
 
-it("narrows to literal", () => {
+test("narrows to literal", () => {
   const data = 1 as number;
   if (isStrictEqual(data, 1 as const)) {
     expectTypeOf(data).toEqualTypeOf<1>();
@@ -27,12 +27,12 @@ it("narrows to literal", () => {
   }
 });
 
-it("doesn't accept non-overlapping types", () => {
+test("doesn't accept non-overlapping types", () => {
   // @ts-expect-error [ts2345] - Checking against the wrong type should fail
   isStrictEqual(1 as number, true);
 });
 
-it("works deeply", () => {
+test("works deeply", () => {
   const data = [] as Array<
     { a: Array<number> | Array<string> } | { b: Array<boolean> }
   >;
@@ -52,7 +52,7 @@ it("works deeply", () => {
   }
 });
 
-it("doesn't narrow when comparing objects of the same type", () => {
+test("doesn't narrow when comparing objects of the same type", () => {
   const data1 = { a: 1 } as { a: number };
   const data2 = { a: 2 } as { a: number };
   if (isStrictEqual(data1, data2)) {
@@ -62,7 +62,7 @@ it("doesn't narrow when comparing objects of the same type", () => {
   }
 });
 
-it("headless usage can infer types", () => {
+test("headless usage can infer types", () => {
   // Tests the issue reported in: https://github.com/remeda/remeda/issues/641
   const result = differenceWith(
     ["a", "b", "c"],

--- a/packages/remeda/src/isStrictEqual.test.ts
+++ b/packages/remeda/src/isStrictEqual.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { isStrictEqual } from "./isStrictEqual";
 
 describe("primitives", () => {

--- a/packages/remeda/src/isStrictEqual.test.ts
+++ b/packages/remeda/src/isStrictEqual.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { isStrictEqual } from "./isStrictEqual";
 
 describe("primitives", () => {
@@ -104,7 +104,7 @@ describe("special cases", () => {
     expect(isStrictEqual(0, 0)).toBe(true);
   });
 
-  it("fails on loose equality", () => {
+  test("fails on loose equality", () => {
     expect(isStrictEqual("" as unknown, 0)).toBe(false);
     expect(isStrictEqual("" as unknown, false)).toBe(false);
     expect(isStrictEqual(0 as unknown, false)).toBe(false);

--- a/packages/remeda/src/isString.test-d.ts
+++ b/packages/remeda/src/isString.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isString.test-d.ts
+++ b/packages/remeda/src/isString.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,28 +6,28 @@ import {
 } from "../test/typesDataProvider";
 import { isString } from "./isString";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.string as AllTypesDataProviderTypes;
   if (isString(data)) {
     expectTypeOf(data).toEqualTypeOf<string>();
   }
 });
 
-it("should work even if data type is unknown", () => {
+test("should work even if data type is unknown", () => {
   const data = TYPES_DATA_PROVIDER.string as unknown;
   if (isString(data)) {
     expectTypeOf(data).toEqualTypeOf<string>();
   }
 });
 
-it("should work with literal types", () => {
+test("should work with literal types", () => {
   const x = dataFunction();
   if (isString(x)) {
     expectTypeOf(x).toEqualTypeOf<"a" | "b" | "c">();
   }
 });
 
-it("should work as type guard in array", () => {
+test("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isString);
 
   expectTypeOf(data).toEqualTypeOf<Array<string>>();

--- a/packages/remeda/src/isString.test.ts
+++ b/packages/remeda/src/isString.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isString.test.ts
+++ b/packages/remeda/src/isString.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isString } from "./isString";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isString(TYPES_DATA_PROVIDER.string)).toBe(true);
 });
 
-it("should work as type guard in array", () => {
+test("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isString);
 
   expect(data.every((c) => typeof c === "string")).toBe(true);

--- a/packages/remeda/src/isSymbol.test-d.ts
+++ b/packages/remeda/src/isSymbol.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isSymbol.test-d.ts
+++ b/packages/remeda/src/isSymbol.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -6,21 +6,21 @@ import {
 } from "../test/typesDataProvider";
 import { isSymbol } from "./isSymbol";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.symbol as AllTypesDataProviderTypes;
   if (isSymbol(data)) {
     expectTypeOf(data).toEqualTypeOf<symbol>();
   }
 });
 
-it("should work even if data type is `unknown`", () => {
+test("should work even if data type is `unknown`", () => {
   const data = TYPES_DATA_PROVIDER.symbol as unknown;
   if (isSymbol(data)) {
     expectTypeOf(data).toEqualTypeOf<symbol>();
   }
 });
 
-it("should work even if data type is `any`", () => {
+test("should work even if data type is `any`", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- Explicitly checking any
   const data = TYPES_DATA_PROVIDER.symbol as any;
   if (isSymbol(data)) {
@@ -28,7 +28,7 @@ it("should work even if data type is `any`", () => {
   }
 });
 
-it("should work as type guard in array", () => {
+test("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isSymbol);
 
   expectTypeOf(data).toEqualTypeOf<Array<symbol>>();

--- a/packages/remeda/src/isSymbol.test.ts
+++ b/packages/remeda/src/isSymbol.test.ts
@@ -1,15 +1,15 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
 } from "../test/typesDataProvider";
 import { isSymbol } from "./isSymbol";
 
-it("should work as type guard", () => {
+test("should work as type guard", () => {
   expect(isSymbol(TYPES_DATA_PROVIDER.symbol)).toBe(true);
 });
 
-it("should work as type guard in array", () => {
+test("should work as type guard in array", () => {
   const data = ALL_TYPES_DATA_PROVIDER.filter(isSymbol);
 
   expect(data.every((c) => typeof c === "symbol")).toBe(true);

--- a/packages/remeda/src/isSymbol.test.ts
+++ b/packages/remeda/src/isSymbol.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,

--- a/packages/remeda/src/isTruthy.test-d.ts
+++ b/packages/remeda/src/isTruthy.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { isTruthy } from "./isTruthy";
 
 test("isTruthy", () => {

--- a/packages/remeda/src/isTruthy.test.ts
+++ b/packages/remeda/src/isTruthy.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { isTruthy } from "./isTruthy";
 
 test("isTruthy", () => {

--- a/packages/remeda/src/join.test-d.ts
+++ b/packages/remeda/src/join.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { join } from "./join";
 
 it("empty tuple", () => {

--- a/packages/remeda/src/join.test-d.ts
+++ b/packages/remeda/src/join.test-d.ts
@@ -1,35 +1,35 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { join } from "./join";
 
-it("empty tuple", () => {
+test("empty tuple", () => {
   const array: [] = [];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<"">();
 });
 
-it("empty readonly tuple", () => {
+test("empty readonly tuple", () => {
   const array: readonly [] = [];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<"">();
 });
 
-it("array", () => {
+test("array", () => {
   const array: Array<number> = [];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<string>();
 });
 
-it("readonly array", () => {
+test("readonly array", () => {
   const array: ReadonlyArray<number> = [];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<string>();
 });
 
-it("tuple", () => {
+test("tuple", () => {
   const array: ["a" | "b", "c" | "d", "e" | "f"] = ["a", "c", "e"];
   const result = join(array, ",");
 
@@ -38,7 +38,7 @@ it("tuple", () => {
     | "f"}`>();
 });
 
-it("readonly tuple", () => {
+test("readonly tuple", () => {
   const array: readonly ["a" | "b", "c" | "d", "e" | "f"] = ["a", "c", "e"];
   const result = join(array, ",");
 
@@ -47,28 +47,28 @@ it("readonly tuple", () => {
     | "f"}`>();
 });
 
-it("tuple with rest tail", () => {
+test("tuple with rest tail", () => {
   const array: ["a" | "b", ...Array<"c" | "d">] = ["a", "c"];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<`${"a" | "b"},${string}`>();
 });
 
-it("readonly tuple with rest tail", () => {
+test("readonly tuple with rest tail", () => {
   const array: readonly ["a" | "b", ...Array<"c" | "d">] = ["a", "c"];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<`${"a" | "b"},${string}`>();
 });
 
-it("tuple with rest head", () => {
+test("tuple with rest head", () => {
   const array: [...Array<"a" | "b">, "c" | "d"] = ["a", "c"];
   const result = join(array, ",");
 
   expectTypeOf(result).toEqualTypeOf<`${string},${"c" | "d"}`>();
 });
 
-it("readonly tuple with rest head", () => {
+test("readonly tuple with rest head", () => {
   const array: readonly [...Array<"a" | "b">, "c" | "d"] = ["a", "c"];
   const result = join(array, ",");
 
@@ -76,56 +76,56 @@ it("readonly tuple with rest head", () => {
 });
 
 describe("tuple item types", () => {
-  it("number", () => {
+  test("number", () => {
     const array: [number, number] = [1, 2];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<`${number},${number}`>();
   });
 
-  it("string", () => {
+  test("string", () => {
     const array: [string, string] = ["a", "b"];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<`${string},${string}`>();
   });
 
-  it("bigint", () => {
+  test("bigint", () => {
     const array: [bigint, bigint] = [1n, 2n];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<`${bigint},${bigint}`>();
   });
 
-  it("boolean", () => {
+  test("boolean", () => {
     const array: [boolean, boolean] = [true, false];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<`${boolean},${boolean}`>();
   });
 
-  it("null", () => {
+  test("null", () => {
     const array: [null, null] = [null, null];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<",">();
   });
 
-  it("undefined", () => {
+  test("undefined", () => {
     const array: [undefined, undefined] = [undefined, undefined];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<",">();
   });
 
-  it("mixed", () => {
+  test("mixed", () => {
     const array: [number, undefined, string] = [1, undefined, "a"];
     const result = join(array, ",");
 
     expectTypeOf(result).toEqualTypeOf<`${number},,${string}`>();
   });
 
-  it("nullish items", () => {
+  test("nullish items", () => {
     const array: [
       "prefix" | undefined,
       "midfix" | undefined,

--- a/packages/remeda/src/join.test.ts
+++ b/packages/remeda/src/join.test.ts
@@ -1,43 +1,43 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { join } from "./join";
 
 describe("joins same-typed items", () => {
-  it("number", () => {
+  test("number", () => {
     const array = [1, 2, 3, 4, 5];
     const result = join(array, ",");
 
     expect(result).toBe("1,2,3,4,5");
   });
 
-  it("string", () => {
+  test("string", () => {
     const array = ["a", "b", "c", "d", "e"];
     const result = join(array, ",");
 
     expect(result).toBe("a,b,c,d,e");
   });
 
-  it("bigint", () => {
+  test("bigint", () => {
     const array = [1n, 2n, 3n, 4n, 5n];
     const result = join(array, ",");
 
     expect(result).toBe("1,2,3,4,5");
   });
 
-  it("boolean", () => {
+  test("boolean", () => {
     const array = [true, false, true, false, true];
     const result = join(array, ",");
 
     expect(result).toBe("true,false,true,false,true");
   });
 
-  it("null", () => {
+  test("null", () => {
     const array = [null, null, null, null, null];
     const result = join(array, ",");
 
     expect(result).toBe(",,,,");
   });
 
-  it("undefined", () => {
+  test("undefined", () => {
     const array = [undefined, undefined, undefined, undefined, undefined];
     const result = join(array, ",");
 
@@ -45,7 +45,7 @@ describe("joins same-typed items", () => {
   });
 });
 
-it("joins different-typed items", () => {
+test("joins different-typed items", () => {
   const array = [1, "2", 3n, true, null, undefined];
   const result = join(array, ",");
 
@@ -53,21 +53,21 @@ it("joins different-typed items", () => {
 });
 
 describe("edge-cases", () => {
-  it("empty glue", () => {
+  test("empty glue", () => {
     const array = [1, 2, 3, 4, 5];
     const result = join(array, "");
 
     expect(result).toBe("12345");
   });
 
-  it("empty array", () => {
+  test("empty array", () => {
     const array: Array<number> = [];
     const result = join(array, ",");
 
     expect(result).toBe("");
   });
 
-  it("doesnt add glue on single item", () => {
+  test("doesnt add glue on single item", () => {
     const array = [1];
     const result = join(array, ",");
 

--- a/packages/remeda/src/join.test.ts
+++ b/packages/remeda/src/join.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { join } from "./join";
 
 describe("joins same-typed items", () => {

--- a/packages/remeda/src/keys.test-d.ts
+++ b/packages/remeda/src/keys.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { keys } from "./keys";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/keys.test.ts
+++ b/packages/remeda/src/keys.test.ts
@@ -1,24 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { keys } from "./keys";
 
 describe("dataFirst", () => {
-  it("work with arrays", () => {
+  test("work with arrays", () => {
     expect(keys(["x", "y", "z"])).toStrictEqual(["0", "1", "2"]);
   });
 
-  it("work with objects", () => {
+  test("work with objects", () => {
     expect(keys({ a: "x", b: "y", c: "z" })).toStrictEqual(["a", "b", "c"]);
   });
 
-  it("should return strict types", () => {
+  test("should return strict types", () => {
     expect(keys({ 5: "x", b: "y", c: "z" })).toStrictEqual(["5", "b", "c"]);
   });
 
-  it("should ignore symbol keys", () => {
+  test("should ignore symbol keys", () => {
     expect(keys({ [Symbol("a")]: 1 })).toStrictEqual([]);
   });
 
-  it("should turn numbers to strings", () => {
+  test("should turn numbers to strings", () => {
     expect(keys({ 1: "hello" })).toStrictEqual(["1"]);
   });
 });

--- a/packages/remeda/src/keys.test.ts
+++ b/packages/remeda/src/keys.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { keys } from "./keys";
 
 describe("dataFirst", () => {

--- a/packages/remeda/src/last.test-d.ts
+++ b/packages/remeda/src/last.test-d.ts
@@ -1,14 +1,14 @@
-import { expectTypeOf, it, test } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { last } from "./last";
 import { pipe } from "./pipe";
 
-it("works with empty arrays", () => {
+test("works with empty arrays", () => {
   const result = last([] as const);
 
   expectTypeOf(result).toEqualTypeOf<never>();
 });
 
-it("works with regular arrays", () => {
+test("works with regular arrays", () => {
   const result = last([1, 2, 3] as Array<number>);
 
   expectTypeOf(result).toEqualTypeOf<number | undefined>();

--- a/packages/remeda/src/last.test-d.ts
+++ b/packages/remeda/src/last.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it, test } from "vitest";
 import { last } from "./last";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/last.test.ts
+++ b/packages/remeda/src/last.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { last } from "./last";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/length.test.ts
+++ b/packages/remeda/src/length.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { length } from "./length";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { map } from "./map";

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -1,33 +1,33 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { map } from "./map";
 
-it("number array", () => {
+test("number array", () => {
   const result = map([1, 2, 3] as Array<number>, add(1));
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("readonly number array", () => {
+test("readonly number array", () => {
   const result = map([1, 2, 3] as ReadonlyArray<number>, add(1));
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("number 3-tuple", () => {
+test("number 3-tuple", () => {
   const result = map([1, 2, 3] as [number, number, number], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
 });
 
-it("readonly number 3-tuple", () => {
+test("readonly number 3-tuple", () => {
   const result = map([1, 2, 3] as readonly [number, number, number], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
 });
 
-it("named number 3-tuple", () => {
+test("named number 3-tuple", () => {
   const result = map(
     [1, 2, 3] as [item1: number, item2: number, item3: number],
     add(1),
@@ -40,13 +40,13 @@ it("named number 3-tuple", () => {
   >();
 });
 
-it("mixed type tuple", () => {
+test("mixed type tuple", () => {
   const result = map([1, "2", true] as [number, string, boolean], constant(1));
 
   expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
 });
 
-it("readonly mixed type tuple", () => {
+test("readonly mixed type tuple", () => {
   const result = map(
     [1, "2", true] as readonly [number, string, boolean],
     constant(1),
@@ -55,38 +55,38 @@ it("readonly mixed type tuple", () => {
   expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
 });
 
-it("nonempty (tail) number array", () => {
+test("nonempty (tail) number array", () => {
   const result = map([1, 2, 3] as [number, ...Array<number>], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
 });
 
-it("nonempty (tail) readonly number array", () => {
+test("nonempty (tail) readonly number array", () => {
   const result = map([1, 2, 3] as readonly [number, ...Array<number>], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
 });
 
-it("nonempty (head) number array", () => {
+test("nonempty (head) number array", () => {
   const result = map([1, 2, 3] as [...Array<number>, number], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
-it("nonempty readonly (head) number array", () => {
+test("nonempty readonly (head) number array", () => {
   const result = map([1, 2, 3] as readonly [...Array<number>, number], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
 describe("indexed", () => {
-  it("number array", () => {
+  test("number array", () => {
     const result = map([1, 2, 3] as Array<number>, (x, index) => x + index);
 
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
-  it("readonly number array", () => {
+  test("readonly number array", () => {
     const result = map(
       [1, 2, 3] as ReadonlyArray<number>,
       (x, index) => x + index,
@@ -95,7 +95,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
-  it("number 3-tuple", () => {
+  test("number 3-tuple", () => {
     const result = map(
       [1, 2, 3] as [number, number, number],
       (x, index) => x + index,
@@ -104,7 +104,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
   });
 
-  it("readonly number 3-tuple", () => {
+  test("readonly number 3-tuple", () => {
     const result = map(
       [1, 2, 3] as readonly [number, number, number],
       (x, index) => x + index,
@@ -113,7 +113,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
   });
 
-  it("named number 3-tuple", () => {
+  test("named number 3-tuple", () => {
     const result = map(
       [1, 2, 3] as [item1: number, item2: number, item3: number],
       (x, index) => x + index,
@@ -126,7 +126,7 @@ describe("indexed", () => {
     >();
   });
 
-  it("mixed type tuple", () => {
+  test("mixed type tuple", () => {
     const result = map(
       [1, "2", true] as [number, string, boolean],
       (_, index) => index,
@@ -135,7 +135,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
   });
 
-  it("readonly mixed type tuple", () => {
+  test("readonly mixed type tuple", () => {
     const result = map(
       [1, "2", true] as readonly [number, string, boolean],
       (_, index) => index,
@@ -144,7 +144,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, number, number]>();
   });
 
-  it("nonempty (tail) number array", () => {
+  test("nonempty (tail) number array", () => {
     const result = map(
       [1, 2, 3] as [number, ...Array<number>],
       (x, index) => x + index,
@@ -153,7 +153,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
-  it("nonempty (tail) readonly number array", () => {
+  test("nonempty (tail) readonly number array", () => {
     const result = map(
       [1, 2, 3] as readonly [number, ...Array<number>],
       (x, index) => x + index,
@@ -162,7 +162,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
   });
 
-  it("nonempty (head) number array", () => {
+  test("nonempty (head) number array", () => {
     const result = map(
       [1, 2, 3] as [...Array<number>, number],
       (x, index) => x + index,
@@ -171,7 +171,7 @@ describe("indexed", () => {
     expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
   });
 
-  it("nonempty readonly (head) number array", () => {
+  test("nonempty readonly (head) number array", () => {
     const result = map(
       [1, 2, 3] as readonly [...Array<number>, number],
       (x, index) => x + index,

--- a/packages/remeda/src/map.test.ts
+++ b/packages/remeda/src/map.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { filter } from "./filter";

--- a/packages/remeda/src/map.test.ts
+++ b/packages/remeda/src/map.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { filter } from "./filter";
@@ -9,21 +9,21 @@ import { pipe } from "./pipe";
 import { take } from "./take";
 
 describe("data_first", () => {
-  it("map", () => {
+  test("map", () => {
     expect(map([1, 2, 3], multiply(2))).toStrictEqual([2, 4, 6]);
   });
 
-  it("map indexed", () => {
+  test("map indexed", () => {
     expect(map([0, 0, 0], (_, i) => i)).toStrictEqual([0, 1, 2]);
   });
 });
 
 describe("data-last", () => {
-  it("passes the value to the mapper as its first argument", () => {
+  test("passes the value to the mapper as its first argument", () => {
     expect(pipe([1, 2, 3], map(multiply(2)))).toStrictEqual([2, 4, 6]);
   });
 
-  it("passes the index to the mapper as its second argument", () => {
+  test("passes the index to the mapper as its second argument", () => {
     expect(
       pipe(
         [0, 0, 0],
@@ -35,7 +35,7 @@ describe("data-last", () => {
 
 // eslint-disable-next-line vitest/valid-title -- This seems to be a bug in the rule, @see https://github.com/vitest-dev/eslint-plugin-vitest/issues/692
 describe(pipe, () => {
-  it("invoked lazily", () => {
+  test("invoked lazily", () => {
     const count = vi.fn<(x: number) => number>(multiply(10));
 
     expect(pipe([1, 2, 3], map(count), take(2))).toStrictEqual([10, 20]);
@@ -43,7 +43,7 @@ describe(pipe, () => {
     expect(count).toHaveBeenCalledTimes(2);
   });
 
-  it("invoked lazily (indexed)", () => {
+  test("invoked lazily (indexed)", () => {
     const count = vi.fn<(_: unknown, index: number) => number>(
       (_, index) => index,
     );
@@ -53,7 +53,7 @@ describe(pipe, () => {
     expect(count).toHaveBeenCalledTimes(2);
   });
 
-  it("indexed: check index and items", () => {
+  test("indexed: check index and items", () => {
     const indexes1: Array<number> = [];
     const indexes2: Array<number> = [];
     const anyItems1: Array<Array<number>> = [];
@@ -89,15 +89,15 @@ describe(pipe, () => {
   });
 });
 
-it("number array", () => {
+test("number array", () => {
   expect(map([1, 2, 3], add(1))).toStrictEqual([2, 3, 4]);
 });
 
-it("mixed type tuple", () => {
+test("mixed type tuple", () => {
   expect(map([1, "2", true], constant(1))).toStrictEqual([1, 1, 1]);
 });
 
-it("complex variadic number array", () => {
+test("complex variadic number array", () => {
   const input = [
     "hello",
     "world",
@@ -113,11 +113,11 @@ it("complex variadic number array", () => {
 });
 
 describe("indexed", () => {
-  it("number array", () => {
+  test("number array", () => {
     expect(map([1, 2, 3], (x, index) => x + index)).toStrictEqual([1, 3, 5]);
   });
 
-  it("mixed type tuple", () => {
+  test("mixed type tuple", () => {
     expect(map([1, "2", true], (_, index) => index)).toStrictEqual([0, 1, 2]);
   });
 });

--- a/packages/remeda/src/mapKeys.test-d.ts
+++ b/packages/remeda/src/mapKeys.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { mapKeys } from "./mapKeys";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/mapKeys.test.ts
+++ b/packages/remeda/src/mapKeys.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { constant } from "./constant";
 import { mapKeys } from "./mapKeys";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/mapToObj.test.ts
+++ b/packages/remeda/src/mapToObj.test.ts
@@ -1,15 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { mapToObj } from "./mapToObj";
 import { pipe } from "./pipe";
 
 describe("data_first", () => {
-  it("mapToObj", () => {
+  test("mapToObj", () => {
     const result = mapToObj([1, 2, 3], (x) => [String(x), x * 2]);
 
     expect(result).toStrictEqual({ 1: 2, 2: 4, 3: 6 });
   });
 
-  it("indexed", () => {
+  test("indexed", () => {
     const result = mapToObj([0, 0, 0], (_, i) => [i, i]);
 
     expect(result).toStrictEqual({ 0: 0, 1: 1, 2: 2 });
@@ -17,7 +17,7 @@ describe("data_first", () => {
 });
 
 describe("data_last", () => {
-  it("mapToObj", () => {
+  test("mapToObj", () => {
     const result = pipe(
       [1, 2, 3],
       mapToObj((x) => [String(x), x * 2]),
@@ -26,7 +26,7 @@ describe("data_last", () => {
     expect(result).toStrictEqual({ 1: 2, 2: 4, 3: 6 });
   });
 
-  it("indexed", () => {
+  test("indexed", () => {
     const result = pipe(
       [0, 0, 0],
       mapToObj((_, i) => [i, i]),

--- a/packages/remeda/src/mapToObj.test.ts
+++ b/packages/remeda/src/mapToObj.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mapToObj } from "./mapToObj";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/mapValues.test-d.ts
+++ b/packages/remeda/src/mapValues.test-d.ts
@@ -1,4 +1,5 @@
 import type { Tagged } from "type-fest";
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { mapValues } from "./mapValues";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/mapValues.test.ts
+++ b/packages/remeda/src/mapValues.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { constant } from "./constant";
 import { mapValues } from "./mapValues";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/mapWithFeedback.test-d.ts
+++ b/packages/remeda/src/mapWithFeedback.test-d.ts
@@ -1,8 +1,8 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { mapWithFeedback } from "./mapWithFeedback";
 import { pipe } from "./pipe";
 
-it("should return a mutable tuple type whose length matches input container's length, consisting of the type of the initial value", () => {
+test("should return a mutable tuple type whose length matches input container's length, consisting of the type of the initial value", () => {
   const result = mapWithFeedback([1, 2, 3, 4, 5], (acc, x) => acc + x, 100);
 
   expectTypeOf(result).toEqualTypeOf<
@@ -10,7 +10,7 @@ it("should return a mutable tuple type whose length matches input container's le
   >();
 });
 
-it("should maintain the input shape via a pipe", () => {
+test("should maintain the input shape via a pipe", () => {
   const result = pipe(
     [1, 2, 3, 4, 5] as const,
     mapWithFeedback((acc, x) => acc + x, 100),
@@ -21,7 +21,7 @@ it("should maintain the input shape via a pipe", () => {
   >();
 });
 
-it("should return a tuple consisting of the initial value type even if the initial iterable contains a different type", () => {
+test("should return a tuple consisting of the initial value type even if the initial iterable contains a different type", () => {
   const result = mapWithFeedback(
     ["1", "2", "3", "4", "5"],
     (acc, x) => acc + Number.parseInt(x, 10),
@@ -33,7 +33,7 @@ it("should return a tuple consisting of the initial value type even if the initi
   >();
 });
 
-it("should correctly infer type with a non-literal array type", () => {
+test("should correctly infer type with a non-literal array type", () => {
   const result = mapWithFeedback(
     [1, 2, 3, 4, 5] as Array<number>,
     (acc, x) => acc + x,
@@ -43,7 +43,7 @@ it("should correctly infer type with a non-literal array type", () => {
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("the items array passed to the callback should be an array type containing the union type of all of the members in the original array", () => {
+test("the items array passed to the callback should be an array type containing the union type of all of the members in the original array", () => {
   mapWithFeedback(
     [1, 2, 3, 4, 5] as const,
     (acc, x, _index, items) => {

--- a/packages/remeda/src/mapWithFeedback.test-d.ts
+++ b/packages/remeda/src/mapWithFeedback.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { mapWithFeedback } from "./mapWithFeedback";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/mapWithFeedback.test.ts
+++ b/packages/remeda/src/mapWithFeedback.test.ts
@@ -1,17 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { map } from "./map";
 import { mapWithFeedback } from "./mapWithFeedback";
 import { pipe } from "./pipe";
 import { take } from "./take";
 
 describe("data first", () => {
-  it("should return an array of successively accumulated values", () => {
+  test("should return an array of successively accumulated values", () => {
     expect(
       mapWithFeedback([1, 2, 3, 4, 5], (acc, x) => acc + x, 100),
     ).toStrictEqual([101, 103, 106, 110, 115]);
   });
 
-  it("should use the same accumulator on every iteration if it's mutable, therefore returning an array containing {array length} references to the accumulator.", () => {
+  test("should use the same accumulator on every iteration if it's mutable, therefore returning an array containing {array length} references to the accumulator.", () => {
     const results = mapWithFeedback(
       [1, 2, 3, 4, 5],
       (acc, x) => {
@@ -30,7 +30,7 @@ describe("data first", () => {
     }
   });
 
-  it("if an empty array is provided, it should never iterate, returning a new empty array.", () => {
+  test("if an empty array is provided, it should never iterate, returning a new empty array.", () => {
     const data: Array<unknown> = [];
     const result = mapWithFeedback(data, (acc) => acc, "value");
 
@@ -38,7 +38,7 @@ describe("data first", () => {
     expect(result).not.toBe(data);
   });
 
-  it("should track index and provide entire items array", () => {
+  test("should track index and provide entire items array", () => {
     const data = [1, 2, 3, 4, 5];
 
     const mockedReducer = vi.fn<(acc: number, x: number) => number>(
@@ -56,7 +56,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("should return an array of successively accumulated values", () => {
+  test("should return an array of successively accumulated values", () => {
     expect(
       pipe(
         [1, 2, 3, 4, 5],
@@ -65,7 +65,7 @@ describe("data last", () => {
     ).toStrictEqual([101, 103, 106, 110, 115]);
   });
 
-  it("evaluates lazily", () => {
+  test("evaluates lazily", () => {
     const counter = vi.fn<(x: number) => number>();
     pipe(
       [1, 2, 3, 4, 5],
@@ -77,7 +77,7 @@ describe("data last", () => {
     expect(counter).toHaveBeenCalledTimes(2);
   });
 
-  it("should track index and progressively include elements from the original array in the items array during each iteration, forming a growing window", () => {
+  test("should track index and progressively include elements from the original array in the items array during each iteration, forming a growing window", () => {
     const lazyItems: Array<Array<number>> = [];
     const indices: Array<number> = [];
     pipe(

--- a/packages/remeda/src/mapWithFeedback.test.ts
+++ b/packages/remeda/src/mapWithFeedback.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { map } from "./map";
 import { mapWithFeedback } from "./mapWithFeedback";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/mean.test-d.ts
+++ b/packages/remeda/src/mean.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { mean } from "./mean";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/mean.test.ts
+++ b/packages/remeda/src/mean.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mean } from "./mean";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/mean.test.ts
+++ b/packages/remeda/src/mean.test.ts
@@ -1,27 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { mean } from "./mean";
 import { pipe } from "./pipe";
 
 describe("dataFirst", () => {
-  it("should return the mean of numbers in an array", () => {
+  test("should return the mean of numbers in an array", () => {
     expect(mean([1, 2, 3])).toBe(2);
     expect(mean([4, 5, 6])).toBe(5);
     expect(mean([-1, 0, 1])).toBe(0);
   });
 
-  it("should return undefined for an empty array", () => {
+  test("should return undefined for an empty array", () => {
     expect(mean([])).toBeUndefined();
   });
 });
 
 describe("dataLast", () => {
-  it("should return the mean of numbers in an array", () => {
+  test("should return the mean of numbers in an array", () => {
     expect(pipe([1, 2, 3], mean())).toBe(2);
     expect(pipe([4, 5, 6], mean())).toBe(5);
     expect(pipe([-1, 0, 1], mean())).toBe(0);
   });
 
-  it("should return undefined for an empty array", () => {
+  test("should return undefined for an empty array", () => {
     expect(pipe([], mean())).toBeUndefined();
   });
 });

--- a/packages/remeda/src/meanBy.test.ts
+++ b/packages/remeda/src/meanBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { identity } from "./identity";
 import { meanBy } from "./meanBy";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/median.test-d.ts
+++ b/packages/remeda/src/median.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { median } from "./median";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/median.test.ts
+++ b/packages/remeda/src/median.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { median } from "./median";
 import { pipe } from "./pipe";
 
@@ -12,7 +12,7 @@ describe("dataFirst", () => {
     expect(median([-1, 0, 1, 10])).toBe(0.5);
   });
 
-  it("should return undefined for an empty array", () => {
+  test("should return undefined for an empty array", () => {
     expect(median([])).toBeUndefined();
   });
 });
@@ -27,7 +27,7 @@ describe("dataLast", () => {
     expect(pipe([-1, 0, 1, 10], median())).toBe(0.5);
   });
 
-  it("should return undefined for an empty array", () => {
+  test("should return undefined for an empty array", () => {
     expect(pipe([], median())).toBeUndefined();
   });
 });

--- a/packages/remeda/src/median.test.ts
+++ b/packages/remeda/src/median.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { median } from "./median";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/merge.test-d.ts
+++ b/packages/remeda/src/merge.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it, test } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { merge } from "./merge";
 
 interface FooInterface {
@@ -15,7 +15,7 @@ test("source type overrides destination type", () => {
   }>();
 });
 
-it("works with interfaces", () => {
+test("works with interfaces", () => {
   expectTypeOf(
     merge(
       {} as FooInterface,

--- a/packages/remeda/src/merge.test-d.ts
+++ b/packages/remeda/src/merge.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it, test } from "vitest";
 import { merge } from "./merge";
 
 interface FooInterface {

--- a/packages/remeda/src/merge.test.ts
+++ b/packages/remeda/src/merge.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { merge } from "./merge";
 
 describe("data first", () => {

--- a/packages/remeda/src/mergeAll.test-d.ts
+++ b/packages/remeda/src/mergeAll.test-d.ts
@@ -1,4 +1,5 @@
 import type { EmptyObject } from "type-fest";
+import { describe, expectTypeOf, it } from "vitest";
 import { mergeAll } from "./mergeAll";
 
 describe("arrays", () => {

--- a/packages/remeda/src/mergeAll.test-d.ts
+++ b/packages/remeda/src/mergeAll.test-d.ts
@@ -1,9 +1,9 @@
 import type { EmptyObject } from "type-fest";
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { mergeAll } from "./mergeAll";
 
 describe("arrays", () => {
-  it("custom case", () => {
+  test("custom case", () => {
     // based on https://github.com/remeda/remeda/issues/918
 
     const userUnionArray: ReadonlyArray<
@@ -25,7 +25,7 @@ describe("arrays", () => {
     >();
   });
 
-  it("should produce the same type when the type isn't a union", () => {
+  test("should produce the same type when the type isn't a union", () => {
     const input: ReadonlyArray<{ a: string; b: number; c: boolean }> = [];
     const result = mergeAll(input);
 
@@ -35,7 +35,7 @@ describe("arrays", () => {
   });
 
   describe("optionality", () => {
-    it("should keep non-optional fields shared across all union members non-optional, with the rest being converted into optionals", () => {
+    test("should keep non-optional fields shared across all union members non-optional, with the rest being converted into optionals", () => {
       // the only real change is c and e becoming optional, because they aren't shared across all union members and they aren't already optional
 
       const input: ReadonlyArray<
@@ -51,7 +51,7 @@ describe("arrays", () => {
       >();
     });
 
-    it("should preserve undefined in fields when converting fields from non-optional to optional", () => {
+    test("should preserve undefined in fields when converting fields from non-optional to optional", () => {
       const input: ReadonlyArray<
         { a: string } | { a: string; b: string | undefined; c: undefined }
       > = [];
@@ -63,7 +63,7 @@ describe("arrays", () => {
       >();
     });
 
-    it("should prefer optional over non-optional when the same field across all members of the union has different optionalities, because it is type safe", () => {
+    test("should prefer optional over non-optional when the same field across all members of the union has different optionalities, because it is type safe", () => {
       // there is no "optionality union", we should prefer the safer option for these ambiguities
       const input: ReadonlyArray<
         { a?: number } | { a: number } | { a?: number; b: string }
@@ -77,7 +77,7 @@ describe("arrays", () => {
   });
 
   describe("should merge different types on same fields into a union", () => {
-    it("when the types are different, they form a union", () => {
+    test("when the types are different, they form a union", () => {
       const input: ReadonlyArray<
         { a: number; b: string } | { a: string; b: string }
       > = [];
@@ -89,7 +89,7 @@ describe("arrays", () => {
       >();
     });
 
-    it("when the fields are unions, they are combined into a single union", () => {
+    test("when the fields are unions, they are combined into a single union", () => {
       const input: ReadonlyArray<
         { a: number | boolean; b: string } | { a: string | Date; b: string }
       > = [];
@@ -101,7 +101,7 @@ describe("arrays", () => {
       >();
     });
 
-    it("when the field has two different intersections, it becomes the union of the intersections", () => {
+    test("when the field has two different intersections, it becomes the union of the intersections", () => {
       const input: ReadonlyArray<
         | { a: { a1: string } & { b1: string }; b: string }
         | { a: { a2: string } & { b2: string }; b: string }
@@ -123,7 +123,7 @@ describe("arrays", () => {
 });
 
 describe("nonempty arrays", () => {
-  it("the return type should not include the possibility of returning a nonempty object given a nonempty array with nonempty objects", () => {
+  test("the return type should not include the possibility of returning a nonempty object given a nonempty array with nonempty objects", () => {
     const input: [
       { a: number; b: string } | { a: string; b: string },
       ...ReadonlyArray<{ a: number; b: string } | { a: string; b: string }>,
@@ -137,7 +137,7 @@ describe("nonempty arrays", () => {
 
 describe("tuples", () => {
   describe("the fields of the rightmost item should have the greatest priority in overrides", () => {
-    it("0 types", () => {
+    test("0 types", () => {
       const input: [] = [];
 
       const result = mergeAll(input);
@@ -145,7 +145,7 @@ describe("tuples", () => {
       expectTypeOf(result).toEqualTypeOf<EmptyObject>();
     });
 
-    it("1 types", () => {
+    test("1 types", () => {
       const input: [{ a: 1; b: 1 }] = [{ a: 1, b: 1 }];
 
       const result = mergeAll(input);
@@ -153,7 +153,7 @@ describe("tuples", () => {
       expectTypeOf(result).toEqualTypeOf<{ a: 1; b: 1 }>();
     });
 
-    it("2 types", () => {
+    test("2 types", () => {
       const input: [{ a: 1; b: 1 }, { a: 2 }] = [{ a: 1, b: 1 }, { a: 2 }];
 
       const result = mergeAll(input);
@@ -161,7 +161,7 @@ describe("tuples", () => {
       expectTypeOf(result).toEqualTypeOf<{ a: 2; b: 1 }>();
     });
 
-    it("3 types", () => {
+    test("3 types", () => {
       const input: [{ a: 1; b: 1 }, { a: 2 }, { a: 3 }] = [
         { a: 1, b: 1 },
         { a: 2 },

--- a/packages/remeda/src/mergeAll.test.ts
+++ b/packages/remeda/src/mergeAll.test.ts
@@ -1,3 +1,4 @@
+import { expect, it, test } from "vitest";
 import { mergeAll } from "./mergeAll";
 
 test("merge objects", () => {

--- a/packages/remeda/src/mergeAll.test.ts
+++ b/packages/remeda/src/mergeAll.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, test } from "vitest";
+import { expect, test } from "vitest";
 import { mergeAll } from "./mergeAll";
 
 test("merge objects", () => {
@@ -12,7 +12,7 @@ test("merge objects", () => {
   });
 });
 
-it("should return an empty object when the input is an empty array", () => {
+test("should return an empty object when the input is an empty array", () => {
   const input: ReadonlyArray<object> = [];
 
   const result = mergeAll(input);

--- a/packages/remeda/src/mergeDeep.test-d.ts
+++ b/packages/remeda/src/mergeDeep.test-d.ts
@@ -1,7 +1,7 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { mergeDeep } from "./mergeDeep";
 
-it("trivially merges disjoint objects", () => {
+test("trivially merges disjoint objects", () => {
   const result = mergeDeep(
     { foo: "bar" } as { foo: string },
     { bar: "baz" } as { bar: string },
@@ -10,7 +10,7 @@ it("trivially merges disjoint objects", () => {
   expectTypeOf(result).toEqualTypeOf<{ foo: string; bar: string }>();
 });
 
-it("merges fully overlapping types", () => {
+test("merges fully overlapping types", () => {
   const result = mergeDeep(
     { foo: "bar" } as { foo: string },
     { foo: "baz" } as { foo: string },
@@ -19,7 +19,7 @@ it("merges fully overlapping types", () => {
   expectTypeOf(result).toEqualTypeOf<{ foo: string }>();
 });
 
-it("merges semi-overlapping types", () => {
+test("merges semi-overlapping types", () => {
   const result = mergeDeep(
     { foo: "bar", x: 1 } as { foo: string; x: number },
     { foo: "baz", y: 2 } as { foo: string; y: number },
@@ -28,7 +28,7 @@ it("merges semi-overlapping types", () => {
   expectTypeOf(result).toEqualTypeOf<{ foo: string; x: number; y: number }>();
 });
 
-it("deeply merges", () => {
+test("deeply merges", () => {
   const result = mergeDeep(
     { foo: { bar: "bar" } } as { foo: { bar: string } },
     { foo: { qux: "qux" } } as { foo: { qux: string } },
@@ -37,7 +37,7 @@ it("deeply merges", () => {
   expectTypeOf(result).toEqualTypeOf<{ foo: { bar: string; qux: string } }>();
 });
 
-it("overrides types", () => {
+test("overrides types", () => {
   const a = { foo: { bar: "baz" } } as { foo: { bar: string } };
   const b = { foo: "qux" } as { foo: string };
 
@@ -50,7 +50,7 @@ it("overrides types", () => {
   expectTypeOf(resultBA).toEqualTypeOf<{ foo: { bar: string } }>();
 });
 
-it("doesn't spread arrays", () => {
+test("doesn't spread arrays", () => {
   const result = mergeDeep(
     { foo: ["bar"] } as const,
     { foo: ["baz"] } as const,
@@ -59,7 +59,7 @@ it("doesn't spread arrays", () => {
   expectTypeOf(result).toEqualTypeOf<{ readonly foo: readonly ["baz"] }>();
 });
 
-it("doesn't recurse into arrays", () => {
+test("doesn't recurse into arrays", () => {
   const result = mergeDeep(
     { foo: [{ bar: "baz", x: 123 }] } as {
       foo: Array<{ bar: string; x: number }>;
@@ -74,7 +74,7 @@ it("doesn't recurse into arrays", () => {
   }>();
 });
 
-it("works with interfaces", () => {
+test("works with interfaces", () => {
   interface Foo {
     a: string;
     b: number;

--- a/packages/remeda/src/mergeDeep.test-d.ts
+++ b/packages/remeda/src/mergeDeep.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { mergeDeep } from "./mergeDeep";
 
 it("trivially merges disjoint objects", () => {

--- a/packages/remeda/src/mergeDeep.test.ts
+++ b/packages/remeda/src/mergeDeep.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { doNothing } from "./doNothing";
 import { mergeDeep } from "./mergeDeep";
 

--- a/packages/remeda/src/mergeDeep.test.ts
+++ b/packages/remeda/src/mergeDeep.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { doNothing } from "./doNothing";
 import { mergeDeep } from "./mergeDeep";
 
@@ -31,21 +31,21 @@ describe("runtime (dataFirst)", () => {
     expect(mergeDeep(a, b)).toStrictEqual({ foo: ["qux"] });
   });
 
-  it("should not merge arrays", () => {
+  test("should not merge arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
 
     expect(mergeDeep(a, b)).toStrictEqual({ foo: ["baz"] });
   });
 
-  it("should merge different types", () => {
+  test("should merge different types", () => {
     const a = { foo: "bar" };
     const b = { foo: 123 };
 
     expect(mergeDeep(a, b)).toStrictEqual({ foo: 123 });
   });
 
-  it("should work with weird object types, null", () => {
+  test("should work with weird object types, null", () => {
     const a = { foo: null };
     const b = { foo: 123 };
 
@@ -53,7 +53,7 @@ describe("runtime (dataFirst)", () => {
     expect(mergeDeep(b, a)).toStrictEqual({ foo: null });
   });
 
-  it("should work with weird object types, functions", () => {
+  test("should work with weird object types, functions", () => {
     const a = { foo: doNothing() };
     const b = { foo: 123 };
 
@@ -61,7 +61,7 @@ describe("runtime (dataFirst)", () => {
     expect(mergeDeep(b, a)).toStrictEqual({ foo: doNothing() });
   });
 
-  it("should work with weird object types, date", () => {
+  test("should work with weird object types, date", () => {
     const a = { foo: new Date(1337) };
     const b = { foo: 123 };
 
@@ -69,14 +69,14 @@ describe("runtime (dataFirst)", () => {
     expect(mergeDeep(b, a)).toStrictEqual({ foo: new Date(1337) });
   });
 
-  it("doesn't spread arrays", () => {
+  test("doesn't spread arrays", () => {
     const a = { foo: ["bar"] };
     const b = { foo: ["baz"] };
 
     expect(mergeDeep(a, b)).toStrictEqual({ foo: ["baz"] });
   });
 
-  it("doesn't recurse into arrays", () => {
+  test("doesn't recurse into arrays", () => {
     const a = { foo: [{ bar: "baz" }] };
     const b = { foo: [{ bar: "hello, world" }] };
 

--- a/packages/remeda/src/multiply.test.ts
+++ b/packages/remeda/src/multiply.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { multiply } from "./multiply";
 
 test("data-first", () => {

--- a/packages/remeda/src/nthBy.test-d.ts
+++ b/packages/remeda/src/nthBy.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { identity } from "./identity";
 import { nthBy } from "./nthBy";
 

--- a/packages/remeda/src/nthBy.test-d.ts
+++ b/packages/remeda/src/nthBy.test-d.ts
@@ -1,20 +1,20 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { identity } from "./identity";
 import { nthBy } from "./nthBy";
 
-it("works with regular arrays", () => {
+test("works with regular arrays", () => {
   const result = nthBy([1, 2, 3], 0, identity());
 
   expectTypeOf(result).toEqualTypeOf<number | undefined>();
 });
 
-it("works with negative indices", () => {
+test("works with negative indices", () => {
   const result = nthBy([1, 2, 3], -1, identity());
 
   expectTypeOf(result).toEqualTypeOf<number | undefined>();
 });
 
-it("works with tuples", () => {
+test("works with tuples", () => {
   const data: [string, boolean, number] = ["a", true, 1];
   const result = nthBy(data, 1, identity());
 

--- a/packages/remeda/src/nthBy.test.ts
+++ b/packages/remeda/src/nthBy.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { identity } from "./identity";
 import { nthBy } from "./nthBy";
 import { pipe } from "./pipe";
 
 describe("runtime (dataFirst)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [2, 1, 3];
 
     expect(nthBy(data, 0, identity())).toBe(1);
@@ -12,7 +12,7 @@ describe("runtime (dataFirst)", () => {
     expect(nthBy(data, 2, identity())).toBe(3);
   });
 
-  it("handles negative indexes", () => {
+  test("handles negative indexes", () => {
     const data = [2, 1, 3];
 
     expect(nthBy(data, -1, identity())).toBe(3);
@@ -20,12 +20,12 @@ describe("runtime (dataFirst)", () => {
     expect(nthBy(data, -3, identity())).toBe(1);
   });
 
-  it("handles overflows gracefully", () => {
+  test("handles overflows gracefully", () => {
     expect(nthBy([1, 2, 3], 100, identity())).toBeUndefined();
     expect(nthBy([1, 2, 3], -100, identity())).toBeUndefined();
   });
 
-  it("works with complex order rules", () => {
+  test("works with complex order rules", () => {
     const data = ["aaaa", "b", "bb", "a", "aaa", "bbbb", "aa", "bbb"] as const;
 
     expect(nthBy(data, 0, (a) => a.length, identity())).toBe("a");
@@ -40,7 +40,7 @@ describe("runtime (dataFirst)", () => {
 });
 
 describe("runtime (dataLast)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [2, 1, 3];
 
     expect(pipe(data, nthBy(0, identity()))).toBe(1);
@@ -48,7 +48,7 @@ describe("runtime (dataLast)", () => {
     expect(pipe(data, nthBy(2, identity()))).toBe(3);
   });
 
-  it("handles negative indexes", () => {
+  test("handles negative indexes", () => {
     const data = [2, 1, 3];
 
     expect(pipe(data, nthBy(-1, identity()))).toBe(3);
@@ -56,12 +56,12 @@ describe("runtime (dataLast)", () => {
     expect(pipe(data, nthBy(-3, identity()))).toBe(1);
   });
 
-  it("handles overflows gracefully", () => {
+  test("handles overflows gracefully", () => {
     expect(pipe([1, 2, 3], nthBy(100, identity()))).toBeUndefined();
     expect(pipe([1, 2, 3], nthBy(-100, identity()))).toBeUndefined();
   });
 
-  it("works with complex order rules", () => {
+  test("works with complex order rules", () => {
     const data = ["aaaa", "b", "bb", "a", "aaa", "bbbb", "aa", "bbb"] as const;
 
     expect(

--- a/packages/remeda/src/nthBy.test.ts
+++ b/packages/remeda/src/nthBy.test.ts
@@ -1,5 +1,6 @@
-import { nthBy } from "./nthBy";
+import { describe, expect, it } from "vitest";
 import { identity } from "./identity";
+import { nthBy } from "./nthBy";
 import { pipe } from "./pipe";
 
 describe("runtime (dataFirst)", () => {

--- a/packages/remeda/src/objOf.test.ts
+++ b/packages/remeda/src/objOf.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { objOf } from "./objOf";
 
 describe("data first", () => {

--- a/packages/remeda/src/omit.test-d.ts
+++ b/packages/remeda/src/omit.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { omit } from "./omit";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/omit.test.ts
+++ b/packages/remeda/src/omit.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { omit } from "./omit";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/omitBy.test-d.ts
+++ b/packages/remeda/src/omitBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { isDeepEqual } from "./isDeepEqual";
 import { isNullish } from "./isNullish";

--- a/packages/remeda/src/omitBy.test.ts
+++ b/packages/remeda/src/omitBy.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, vi } from "vitest";
 import { constant } from "./constant";
 import { omitBy } from "./omitBy";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/once.test.ts
+++ b/packages/remeda/src/once.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, vi } from "vitest";
 import { constant } from "./constant";
 import { once } from "./once";
 

--- a/packages/remeda/src/only.test-d.ts
+++ b/packages/remeda/src/only.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { only } from "./only";
 
 test("simple array", () => {

--- a/packages/remeda/src/only.test.ts
+++ b/packages/remeda/src/only.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { only } from "./only";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/partialBind.test-d.ts
+++ b/packages/remeda/src/partialBind.test-d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types, unicorn/consistent-function-scoping */
+import { describe, expectTypeOf, test } from "vitest";
 import { partialBind } from "./partialBind";
 
 describe("simple case (all required, no rest params)", () => {

--- a/packages/remeda/src/partialBind.test-d.ts
+++ b/packages/remeda/src/partialBind.test-d.ts
@@ -178,7 +178,7 @@ describe("optional and rest param case", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("does not support readonly rest params", () => {
     const fn = (...parts: ReadonlyArray<string>): string => parts.join("");
 

--- a/packages/remeda/src/partialBind.test.ts
+++ b/packages/remeda/src/partialBind.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { partialBind } from "./partialBind";
 
 const fn = (x: number, y: number, z: number): string => `${x}, ${y}, and ${z}`;

--- a/packages/remeda/src/partialLastBind.test-d.ts
+++ b/packages/remeda/src/partialLastBind.test-d.ts
@@ -123,7 +123,7 @@ describe("simple rest param case", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("does not support readonly rest params", () => {
     const fn = (...parts: ReadonlyArray<string>): string => parts.join("");
 

--- a/packages/remeda/src/partialLastBind.test-d.ts
+++ b/packages/remeda/src/partialLastBind.test-d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types, unicorn/consistent-function-scoping */
+import { describe, expectTypeOf, test } from "vitest";
 import { partialLastBind } from "./partialLastBind";
 
 describe("simple case (all required, no rest params)", () => {

--- a/packages/remeda/src/partialLastBind.test.ts
+++ b/packages/remeda/src/partialLastBind.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { partialLastBind } from "./partialLastBind";
 
 const fn = (x: number, y: number, z: number): string => `${x}, ${y}, and ${z}`;

--- a/packages/remeda/src/partition.test-d.ts
+++ b/packages/remeda/src/partition.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { isNumber } from "./isNumber";
 import { partition } from "./partition";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/partition.test.ts
+++ b/packages/remeda/src/partition.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { isNumber } from "./isNumber";
 import { partition } from "./partition";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/pathOr.test.ts
+++ b/packages/remeda/src/pathOr.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pathOr } from "./pathOr";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/pick.test-d.ts
+++ b/packages/remeda/src/pick.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { keys } from "./keys";
 import { pick } from "./pick";
 import { pipe } from "./pipe";
@@ -18,7 +18,7 @@ describe("data first", () => {
     >();
   });
 
-  it("infers the key types from the keys array (issue #886)", () => {
+  test("infers the key types from the keys array (issue #886)", () => {
     const data = { foo: "hello", bar: "world" };
 
     const raw = pick(data, ["foo"]);
@@ -34,7 +34,7 @@ describe("data first", () => {
     expectTypeOf(withConstKeys).toEqualTypeOf<Array<"foo">>();
   });
 
-  it("handles optional keys (issue #911)", () => {
+  test("handles optional keys (issue #911)", () => {
     const data = { foo: "hello", bar: "world" } as const;
     const result = pick(data, [] as Array<keyof typeof data>);
 

--- a/packages/remeda/src/pick.test-d.ts
+++ b/packages/remeda/src/pick.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { keys } from "./keys";
 import { pick } from "./pick";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/pick.test.ts
+++ b/packages/remeda/src/pick.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { pick } from "./pick";
 import { pipe } from "./pipe";
 

--- a/packages/remeda/src/pickBy.test-d.ts
+++ b/packages/remeda/src/pickBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { isDeepEqual } from "./isDeepEqual";
 import { isDefined } from "./isDefined";

--- a/packages/remeda/src/pickBy.test.ts
+++ b/packages/remeda/src/pickBy.test.ts
@@ -1,3 +1,4 @@
+import { expect, test, vi } from "vitest";
 import { constant } from "./constant";
 import { pickBy } from "./pickBy";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/pipe.test-d.ts
+++ b/packages/remeda/src/pipe.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { pipe } from "./pipe";
 
 it("acts as identity with 0 functions", () => {

--- a/packages/remeda/src/pipe.test-d.ts
+++ b/packages/remeda/src/pipe.test-d.ts
@@ -1,7 +1,7 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 
-it("acts as identity with 0 functions", () => {
+test("acts as identity with 0 functions", () => {
   const data = { a: "hello", b: 123 };
 
   expectTypeOf(pipe(data)).toEqualTypeOf(data);

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { filter } from "./filter";
 import { flat } from "./flat";
 import { identity } from "./identity";

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { flat } from "./flat";
 import { identity } from "./identity";
@@ -7,19 +7,19 @@ import { pipe } from "./pipe";
 import { prop } from "./prop";
 import { take } from "./take";
 
-it("should pass through data with 0 functions", () => {
+test("should pass through data with 0 functions", () => {
   const data = { a: "hello", b: 123 };
 
   expect(pipe(data)).toBe(data);
 });
 
-it("should pipe a single operation", () => {
+test("should pipe a single operation", () => {
   const result = pipe(1, (x) => x * 2);
 
   expect(result).toBe(2);
 });
 
-it("should pipe operations", () => {
+test("should pipe operations", () => {
   const result = pipe(
     1,
     (x) => x * 2,
@@ -30,7 +30,7 @@ it("should pipe operations", () => {
 });
 
 describe("lazy", () => {
-  it("lazy map + take", () => {
+  test("lazy map + take", () => {
     const count = vi.fn<() => void>();
     const result = pipe(
       [1, 2, 3],
@@ -45,7 +45,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([10, 20]);
   });
 
-  it("lazy map + filter + take", () => {
+  test("lazy map + filter + take", () => {
     const count = vi.fn<() => void>();
     const result = pipe(
       [1, 2, 3, 4, 5],
@@ -61,7 +61,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([10, 30]);
   });
 
-  it("lazy after 1st op", () => {
+  test("lazy after 1st op", () => {
     const count = vi.fn<() => void>();
     const result = pipe(
       { inner: [1, 2, 3] },
@@ -77,7 +77,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([10, 20]);
   });
 
-  it("break lazy", () => {
+  test("break lazy", () => {
     const count = vi.fn<() => void>();
     const result = pipe(
       [1, 2, 3],
@@ -93,7 +93,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([10, 20]);
   });
 
-  it("multiple take", () => {
+  test("multiple take", () => {
     const count = vi.fn<() => void>();
     const result = pipe(
       [1, 2, 3],
@@ -109,7 +109,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([10]);
   });
 
-  it("multiple lazy", () => {
+  test("multiple lazy", () => {
     const count = vi.fn<() => void>();
     const count2 = vi.fn<() => void>();
     const result = pipe(
@@ -132,7 +132,7 @@ describe("lazy", () => {
     expect(result).toStrictEqual([100, 200]);
   });
 
-  it("lazy early exit with hasMany", () => {
+  test("lazy early exit with hasMany", () => {
     const result = pipe(
       [
         [1, 2],

--- a/packages/remeda/src/piped.test.ts
+++ b/packages/remeda/src/piped.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { piped } from "./piped";
 
 it("should pipe a single operation", () => {

--- a/packages/remeda/src/piped.test.ts
+++ b/packages/remeda/src/piped.test.ts
@@ -1,13 +1,13 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { piped } from "./piped";
 
-it("should pipe a single operation", () => {
+test("should pipe a single operation", () => {
   const fn = piped((x: number) => x * 2);
 
   expect(fn(1)).toBe(2);
 });
 
-it("should pipe operations", () => {
+test("should pipe operations", () => {
   const fn = piped(
     (x: number) => x * 2,
     (x) => x * 3,

--- a/packages/remeda/src/product.test-d.ts
+++ b/packages/remeda/src/product.test-d.ts
@@ -91,7 +91,7 @@ test("doesn't allow mixed arrays", () => {
   product([1, 2n]);
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
 

--- a/packages/remeda/src/product.test-d.ts
+++ b/packages/remeda/src/product.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { pipe } from "./pipe";
 import { product } from "./product";
 

--- a/packages/remeda/src/product.test-d.ts
+++ b/packages/remeda/src/product.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { product } from "./product";
 
@@ -86,13 +86,13 @@ describe("dataLast", () => {
   });
 });
 
-it("doesn't allow mixed arrays", () => {
+test("doesn't allow mixed arrays", () => {
   // @ts-expect-error [ts2345] - Can't product bigints and numbers...
   product([1, 2n]);
 });
 
 describe("KNOWN ISSUES", () => {
-  it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
+  test("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
 
     expectTypeOf(result).toEqualTypeOf<bigint | 1>();

--- a/packages/remeda/src/product.test.ts
+++ b/packages/remeda/src/product.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { pipe } from "./pipe";
 import { product } from "./product";
 

--- a/packages/remeda/src/product.test.ts
+++ b/packages/remeda/src/product.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { product } from "./product";
 
 describe("dataFirst", () => {
-  it("should return the product of numbers in the array", () => {
+  test("should return the product of numbers in the array", () => {
     expect(product([1, 2, 3])).toBe(6);
     expect(product([4, 5, 6])).toBe(120);
     expect(product([0, 1, 2])).toBe(0);
     expect(product([-1, -2, -3])).toBe(-6);
   });
 
-  it("should return 1 for an empty array", () => {
+  test("should return 1 for an empty array", () => {
     expect(product([])).toBe(1);
   });
 
-  it("works with bigints", () => {
+  test("works with bigints", () => {
     expect(product([1n, 2n, 3n])).toBe(6n);
   });
 });
 
 describe("dataLast", () => {
-  it("should return the product of numbers in the array", () => {
+  test("should return the product of numbers in the array", () => {
     expect(pipe([1, 2, 3], product())).toBe(6);
     expect(pipe([4, 5, 6], product())).toBe(120);
     expect(pipe([0, 1, 2], product())).toBe(0);
     expect(pipe([-1, -2, -3], product())).toBe(-6);
   });
 
-  it("should return 1 for an empty array", () => {
+  test("should return 1 for an empty array", () => {
     expect(pipe([], product())).toBe(1);
   });
 });
 
 describe("KNOWN ISSUES", () => {
-  it("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
+  test("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
 
     expect(result).toBe(1);

--- a/packages/remeda/src/product.test.ts
+++ b/packages/remeda/src/product.test.ts
@@ -32,7 +32,7 @@ describe("dataLast", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("returns 1 (`number`) instead of 1n (`bigint`) for empty `bigint` arrays", () => {
     const result = product([] as Array<bigint>);
 

--- a/packages/remeda/src/prop.test-d.ts
+++ b/packages/remeda/src/prop.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/prop.test.ts
+++ b/packages/remeda/src/prop.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { indexBy } from "./indexBy";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/pullObject.test-d.ts
+++ b/packages/remeda/src/pullObject.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/pullObject.test.ts
+++ b/packages/remeda/src/pullObject.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
 import { identity } from "./identity";

--- a/packages/remeda/src/purry.test.ts
+++ b/packages/remeda/src/purry.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { purry } from "./purry";
 
 function sub(a: number, b: number): number {

--- a/packages/remeda/src/randomBigInt.test-d.ts
+++ b/packages/remeda/src/randomBigInt.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { randomBigInt } from "./randomBigInt";
 
 describe("KNOWN LIMITATIONS", () => {

--- a/packages/remeda/src/randomBigInt.test-d.ts
+++ b/packages/remeda/src/randomBigInt.test-d.ts
@@ -1,8 +1,8 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { randomBigInt } from "./randomBigInt";
 
 describe("KNOWN LIMITATIONS", () => {
-  it("doesn't return never on invalid range", () => {
+  test("doesn't return never on invalid range", () => {
     // @ts-expect-error [ts2554] - We can't detect these cases with TypeScript.
     expectTypeOf(randomBigInt(10n, 0n)).toEqualTypeOf<never>();
   });

--- a/packages/remeda/src/randomBigInt.test-d.ts
+++ b/packages/remeda/src/randomBigInt.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { randomBigInt } from "./randomBigInt";
 
-describe("KNOWN LIMITATIONS", () => {
+describe("known limitations!", () => {
   test("doesn't return never on invalid range", () => {
     // @ts-expect-error [ts2554] - We can't detect these cases with TypeScript.
     expectTypeOf(randomBigInt(10n, 0n)).toEqualTypeOf<never>();

--- a/packages/remeda/src/randomBigInt.test.ts
+++ b/packages/remeda/src/randomBigInt.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { randomBigInt } from "./randomBigInt";
 
 const ITERATIONS = 10_000;

--- a/packages/remeda/src/randomBigInt.test.ts
+++ b/packages/remeda/src/randomBigInt.test.ts
@@ -1,3 +1,8 @@
+/* eslint-disable vitest/no-hooks --
+ * This utility relies on the execution environment (node). These APIs need to
+ * be mocked for our tests, which is done via hooks.
+ */
+
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { randomBigInt } from "./randomBigInt";
 

--- a/packages/remeda/src/randomInteger.test-d.ts
+++ b/packages/remeda/src/randomInteger.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { randomInteger } from "./randomInteger";
 
 test("returns number when from is float", () => {

--- a/packages/remeda/src/randomInteger.test.ts
+++ b/packages/remeda/src/randomInteger.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { randomInteger } from "./randomInteger";
 
 const ITERATIONS = 1000;

--- a/packages/remeda/src/randomString.test.ts
+++ b/packages/remeda/src/randomString.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { randomString } from "./randomString";
 
 test("randomString", () => {

--- a/packages/remeda/src/range.test.ts
+++ b/packages/remeda/src/range.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { range } from "./range";
 
 describe("data first", () => {

--- a/packages/remeda/src/rankBy.test.ts
+++ b/packages/remeda/src/rankBy.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { identity } from "./identity";
 import { rankBy } from "./rankBy";
 
 describe("runtime (dataFirst)", () => {
-  it("works trivially with empty arrays", () => {
+  test("works trivially with empty arrays", () => {
     expect(rankBy([], 1, identity)).toBe(0);
   });
 
-  it("maintains the rank for items already in the array", () => {
+  test("maintains the rank for items already in the array", () => {
     const data = [5, 1, 3] as const;
     const sorted = [...data].sort((a, b) => a - b);
     for (const [index, item] of sorted.entries()) {
@@ -15,7 +15,7 @@ describe("runtime (dataFirst)", () => {
     }
   });
 
-  it("can rank items not in the array", () => {
+  test("can rank items not in the array", () => {
     const data = [5, 1, 3] as const;
 
     expect(rankBy(data, 0, identity())).toBe(0);
@@ -23,7 +23,7 @@ describe("runtime (dataFirst)", () => {
     expect(rankBy(data, 4, identity())).toBe(2);
   });
 
-  it("finds items ranked at the end of the array", () => {
+  test("finds items ranked at the end of the array", () => {
     const data = [5, 1, 3] as const;
 
     expect(rankBy(data, 6, identity())).toBe(3);

--- a/packages/remeda/src/rankBy.test.ts
+++ b/packages/remeda/src/rankBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { identity } from "./identity";
 import { rankBy } from "./rankBy";
 

--- a/packages/remeda/src/reduce.test.ts
+++ b/packages/remeda/src/reduce.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { reduce } from "./reduce";
 

--- a/packages/remeda/src/reverse.test-d.ts
+++ b/packages/remeda/src/reverse.test-d.ts
@@ -1,5 +1,6 @@
-import { reverse } from "./reverse";
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
+import { reverse } from "./reverse";
 
 describe("data first", () => {
   test("arrays", () => {

--- a/packages/remeda/src/reverse.test.ts
+++ b/packages/remeda/src/reverse.test.ts
@@ -1,5 +1,6 @@
-import { reverse } from "./reverse";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
+import { reverse } from "./reverse";
 
 describe("data first", () => {
   test("reverse", () => {

--- a/packages/remeda/src/round.test.ts
+++ b/packages/remeda/src/round.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { round } from "./round";
 
 describe("data-first", () => {

--- a/packages/remeda/src/sample.test-d.ts
+++ b/packages/remeda/src/sample.test-d.ts
@@ -1,57 +1,57 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { sample } from "./sample";
 
 describe("sampleSize 0", () => {
-  it("on arrays", () => {
+  test("on arrays", () => {
     const array: Array<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on readonly arrays", () => {
+  test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on tuples", () => {
+  test("on tuples", () => {
     const array: [number, number, number, number, number] = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on readonly tuples", () => {
+  test("on readonly tuples", () => {
     const array = [1, 2, 3, 4, 5] as const;
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on tuples with rest tail", () => {
+  test("on tuples with rest tail", () => {
     const array: [number, ...Array<number>] = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on tuples with rest head", () => {
+  test("on tuples with rest head", () => {
     const array: [...Array<number>, number] = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on readonly tuples with rest tail", () => {
+  test("on readonly tuples with rest tail", () => {
     const array: readonly [number, ...Array<number>] = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("on readonly tuples with rest head", () => {
+  test("on readonly tuples with rest head", () => {
     const array: readonly [...Array<number>, number] = [1, 2, 3, 4, 5];
     const result = sample(array, 0);
 
@@ -60,7 +60,7 @@ describe("sampleSize 0", () => {
 });
 
 describe("sampleSize < n", () => {
-  it("on arrays", () => {
+  test("on arrays", () => {
     const array: Array<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 4);
 
@@ -73,7 +73,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on readonly arrays", () => {
+  test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 4);
 
@@ -86,7 +86,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on tuples", () => {
+  test("on tuples", () => {
     const array: [1, 2, 3, 4, 5] = [1, 2, 3, 4, 5];
     const result = sample(array, 4);
 
@@ -95,7 +95,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on readonly tuples", () => {
+  test("on readonly tuples", () => {
     const array = [1, 2, 3, 4, 5] as const;
     const result = sample(array, 4);
 
@@ -104,7 +104,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on tuples with rest tail", () => {
+  test("on tuples with rest tail", () => {
     const array: [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -122,7 +122,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on readonly tuples with rest tail", () => {
+  test("on readonly tuples with rest tail", () => {
     const array: readonly [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -140,7 +140,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on tuples with rest head", () => {
+  test("on tuples with rest head", () => {
     const array: [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -157,7 +157,7 @@ describe("sampleSize < n", () => {
     >();
   });
 
-  it("on readonly tuples with rest head", () => {
+  test("on readonly tuples with rest head", () => {
     const array: readonly [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -176,21 +176,21 @@ describe("sampleSize < n", () => {
 });
 
 describe("sampleSize === n", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 0);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on arrays", () => {
+  test("on arrays", () => {
     const array: Array<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 5);
 
@@ -204,7 +204,7 @@ describe("sampleSize === n", () => {
     >();
   });
 
-  it("on readonly arrays", () => {
+  test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 5);
 
@@ -218,21 +218,21 @@ describe("sampleSize === n", () => {
     >();
   });
 
-  it("on tuples", () => {
+  test("on tuples", () => {
     const array: [1, 2, 3, 4, 5] = [1, 2, 3, 4, 5];
     const result = sample(array, 5);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on readonly tuples", () => {
+  test("on readonly tuples", () => {
     const array = [1, 2, 3, 4, 5] as const;
     const result = sample(array, 5);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on tuples with rest tail", () => {
+  test("on tuples with rest tail", () => {
     const array: [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -251,7 +251,7 @@ describe("sampleSize === n", () => {
     >();
   });
 
-  it("on readonly tuples with rest tail", () => {
+  test("on readonly tuples with rest tail", () => {
     const array: readonly [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -270,7 +270,7 @@ describe("sampleSize === n", () => {
     >();
   });
 
-  it("on tuples with rest head", () => {
+  test("on tuples with rest head", () => {
     const array: [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -288,7 +288,7 @@ describe("sampleSize === n", () => {
     >();
   });
 
-  it("on readonly tuples with rest head", () => {
+  test("on readonly tuples with rest head", () => {
     const array: readonly [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -308,21 +308,21 @@ describe("sampleSize === n", () => {
 });
 
 describe("sampleSize > n", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 10);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 10);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on arrays", () => {
+  test("on arrays", () => {
     const array: Array<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 10);
 
@@ -352,7 +352,7 @@ describe("sampleSize > n", () => {
     >();
   });
 
-  it("on readonly arrays", () => {
+  test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 10);
 
@@ -382,21 +382,21 @@ describe("sampleSize > n", () => {
     >();
   });
 
-  it("on tuples", () => {
+  test("on tuples", () => {
     const array: [1, 2, 3, 4, 5] = [1, 2, 3, 4, 5];
     const result = sample(array, 10);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on readonly tuples", () => {
+  test("on readonly tuples", () => {
     const array = [1, 2, 3, 4, 5] as const;
     const result = sample(array, 10);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on tuples with rest tail", () => {
+  test("on tuples with rest tail", () => {
     const array: [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -465,7 +465,7 @@ describe("sampleSize > n", () => {
     >();
   });
 
-  it("on readonly tuples with rest tail", () => {
+  test("on readonly tuples with rest tail", () => {
     const array: readonly [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -534,7 +534,7 @@ describe("sampleSize > n", () => {
     >();
   });
 
-  it("on tuples with rest head", () => {
+  test("on tuples with rest head", () => {
     const array: [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -578,7 +578,7 @@ describe("sampleSize > n", () => {
     >();
   });
 
-  it("on readonly tuples with rest head", () => {
+  test("on readonly tuples with rest head", () => {
     const array: readonly [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -624,35 +624,35 @@ describe("sampleSize > n", () => {
 });
 
 describe("non-const sampleSize", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 5 as number);
 
     expectTypeOf(result).toEqualTypeOf<[]>();
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 5 as number);
 
     expectTypeOf(result).toEqualTypeOf<typeof array>();
   });
 
-  it("on arrays", () => {
+  test("on arrays", () => {
     const array: Array<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 5 as number);
 
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
-  it("on readonly arrays", () => {
+  test("on readonly arrays", () => {
     const array: ReadonlyArray<number> = [1, 2, 3, 4, 5];
     const result = sample(array, 5 as number);
 
     expectTypeOf(result).toEqualTypeOf<Array<number>>();
   });
 
-  it("on tuples", () => {
+  test("on tuples", () => {
     const array: [1, 2, 3, 4, 5] = [1, 2, 3, 4, 5];
     const result = sample(array, 5 as number);
 
@@ -692,7 +692,7 @@ describe("non-const sampleSize", () => {
     >();
   });
 
-  it("on readonly tuples", () => {
+  test("on readonly tuples", () => {
     const array = [1, 2, 3, 4, 5] as const;
     const result = sample(array, 5 as number);
 
@@ -732,7 +732,7 @@ describe("non-const sampleSize", () => {
     >();
   });
 
-  it("on tuples with rest tail", () => {
+  test("on tuples with rest tail", () => {
     const array: [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -750,7 +750,7 @@ describe("non-const sampleSize", () => {
     >();
   });
 
-  it("on readonly tuples with rest tail", () => {
+  test("on readonly tuples with rest tail", () => {
     const array: readonly [number, boolean, ...Array<string>] = [
       1,
       true,
@@ -768,7 +768,7 @@ describe("non-const sampleSize", () => {
     >();
   });
 
-  it("on tuples with rest head", () => {
+  test("on tuples with rest head", () => {
     const array: [...Array<string>, boolean, number] = [
       "yey",
       "hello",
@@ -784,7 +784,7 @@ describe("non-const sampleSize", () => {
     >();
   });
 
-  it("on readonly tuples with rest head", () => {
+  test("on readonly tuples with rest head", () => {
     const array: readonly [...Array<string>, boolean, number] = [
       "yey",
       "hello",

--- a/packages/remeda/src/sample.test-d.ts
+++ b/packages/remeda/src/sample.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { sample } from "./sample";
 
 describe("sampleSize 0", () => {

--- a/packages/remeda/src/sample.test.ts
+++ b/packages/remeda/src/sample.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 import { sample } from "./sample";
 import { times } from "./times";

--- a/packages/remeda/src/sample.test.ts
+++ b/packages/remeda/src/sample.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { NonEmptyArray } from "./internal/types/NonEmptyArray";
 import { sample } from "./sample";
 import { times } from "./times";
 import { unique } from "./unique";
 
 describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
-  it.each(allIndices(array))(
+  test.each(allIndices(array))(
     "returns the right number of items",
     (sampleSize) => {
       const result = sample(array, sampleSize);
@@ -14,7 +14,7 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
     },
   );
 
-  it.each(allIndices(array))(
+  test.each(allIndices(array))(
     "doesn't make items up (returns a subset of the input array)",
     (sampleSize) => {
       const result = sample(array, sampleSize);
@@ -25,7 +25,7 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
     },
   );
 
-  it("returns a random result", () => {
+  test("returns a random result", () => {
     const collector = new Set<number>();
     // We iterate because we might hit randomly on the same item several
     // times. We took a large enough number so that it's unlikely to happen
@@ -41,13 +41,13 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
     expect(collector.size).toBeGreaterThan(1);
   });
 
-  it.each(allIndices(array))("doesn't return repetitions", (sampleSize) => {
+  test.each(allIndices(array))("doesn't return repetitions", (sampleSize) => {
     const result = sample(array, sampleSize);
 
     expect(result).toHaveLength(new Set(result).size);
   });
 
-  it.each(allIndices(array))("doesn't reorder items", (sampleSize) => {
+  test.each(allIndices(array))("doesn't reorder items", (sampleSize) => {
     const result = sample(array, sampleSize);
 
     let lastInputIndex = -1; // outside of the array
@@ -65,7 +65,7 @@ describe.each([[generateRandomArray()]])("mathy stuff", (array) => {
 });
 
 describe("identity", () => {
-  it("for full (=== n) sample size", () => {
+  test("for full (=== n) sample size", () => {
     const array = [1, 2, 3];
     const result = sample(array, 3);
 
@@ -73,7 +73,7 @@ describe("identity", () => {
     expect(result).not.toBe(array);
   });
 
-  it("for large (> n) sample sizes", () => {
+  test("for large (> n) sample sizes", () => {
     const array = [1, 2, 3];
     const result = sample(array, 10);
 
@@ -81,7 +81,7 @@ describe("identity", () => {
     expect(result).not.toBe(array);
   });
 
-  it("on empty arrays", () => {
+  test("on empty arrays", () => {
     const array: Array<number> = [];
     const result = sample(array, 1);
 
@@ -89,7 +89,7 @@ describe("identity", () => {
     expect(result).not.toBe(array);
   });
 
-  it("on empty arrays and sample size 0", () => {
+  test("on empty arrays and sample size 0", () => {
     const array: Array<number> = [];
     const result = sample(array, 0);
 
@@ -99,30 +99,30 @@ describe("identity", () => {
 });
 
 describe("edge cases", () => {
-  it("works on empty arrays", () => {
+  test("works on empty arrays", () => {
     const result = sample([], 1);
 
     expect(result).toStrictEqual([]);
   });
 
-  it("treats negative sample sizes as 0", () => {
+  test("treats negative sample sizes as 0", () => {
     expect(sample([1, 2, 3], -1 as number)).toStrictEqual([]);
   });
 
-  it("rounds non-integer sample sizes", () => {
+  test("rounds non-integer sample sizes", () => {
     expect(sample([1, 2, 3], 0.5)).toHaveLength(1);
   });
 });
 
 describe("sampleSize === n", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 0);
 
     expect(result).toStrictEqual([]);
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 0);
 
@@ -131,14 +131,14 @@ describe("sampleSize === n", () => {
 });
 
 describe("sampleSize > n", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 10);
 
     expect(result).toStrictEqual([]);
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 10);
 
@@ -147,14 +147,14 @@ describe("sampleSize > n", () => {
 });
 
 describe("non-const sampleSize", () => {
-  it("empty array", () => {
+  test("empty array", () => {
     const array: [] = [];
     const result = sample(array, 5 as number);
 
     expect(result).toStrictEqual([]);
   });
 
-  it("empty readonly array", () => {
+  test("empty readonly array", () => {
     const array: readonly [] = [];
     const result = sample(array, 5 as number);
 

--- a/packages/remeda/src/set.test-d.ts
+++ b/packages/remeda/src/set.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it } from "vitest";
 import { set } from "./set";
 
 describe("parameter enforcing", () => {

--- a/packages/remeda/src/set.test-d.ts
+++ b/packages/remeda/src/set.test-d.ts
@@ -1,35 +1,35 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { set } from "./set";
 
 describe("parameter enforcing", () => {
-  it("prevents setting the wrong type", () => {
+  test("prevents setting the wrong type", () => {
     // @ts-expect-error [ts2345] - 'number' is not assignable to 'string'.
     set({} as { a: string }, "a", 1);
   });
 
-  it("doesn't expand narrow types", () => {
+  test("doesn't expand narrow types", () => {
     // @ts-expect-error [ts2345] - 'mouse' is not assignable to 'cat' | 'dog'.
     set({} as { a: "cat" | "dog" }, "a", "mouse");
   });
 
-  it("prevents setting `undefined` on optional fields", () => {
+  test("prevents setting `undefined` on optional fields", () => {
     // @ts-expect-error [ts2345] - 'a' cannot be `undefined`.
     set({} as { a?: string }, "a", undefined);
   });
 
-  it("prevents setting an unknown prop", () => {
+  test("prevents setting an unknown prop", () => {
     // @ts-expect-error [ts2345] - 'b' does not exist on type '{ a: string; }'.
     set({ a: "foo" }, "b", "bar");
   });
 });
 
-it("narrows the prop type", () => {
+test("narrows the prop type", () => {
   const result = set({} as { a?: string }, "a", "hello" as const);
 
   expectTypeOf(result).toEqualTypeOf<{ a: "hello" }>();
 });
 
-it("keeps the prop optional when the key isn't literal", () => {
+test("keeps the prop optional when the key isn't literal", () => {
   const result = set(
     {} as { a?: string; b?: number },
     "a" as "a" | "b",
@@ -39,7 +39,7 @@ it("keeps the prop optional when the key isn't literal", () => {
   expectTypeOf(result).toEqualTypeOf<{ a?: string; b?: number | "foo" }>();
 });
 
-it("works on simple objects", () => {
+test("works on simple objects", () => {
   const result = set({} as Record<string, string>, "a", "foo" as const);
 
   expectTypeOf(result).toEqualTypeOf<{ [x: string]: string; a: "foo" }>();

--- a/packages/remeda/src/set.test.ts
+++ b/packages/remeda/src/set.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { set } from "./set";
 

--- a/packages/remeda/src/setPath.test-d.ts
+++ b/packages/remeda/src/setPath.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, it, test } from "vitest";
 import { pipe } from "./pipe";
 import { setPath } from "./setPath";
 

--- a/packages/remeda/src/setPath.test-d.ts
+++ b/packages/remeda/src/setPath.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, it, test } from "vitest";
+import { describe, test } from "vitest";
 import { pipe } from "./pipe";
 import { setPath } from "./setPath";
 
@@ -13,7 +13,7 @@ declare const TEST_OBJECT: {
 };
 
 describe("data first", () => {
-  it("should correctly type value argument", () => {
+  test("should correctly type value argument", () => {
     // @ts-expect-error [ts2345] - this path should yield a type of number
     setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], "hello");
 
@@ -21,7 +21,7 @@ describe("data first", () => {
     setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], 123);
   });
 
-  it("should correctly type path argument", () => {
+  test("should correctly type path argument", () => {
     // @ts-expect-error [ts2322] - 'hello' isn't a valid path
     setPath(TEST_OBJECT, ["a", "hello"], "hello");
 

--- a/packages/remeda/src/setPath.test.ts
+++ b/packages/remeda/src/setPath.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { setPath } from "./setPath";
 import { stringToPath } from "./stringToPath";

--- a/packages/remeda/src/shuffle.test-d.ts
+++ b/packages/remeda/src/shuffle.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it, test } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { shuffle } from "./shuffle";
 
@@ -32,13 +32,13 @@ test("fixed size tuple", () => {
   >();
 });
 
-it("removes readonlyness from array", () => {
+test("removes readonlyness from array", () => {
   const result = shuffle([] as ReadonlyArray<string>);
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("infers type via a pipe", () => {
+test("infers type via a pipe", () => {
   const result = pipe(["a", 1, true] as [string, number, boolean], shuffle());
 
   expectTypeOf(result).toEqualTypeOf<

--- a/packages/remeda/src/shuffle.test-d.ts
+++ b/packages/remeda/src/shuffle.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it, test } from "vitest";
 import { pipe } from "./pipe";
 import { shuffle } from "./shuffle";
 

--- a/packages/remeda/src/shuffle.test.ts
+++ b/packages/remeda/src/shuffle.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { difference } from "./difference";
 import { pipe } from "./pipe";
 import { shuffle } from "./shuffle";

--- a/packages/remeda/src/sliceString.test.ts
+++ b/packages/remeda/src/sliceString.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { sliceString } from "./sliceString";
 
 const ALPHABET = "abcdefghijklmnopqrstuvwxyz";

--- a/packages/remeda/src/sort.test-d.ts
+++ b/packages/remeda/src/sort.test-d.ts
@@ -1,49 +1,49 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { sort } from "./sort";
 
-it("on empty tuple", () => {
+test("on empty tuple", () => {
   const result = sort([] as [], (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("on empty readonly tuple", () => {
+test("on empty readonly tuple", () => {
   const result = sort([] as const, (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("on array", () => {
+test("on array", () => {
   const result = sort([] as Array<number>, (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("on readonly array", () => {
+test("on readonly array", () => {
   const result = sort([] as ReadonlyArray<number>, (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("on tuple", () => {
+test("on tuple", () => {
   const result = sort([1, 2, 3] as [1, 2, 3], (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
 });
 
-it("on readonly tuple", () => {
+test("on readonly tuple", () => {
   const result = sort([1, 2, 3] as const, (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
 });
 
-it("on tuple with rest tail", () => {
+test("on tuple with rest tail", () => {
   const result = sort([1] as [number, ...Array<number>], (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
 });
 
-it("on readonly tuple with rest tail", () => {
+test("on readonly tuple with rest tail", () => {
   const result = sort(
     [1] as readonly [number, ...Array<number>],
     (a, b) => a - b,
@@ -52,13 +52,13 @@ it("on readonly tuple with rest tail", () => {
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
 });
 
-it("on tuple with rest head", () => {
+test("on tuple with rest head", () => {
   const result = sort([1] as [...Array<number>, number], (a, b) => a - b);
 
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
-it("on readonly tuple with rest head", () => {
+test("on readonly tuple with rest head", () => {
   const result = sort(
     [1] as readonly [...Array<number>, number],
     (a, b) => a - b,
@@ -67,7 +67,7 @@ it("on readonly tuple with rest head", () => {
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
-it("on mixed types tuple", () => {
+test("on mixed types tuple", () => {
   const result = sort([1, "hello", true] as [number, string, boolean], () => 1);
 
   expectTypeOf(result).toEqualTypeOf<

--- a/packages/remeda/src/sort.test-d.ts
+++ b/packages/remeda/src/sort.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { sort } from "./sort";
 
 it("on empty tuple", () => {

--- a/packages/remeda/src/sort.test.ts
+++ b/packages/remeda/src/sort.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { sort } from "./sort";
 

--- a/packages/remeda/src/sortBy.test-d.ts
+++ b/packages/remeda/src/sortBy.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { constant } from "./constant";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/sortBy.test-d.ts
+++ b/packages/remeda/src/sortBy.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
@@ -63,49 +63,49 @@ describe("dataLast", () => {
   });
 });
 
-it("on empty tuple", () => {
+test("on empty tuple", () => {
   const result = sortBy([] as [], identity);
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("on empty readonly tuple", () => {
+test("on empty readonly tuple", () => {
   const result = sortBy([] as const, identity);
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("on array", () => {
+test("on array", () => {
   const result = sortBy([] as Array<number>, identity);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("on readonly array", () => {
+test("on readonly array", () => {
   const result = sortBy([] as ReadonlyArray<number>, identity);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("on tuple", () => {
+test("on tuple", () => {
   const result = sortBy([1, 2, 3] as [1, 2, 3], identity);
 
   expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
 });
 
-it("on readonly tuple", () => {
+test("on readonly tuple", () => {
   const result = sortBy([1, 2, 3] as const, identity);
 
   expectTypeOf(result).toEqualTypeOf<[1 | 2 | 3, 1 | 2 | 3, 1 | 2 | 3]>();
 });
 
-it("on tuple with rest tail", () => {
+test("on tuple with rest tail", () => {
   const result = sortBy([1] as [number, ...Array<number>], identity);
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
 });
 
-it("on readonly tuple with rest tail", () => {
+test("on readonly tuple with rest tail", () => {
   const result = sortBy([1] as readonly [number, ...Array<number>], identity);
 
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>]>();
@@ -129,13 +129,13 @@ test("on readonly tuple with rest middle", () => {
   expectTypeOf(result).toEqualTypeOf<[number, ...Array<number>, number]>();
 });
 
-it("on tuple with rest head", () => {
+test("on tuple with rest head", () => {
   const result = sortBy([1] as [...Array<number>, number], identity);
 
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
 });
 
-it("on readonly tuple with rest head", () => {
+test("on readonly tuple with rest head", () => {
   const result = sortBy([1] as readonly [...Array<number>, number], identity);
 
   expectTypeOf(result).toEqualTypeOf<[...Array<number>, number]>();
@@ -156,7 +156,7 @@ test("on readonly tuple with optional values", () => {
   expectTypeOf(result).toEqualTypeOf<[number?, number?, number?]>();
 });
 
-it("on mixed types tuple", () => {
+test("on mixed types tuple", () => {
   const result = sortBy(
     [1, "hello", true] as [number, string, boolean],
     identity,

--- a/packages/remeda/src/sortBy.test.ts
+++ b/packages/remeda/src/sortBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { prop } from "./prop";

--- a/packages/remeda/src/sortedIndex.test.ts
+++ b/packages/remeda/src/sortedIndex.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { sortedIndex } from "./sortedIndex";
 
 test("empty array", () => {

--- a/packages/remeda/src/sortedIndexBy.test.ts
+++ b/packages/remeda/src/sortedIndexBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { sortedIndexBy } from "./sortedIndexBy";
 
 describe("runtime correctness", () => {

--- a/packages/remeda/src/sortedIndexWith.test.ts
+++ b/packages/remeda/src/sortedIndexWith.test.ts
@@ -3,6 +3,7 @@
  * so we test it mainly via the tests for that function.
  */
 
+import { expect, test } from "vitest";
 import { sortedIndexWith } from "./sortedIndexWith";
 
 test("regular", () => {

--- a/packages/remeda/src/sortedLastIndex.test.ts
+++ b/packages/remeda/src/sortedLastIndex.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { sortedLastIndex } from "./sortedLastIndex";
 
 test("empty array", () => {

--- a/packages/remeda/src/sortedLastIndexBy.test.ts
+++ b/packages/remeda/src/sortedLastIndexBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { sortedLastIndexBy } from "./sortedLastIndexBy";
 
 describe("runtime correctness", () => {

--- a/packages/remeda/src/splice.test-d.ts
+++ b/packages/remeda/src/splice.test-d.ts
@@ -1,21 +1,21 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { splice } from "./splice";
 
-it("reflects the type of `items` in the return value", () => {
+test("reflects the type of `items` in the return value", () => {
   const items: Array<number> = [];
   const result = splice(items, 0, 0, []);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("reflects the type of `replacement` in the return value", () => {
+test("reflects the type of `replacement` in the return value", () => {
   const replacement: Array<number> = [];
   const result = splice([], 0, 0, replacement);
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("reflects the type of `replacement` in the return value (data-last)", () => {
+test("reflects the type of `replacement` in the return value (data-last)", () => {
   const replacement: Array<number> = [];
   const result = splice(0, 0, replacement);
 

--- a/packages/remeda/src/splice.test-d.ts
+++ b/packages/remeda/src/splice.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { splice } from "./splice";
 
 it("reflects the type of `items` in the return value", () => {

--- a/packages/remeda/src/splice.test.ts
+++ b/packages/remeda/src/splice.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { splice } from "./splice";
 

--- a/packages/remeda/src/split.test-d.ts
+++ b/packages/remeda/src/split.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { split } from "./split";
 
 test("non-literals", () => {

--- a/packages/remeda/src/split.test.ts
+++ b/packages/remeda/src/split.test.ts
@@ -1,5 +1,6 @@
-import { split } from "./split";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
+import { split } from "./split";
 
 test("empty string, empty separator", () => {
   expect(split("", "")).toStrictEqual([]);

--- a/packages/remeda/src/splitAt.test.ts
+++ b/packages/remeda/src/splitAt.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { splitAt } from "./splitAt";
 
 describe("data_first", () => {

--- a/packages/remeda/src/splitWhen.test.ts
+++ b/packages/remeda/src/splitWhen.test.ts
@@ -1,14 +1,14 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { splitWhen } from "./splitWhen";
 
-it("should split array", () => {
+test("should split array", () => {
   expect(splitWhen([1, 2, 3, 1, 2, 3] as const, (x) => x === 2)).toStrictEqual([
     [1],
     [2, 3, 1, 2, 3],
   ]);
 });
 
-it("should with no matches", () => {
+test("should with no matches", () => {
   const n = 1232;
 
   expect(splitWhen([1, 2, 3, 1, 2, 3], (x) => x === n)).toStrictEqual([

--- a/packages/remeda/src/splitWhen.test.ts
+++ b/packages/remeda/src/splitWhen.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { splitWhen } from "./splitWhen";
 
 it("should split array", () => {

--- a/packages/remeda/src/startsWith.test-d.ts
+++ b/packages/remeda/src/startsWith.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { partition } from "./partition";
 import { startsWith } from "./startsWith";
 

--- a/packages/remeda/src/startsWith.test.ts
+++ b/packages/remeda/src/startsWith.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { startsWith } from "./startsWith";
 

--- a/packages/remeda/src/stringToPath.test-d.ts
+++ b/packages/remeda/src/stringToPath.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { stringToPath } from "./stringToPath";
 
 test("should convert a string to a deeply nested path", () => {

--- a/packages/remeda/src/stringToPath.test.ts
+++ b/packages/remeda/src/stringToPath.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { stringToPath } from "./stringToPath";
 
 test("empty path", () => {

--- a/packages/remeda/src/subtract.test.ts
+++ b/packages/remeda/src/subtract.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { subtract } from "./subtract";
 
 test("data-first", () => {

--- a/packages/remeda/src/sum.test-d.ts
+++ b/packages/remeda/src/sum.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { sum } from "./sum";
 
@@ -86,13 +86,13 @@ describe("dataLast", () => {
   });
 });
 
-it("doesn't allow mixed arrays", () => {
+test("doesn't allow mixed arrays", () => {
   // @ts-expect-error [ts2345] - Can't sum bigints and numbers...
   sum([1, 2n]);
 });
 
 describe("KNOWN ISSUES", () => {
-  it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
+  test("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
 
     expectTypeOf(result).toEqualTypeOf<bigint | 0>();

--- a/packages/remeda/src/sum.test-d.ts
+++ b/packages/remeda/src/sum.test-d.ts
@@ -91,7 +91,7 @@ test("doesn't allow mixed arrays", () => {
   sum([1, 2n]);
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
 

--- a/packages/remeda/src/sum.test-d.ts
+++ b/packages/remeda/src/sum.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { pipe } from "./pipe";
 import { sum } from "./sum";
 

--- a/packages/remeda/src/sum.test.ts
+++ b/packages/remeda/src/sum.test.ts
@@ -1,37 +1,37 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { sum } from "./sum";
 
 describe("dataFirst", () => {
-  it("should return the sum of numbers in an array", () => {
+  test("should return the sum of numbers in an array", () => {
     expect(sum([1, 2, 3])).toBe(6);
     expect(sum([4, 5, 6])).toBe(15);
     expect(sum([-1, 0, 1])).toBe(0);
   });
 
-  it("should return 0 for an empty array", () => {
+  test("should return 0 for an empty array", () => {
     expect(sum([])).toBe(0);
   });
 
-  it("works on bigints", () => {
+  test("works on bigints", () => {
     expect(sum([1n, 2n, 3n])).toBe(6n);
   });
 });
 
 describe("dataLast", () => {
-  it("should return the sum of numbers in an array", () => {
+  test("should return the sum of numbers in an array", () => {
     expect(pipe([1, 2, 3], sum())).toBe(6);
     expect(pipe([4, 5, 6], sum())).toBe(15);
     expect(pipe([-1, 0, 1], sum())).toBe(0);
   });
 
-  it("should return 0 for an empty array", () => {
+  test("should return 0 for an empty array", () => {
     expect(pipe([], sum())).toBe(0);
   });
 });
 
 describe("KNOWN ISSUES", () => {
-  it("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
+  test("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
 
     expect(result).toBe(0);

--- a/packages/remeda/src/sum.test.ts
+++ b/packages/remeda/src/sum.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { pipe } from "./pipe";
 import { sum } from "./sum";
 

--- a/packages/remeda/src/sum.test.ts
+++ b/packages/remeda/src/sum.test.ts
@@ -30,7 +30,7 @@ describe("dataLast", () => {
   });
 });
 
-describe("KNOWN ISSUES", () => {
+describe("known issues!", () => {
   test("returns 0 (`number`) instead of 0n (`bigint`) for empty `bigint` arrays", () => {
     const result = sum([] as Array<bigint>);
 

--- a/packages/remeda/src/sumBy.test-d.ts
+++ b/packages/remeda/src/sumBy.test-d.ts
@@ -1,6 +1,7 @@
-import { sumBy } from "./sumBy";
-import { pipe } from "./pipe";
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
+import { pipe } from "./pipe";
+import { sumBy } from "./sumBy";
 
 test("empty array", () => {
   const result1 = sumBy([], constant(1n));

--- a/packages/remeda/src/sumBy.test.ts
+++ b/packages/remeda/src/sumBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
 import { sumBy } from "./sumBy";

--- a/packages/remeda/src/sumBy.test.ts
+++ b/packages/remeda/src/sumBy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
 import { sumBy } from "./sumBy";
@@ -25,7 +25,7 @@ describe("data first", () => {
     ).toBe(15n);
   });
 
-  it("should return 0 for an empty array", () => {
+  test("should return 0 for an empty array", () => {
     expect(sumBy([], prop("a"))).toBe(0);
   });
 });
@@ -49,7 +49,7 @@ describe("data last", () => {
     ).toBe(15n);
   });
 
-  it("should return 0 for an empty array", () => {
+  test("should return 0 for an empty array", () => {
     expect(pipe([], sumBy(prop("a")))).toBe(0);
   });
 

--- a/packages/remeda/src/swapIndices.test.ts
+++ b/packages/remeda/src/swapIndices.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { swapIndices } from "./swapIndices";
 
 describe("data_first", () => {

--- a/packages/remeda/src/swapIndices.test.ts
+++ b/packages/remeda/src/swapIndices.test.ts
@@ -1,22 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { swapIndices } from "./swapIndices";
 
 describe("data_first", () => {
-  it("swap array", () => {
+  test("swap array", () => {
     expect(swapIndices([1, 2, 3, 4, 5], 0, -1)).toStrictEqual([5, 2, 3, 4, 1]);
   });
 
-  it("swap string", () => {
+  test("swap string", () => {
     expect(swapIndices("apple", 0, 1)).toBe("paple");
   });
 
-  it("fails gracefully on NaN indices", () => {
+  test("fails gracefully on NaN indices", () => {
     expect(swapIndices("apple", Number.NaN, 1)).toBe("apple");
     expect(swapIndices("apple", 1, Number.NaN)).toBe("apple");
     expect(swapIndices("apple", Number.NaN, Number.NaN)).toBe("apple");
   });
 
-  it("fails gracefully on overflow indices", () => {
+  test("fails gracefully on overflow indices", () => {
     expect(swapIndices("apple", 100, 1)).toBe("apple");
     expect(swapIndices("apple", 1, 100)).toBe("apple");
     expect(swapIndices("apple", 200, 300)).toBe("apple");
@@ -24,11 +24,11 @@ describe("data_first", () => {
 });
 
 describe("data_last", () => {
-  it("swap array", () => {
+  test("swap array", () => {
     expect(swapIndices(-1, 4)([1, 2, 3, 4, 5])).toStrictEqual([1, 2, 3, 4, 5]);
   });
 
-  it("swap string", () => {
+  test("swap string", () => {
     expect(swapIndices(0, -1)("apple")).toBe("eppla");
   });
 });

--- a/packages/remeda/src/swapProps.test-d.ts
+++ b/packages/remeda/src/swapProps.test-d.ts
@@ -1,7 +1,7 @@
-import { it } from "vitest";
+import { test } from "vitest";
 import { swapProps } from "./swapProps";
 
-it("protects against invalid prop names", () => {
+test("protects against invalid prop names", () => {
   // @ts-expect-error [ts2345] - Argument of type '"c"' is not assignable to parameter of type '"a" | "b"'.
   swapProps({ a: 1, b: 2 }, "a", "c");
 });

--- a/packages/remeda/src/swapProps.test-d.ts
+++ b/packages/remeda/src/swapProps.test-d.ts
@@ -1,3 +1,4 @@
+import { it } from "vitest";
 import { swapProps } from "./swapProps";
 
 it("protects against invalid prop names", () => {

--- a/packages/remeda/src/swapProps.test.ts
+++ b/packages/remeda/src/swapProps.test.ts
@@ -1,19 +1,19 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { swapProps } from "./swapProps";
 
-it("data-first", () => {
+test("data-first", () => {
   expect(swapProps({ a: 1, b: 2 }, "a", "b")).toStrictEqual({ a: 2, b: 1 });
 });
 
-it("data-last", () => {
+test("data-last", () => {
   expect(pipe({ a: 1, b: 2 }, swapProps("a", "b"))).toStrictEqual({
     a: 2,
     b: 1,
   });
 });
 
-it("maintains the shape of the rest of the object", () => {
+test("maintains the shape of the rest of the object", () => {
   expect(swapProps({ a: true, b: "hello", c: 3 }, "a", "b")).toStrictEqual({
     a: "hello",
     b: true,

--- a/packages/remeda/src/swapProps.test.ts
+++ b/packages/remeda/src/swapProps.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { pipe } from "./pipe";
 import { swapProps } from "./swapProps";
 

--- a/packages/remeda/src/take.test-d.ts
+++ b/packages/remeda/src/take.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { take } from "./take";
 

--- a/packages/remeda/src/take.test.ts
+++ b/packages/remeda/src/take.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test, vi } from "vitest";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { take } from "./take";

--- a/packages/remeda/src/take.test.ts
+++ b/packages/remeda/src/take.test.ts
@@ -1,22 +1,22 @@
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { take } from "./take";
 
 describe("data first", () => {
-  it("works on regular inputs", () => {
+  test("works on regular inputs", () => {
     expect(take([1, 2, 3, 4, 5], 2)).toStrictEqual([1, 2]);
   });
 
-  it("works trivially on empty arrays", () => {
+  test("works trivially on empty arrays", () => {
     expect(take([], 2)).toStrictEqual([]);
   });
 
-  it("works trivially with negative numbers", () => {
+  test("works trivially with negative numbers", () => {
     expect(take([1, 2, 3, 4, 5], -1)).toStrictEqual([]);
   });
 
-  it("works when taking more than the length of the array", () => {
+  test("works when taking more than the length of the array", () => {
     expect(take([1, 2, 3, 4, 5], 10)).toStrictEqual([1, 2, 3, 4, 5]);
   });
 
@@ -30,19 +30,19 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("works on regular inputs", () => {
+  test("works on regular inputs", () => {
     expect(pipe([1, 2, 3, 4, 5], take(2))).toStrictEqual([1, 2]);
   });
 
-  it("works trivially on empty arrays", () => {
+  test("works trivially on empty arrays", () => {
     expect(pipe([], take(2))).toStrictEqual([]);
   });
 
-  it("works trivially with negative numbers", () => {
+  test("works trivially with negative numbers", () => {
     expect(pipe([1, 2, 3, 4, 5], take(-1))).toStrictEqual([]);
   });
 
-  it("works when taking more than the length of the array", () => {
+  test("works when taking more than the length of the array", () => {
     expect(pipe([1, 2, 3, 4, 5], take(10))).toStrictEqual([1, 2, 3, 4, 5]);
   });
 

--- a/packages/remeda/src/takeFirstBy.test.ts
+++ b/packages/remeda/src/takeFirstBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
 import { takeFirstBy } from "./takeFirstBy";

--- a/packages/remeda/src/takeFirstBy.test.ts
+++ b/packages/remeda/src/takeFirstBy.test.ts
@@ -1,34 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
 import { takeFirstBy } from "./takeFirstBy";
 
 describe("runtime (dataFirst)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(takeFirstBy(data, 2, identity())).toStrictEqual([2, 1]);
   });
 
-  it("handles empty arrays gracefully", () => {
+  test("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
 
     expect(takeFirstBy(data, 1, identity())).toHaveLength(0);
   });
 
-  it("handles negative numbers gracefully", () => {
+  test("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(takeFirstBy(data, -3, identity())).toHaveLength(0);
   });
 
-  it("handles overflowing numbers gracefully", () => {
+  test("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(takeFirstBy(data, 100, identity())).toHaveLength(data.length);
   });
 
-  it("clones the array when needed", () => {
+  test("clones the array when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = takeFirstBy(data, 100, identity());
 
@@ -36,7 +36,7 @@ describe("runtime (dataFirst)", () => {
     expect(result).toStrictEqual(data);
   });
 
-  it("works with complex compare rules", () => {
+  test("works with complex compare rules", () => {
     const data = [
       "a",
       "aaa",
@@ -59,7 +59,7 @@ describe("runtime (dataFirst)", () => {
 });
 
 describe("runtime (dataLast)", () => {
-  it("works", () => {
+  test("works", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -70,7 +70,7 @@ describe("runtime (dataLast)", () => {
     ).toStrictEqual([2, 1]);
   });
 
-  it("handles empty arrays gracefully", () => {
+  test("handles empty arrays gracefully", () => {
     const data: Array<number> = [];
 
     expect(
@@ -81,7 +81,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(0);
   });
 
-  it("handles negative numbers gracefully", () => {
+  test("handles negative numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -92,7 +92,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(0);
   });
 
-  it("handles overflowing numbers gracefully", () => {
+  test("handles overflowing numbers gracefully", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
 
     expect(
@@ -103,7 +103,7 @@ describe("runtime (dataLast)", () => {
     ).toHaveLength(data.length);
   });
 
-  it("clones the array when needed", () => {
+  test("clones the array when needed", () => {
     const data = [4, 5, 1, 6, 2, 3, 7];
     const result = pipe(
       data,
@@ -114,7 +114,7 @@ describe("runtime (dataLast)", () => {
     expect(result).toStrictEqual(data);
   });
 
-  it("works with complex compare rules", () => {
+  test("works with complex compare rules", () => {
     const data = [
       "a",
       "aaa",

--- a/packages/remeda/src/takeLast.test-d.ts
+++ b/packages/remeda/src/takeLast.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { takeLast } from "./takeLast";
 

--- a/packages/remeda/src/takeLast.test.ts
+++ b/packages/remeda/src/takeLast.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "vitest";
 import { takeLast } from "./takeLast";
 
 test("empty array", () => {

--- a/packages/remeda/src/takeLastWhile.test-d.ts
+++ b/packages/remeda/src/takeLastWhile.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/takeLastWhile.test.ts
+++ b/packages/remeda/src/takeLastWhile.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { pipe } from "./pipe";
 import { takeLastWhile } from "./takeLastWhile";
 

--- a/packages/remeda/src/takeLastWhile.test.ts
+++ b/packages/remeda/src/takeLastWhile.test.ts
@@ -1,27 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { takeLastWhile } from "./takeLastWhile";
 
 describe("data first", () => {
-  it("should return items after the last predicate failure", () => {
+  test("should return items after the last predicate failure", () => {
     expect(takeLastWhile([1, 2, 3, 4], (n) => n !== 2)).toStrictEqual([3, 4]);
   });
 
-  it("should return an empty array when the last item fails the predicate", () => {
+  test("should return an empty array when the last item fails the predicate", () => {
     expect(takeLastWhile([1, 2, 3, 4], (n) => n !== 4)).toStrictEqual([]);
   });
 
-  it("should return rest of the items when first item fails the predicate", () => {
+  test("should return rest of the items when first item fails the predicate", () => {
     expect(takeLastWhile([1, 2, 3, 4], (n) => n !== 1)).toStrictEqual([
       2, 3, 4,
     ]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(takeLastWhile([], (n) => n > 0)).toStrictEqual([]);
   });
 
-  it("should return a copy of the original array when all items pass the predicate", () => {
+  test("should return a copy of the original array when all items pass the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = takeLastWhile(data, (n) => n > 0);
 
@@ -31,7 +31,7 @@ describe("data first", () => {
 });
 
 describe("data last", () => {
-  it("should return items after the last predicate failure", () => {
+  test("should return items after the last predicate failure", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -40,7 +40,7 @@ describe("data last", () => {
     ).toStrictEqual([3, 4]);
   });
 
-  it("should return an empty array when the last item fails the predicate", () => {
+  test("should return an empty array when the last item fails the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -49,7 +49,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return rest of the items when first item fails the predicate", () => {
+  test("should return rest of the items when first item fails the predicate", () => {
     expect(
       pipe(
         [1, 2, 3, 4],
@@ -58,7 +58,7 @@ describe("data last", () => {
     ).toStrictEqual([2, 3, 4]);
   });
 
-  it("should return an empty array when an empty array is passed", () => {
+  test("should return an empty array when an empty array is passed", () => {
     expect(
       pipe(
         [],
@@ -67,7 +67,7 @@ describe("data last", () => {
     ).toStrictEqual([]);
   });
 
-  it("should return a copy of the original array when all items pass the predicate", () => {
+  test("should return a copy of the original array when all items pass the predicate", () => {
     const data = [1, 2, 3, 4];
     const result = pipe(
       data,

--- a/packages/remeda/src/takeWhile.test-d.ts
+++ b/packages/remeda/src/takeWhile.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { isNumber } from "./isNumber";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/takeWhile.test.ts
+++ b/packages/remeda/src/takeWhile.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { takeWhile } from "./takeWhile";
 
 describe("data_first", () => {
-  it("takeWhile", () => {
+  test("takeWhile", () => {
     expect(
       takeWhile([1, 2, 3, 4, 3, 2, 1] as const, (x) => x !== 4),
     ).toStrictEqual([1, 2, 3]);
@@ -11,7 +11,7 @@ describe("data_first", () => {
 });
 
 describe("data_last", () => {
-  it("takeWhile", () => {
+  test("takeWhile", () => {
     expect(
       pipe(
         [1, 2, 3, 4, 3, 2, 1] as const,

--- a/packages/remeda/src/takeWhile.test.ts
+++ b/packages/remeda/src/takeWhile.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { pipe } from "./pipe";
 import { takeWhile } from "./takeWhile";
 

--- a/packages/remeda/src/tap.test-d.ts
+++ b/packages/remeda/src/tap.test-d.ts
@@ -1,11 +1,11 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { filter } from "./filter";
 import { map } from "./map";
 import { multiply } from "./multiply";
 import { pipe } from "./pipe";
 import { tap } from "./tap";
 
-it("should work in the middle of pipe sequence", () => {
+test("should work in the middle of pipe sequence", () => {
   pipe(
     [-1, 2],
     filter((n) => n > 0),
@@ -16,7 +16,7 @@ it("should work in the middle of pipe sequence", () => {
   );
 });
 
-it("should infer types after tapping function reference with parameter type any", () => {
+test("should infer types after tapping function reference with parameter type any", () => {
   pipe(
     [-1, 2],
     filter((n) => n > 0),

--- a/packages/remeda/src/tap.test-d.ts
+++ b/packages/remeda/src/tap.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { filter } from "./filter";
 import { map } from "./map";
 import { multiply } from "./multiply";

--- a/packages/remeda/src/tap.test.ts
+++ b/packages/remeda/src/tap.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { filter } from "./filter";
 import { map } from "./map";
 import { multiply } from "./multiply";
@@ -12,7 +13,7 @@ describe("data first", () => {
     tap(DATA, fn);
 
     expect(fn).toHaveBeenCalledWith(DATA);
-    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it("should return input value", () => {
@@ -26,7 +27,7 @@ describe("data last", () => {
     pipe(DATA, tap(fn));
 
     expect(fn).toHaveBeenCalledWith(DATA);
-    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it("should return input value", () => {

--- a/packages/remeda/src/tap.test.ts
+++ b/packages/remeda/src/tap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { map } from "./map";
 import { multiply } from "./multiply";
@@ -8,7 +8,7 @@ import { tap } from "./tap";
 const DATA = [1] as const;
 
 describe("data first", () => {
-  it("should call function with input value", () => {
+  test("should call function with input value", () => {
     const fn = vi.fn<() => void>();
     tap(DATA, fn);
 
@@ -16,13 +16,13 @@ describe("data first", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it("should return input value", () => {
+  test("should return input value", () => {
     expect(tap(DATA, (data) => data.length)).toBe(DATA);
   });
 });
 
 describe("data last", () => {
-  it("should call function with input value", () => {
+  test("should call function with input value", () => {
     const fn = vi.fn<() => void>();
     pipe(DATA, tap(fn));
 
@@ -30,7 +30,7 @@ describe("data last", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it("should return input value", () => {
+  test("should return input value", () => {
     expect(
       pipe(
         DATA,
@@ -39,7 +39,7 @@ describe("data last", () => {
     ).toBe(DATA);
   });
 
-  it("should work in the middle of pipe sequence", () => {
+  test("should work in the middle of pipe sequence", () => {
     expect(
       pipe(
         [-1, 2],
@@ -52,7 +52,7 @@ describe("data last", () => {
     ).toStrictEqual([4]);
   });
 
-  it("should infer types after tapping function reference with parameter type any", () => {
+  test("should infer types after tapping function reference with parameter type any", () => {
     expect(
       pipe(
         [-1, 2],

--- a/packages/remeda/src/times.test-d.ts
+++ b/packages/remeda/src/times.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { identity } from "./identity";
 import { times } from "./times";
 

--- a/packages/remeda/src/times.test-d.ts
+++ b/packages/remeda/src/times.test-d.ts
@@ -1,20 +1,20 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { identity } from "./identity";
 import { times } from "./times";
 
-it("works with 0", () => {
+test("works with 0", () => {
   const result = times(0, identity());
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("works with non-literals", () => {
+test("works with non-literals", () => {
   const result = times(10 as number, identity());
 
   expectTypeOf(result).toEqualTypeOf<Array<number>>();
 });
 
-it("works with positive integer literals", () => {
+test("works with positive integer literals", () => {
   const result = times(10, identity());
 
   expectTypeOf(result).toEqualTypeOf<
@@ -33,13 +33,13 @@ it("works with positive integer literals", () => {
   >();
 });
 
-it("works with negative integers", () => {
+test("works with negative integers", () => {
   const result = times(-10, identity());
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("works with non-integer positive literals", () => {
+test("works with non-integer positive literals", () => {
   const result = times(10.5, identity());
 
   expectTypeOf(result).toEqualTypeOf<
@@ -58,19 +58,19 @@ it("works with non-integer positive literals", () => {
   >();
 });
 
-it("works with non-integer negative literals", () => {
+test("works with non-integer negative literals", () => {
   const result = times(-10.5, identity());
 
   expectTypeOf(result).toEqualTypeOf<[]>();
 });
 
-it("works with literal unions", () => {
+test("works with literal unions", () => {
   const result = times(1 as 1 | 3, identity());
 
   expectTypeOf(result).toEqualTypeOf<[number, number, number] | [number]>();
 });
 
-it("could be 'disabled' with large literals", () => {
+test("could be 'disabled' with large literals", () => {
   const result = times(10_000, identity());
 
   // The result is a tuple of our max length supported for a literal, with an

--- a/packages/remeda/src/times.test.ts
+++ b/packages/remeda/src/times.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { constant } from "./constant";
 import { identity } from "./identity";
 import { multiply } from "./multiply";

--- a/packages/remeda/src/times.test.ts
+++ b/packages/remeda/src/times.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { constant } from "./constant";
 import { identity } from "./identity";
 import { multiply } from "./multiply";
@@ -6,7 +6,7 @@ import { pipe } from "./pipe";
 import { times } from "./times";
 
 describe("data_first", () => {
-  it("returns a trivial empty array for non-positive values", () => {
+  test("returns a trivial empty array for non-positive values", () => {
     const zeroResult = times(0, identity());
 
     expect(zeroResult).toStrictEqual([]);
@@ -21,11 +21,11 @@ describe("data_first", () => {
     expect(times(-5.5, identity())).toStrictEqual([]);
   });
 
-  it("creates an array of the correct length", () => {
+  test("creates an array of the correct length", () => {
     expect(times(123 as number, constant(1))).toHaveLength(123);
   });
 
-  it("passes idx to fn", () => {
+  test("passes idx to fn", () => {
     const fn = vi.fn<(x: number) => void>();
     times(5, fn);
 
@@ -36,18 +36,18 @@ describe("data_first", () => {
     expect(fn).toHaveBeenCalledWith(4);
   });
 
-  it("returns fn results as arr", () => {
+  test("returns fn results as arr", () => {
     expect(times(5, identity())).toStrictEqual([0, 1, 2, 3, 4]);
     expect(times(5, multiply(2))).toStrictEqual([0, 2, 4, 6, 8]);
   });
 
-  it("rounds down non-integer numbers", () => {
+  test("rounds down non-integer numbers", () => {
     expect(times(5.5, identity())).toStrictEqual([0, 1, 2, 3, 4]);
   });
 });
 
 describe("data_last", () => {
-  it("returns a trivial empty array for non-positive values", () => {
+  test("returns a trivial empty array for non-positive values", () => {
     const zeroResult = pipe(0, times(identity()));
 
     expect(zeroResult).toStrictEqual([]);
@@ -62,11 +62,11 @@ describe("data_last", () => {
     expect(pipe(-5.5, times(identity()))).toStrictEqual([]);
   });
 
-  it("creates an array of the correct length", () => {
+  test("creates an array of the correct length", () => {
     expect(pipe(123 as number, times(constant(1)))).toHaveLength(123);
   });
 
-  it("passes idx to fn", () => {
+  test("passes idx to fn", () => {
     const fn = vi.fn<(x: number) => void>();
     pipe(5, times(fn));
 
@@ -77,12 +77,12 @@ describe("data_last", () => {
     expect(fn).toHaveBeenCalledWith(4);
   });
 
-  it("returns fn results as arr", () => {
+  test("returns fn results as arr", () => {
     expect(pipe(5, times(identity()))).toStrictEqual([0, 1, 2, 3, 4]);
     expect(pipe(5, times(multiply(2)))).toStrictEqual([0, 2, 4, 6, 8]);
   });
 
-  it("rounds down non-integer numbers", () => {
+  test("rounds down non-integer numbers", () => {
     expect(pipe(5.5, times(identity()))).toStrictEqual([0, 1, 2, 3, 4]);
   });
 });

--- a/packages/remeda/src/toCamelCase.test-d.ts
+++ b/packages/remeda/src/toCamelCase.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { toCamelCase } from "./toCamelCase";
 

--- a/packages/remeda/src/toCamelCase.test.ts
+++ b/packages/remeda/src/toCamelCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { toCamelCase } from "./toCamelCase";
 

--- a/packages/remeda/src/toKebabCase.test-d.ts
+++ b/packages/remeda/src/toKebabCase.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf } from "expect-type";
+import { expectTypeOf, test } from "vitest";
 import { toKebabCase } from "./toKebabCase";
 
 test("primitive string", () => {

--- a/packages/remeda/src/toKebabCase.test.ts
+++ b/packages/remeda/src/toKebabCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { toKebabCase } from "./toKebabCase";
 

--- a/packages/remeda/src/toLowerCase.test-d.ts
+++ b/packages/remeda/src/toLowerCase.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { toLowerCase } from "./toLowerCase";
 

--- a/packages/remeda/src/toLowerCase.test.ts
+++ b/packages/remeda/src/toLowerCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { toLowerCase } from "./toLowerCase";
 

--- a/packages/remeda/src/toSnakeCase.test-d.ts
+++ b/packages/remeda/src/toSnakeCase.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf } from "expect-type";
+import { expectTypeOf, test } from "vitest";
 import { toSnakeCase } from "./toSnakeCase";
 
 test("primitive string", () => {

--- a/packages/remeda/src/toSnakeCase.test.ts
+++ b/packages/remeda/src/toSnakeCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { toSnakeCase } from "./toSnakeCase";
 

--- a/packages/remeda/src/toUpperCase.test-d.ts
+++ b/packages/remeda/src/toUpperCase.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { toUpperCase } from "./toUpperCase";
 

--- a/packages/remeda/src/toUpperCase.test.ts
+++ b/packages/remeda/src/toUpperCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { toUpperCase } from "./toUpperCase";
 

--- a/packages/remeda/src/uncapitalize.test-d.ts
+++ b/packages/remeda/src/uncapitalize.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { uncapitalize } from "./uncapitalize";
 

--- a/packages/remeda/src/uncapitalize.test.ts
+++ b/packages/remeda/src/uncapitalize.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { uncapitalize } from "./uncapitalize";
 

--- a/packages/remeda/src/unique.test.ts
+++ b/packages/remeda/src/unique.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { pipe } from "./pipe";
 import { take } from "./take";

--- a/packages/remeda/src/unique.test.ts
+++ b/packages/remeda/src/unique.test.ts
@@ -1,16 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { pipe } from "./pipe";
 import { take } from "./take";
 import { unique } from "./unique";
 
-it("unique", () => {
+test("unique", () => {
   expect(unique([1, 2, 2, 5, 1, 6, 7] as const)).toStrictEqual([1, 2, 5, 6, 7]);
 });
 
 // eslint-disable-next-line vitest/valid-title -- This seems to be a bug in the rule, @see https://github.com/vitest-dev/eslint-plugin-vitest/issues/692
 describe(pipe, () => {
-  it("unique", () => {
+  test("unique", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 2, 5, 1, 6, 7] as const,
@@ -23,7 +23,7 @@ describe(pipe, () => {
     expect(result).toStrictEqual([1, 2, 5]);
   });
 
-  it("take before unique", () => {
+  test("take before unique", () => {
     // bug from https://github.com/remeda/remeda/issues/14
     const counter = createLazyInvocationCounter();
     const result = pipe(

--- a/packages/remeda/src/uniqueBy.test.ts
+++ b/packages/remeda/src/uniqueBy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { identity } from "./identity";
 import { pipe } from "./pipe";
@@ -15,13 +15,13 @@ const PEOPLE = [
   { name: "Emily", age: 42 },
 ] as const;
 
-it("handles uniq by identity", () => {
+test("handles uniq by identity", () => {
   expect(uniqueBy([1, 2, 2, 5, 1, 6, 7], identity())).toStrictEqual([
     1, 2, 5, 6, 7,
   ]);
 });
 
-it("returns people with uniq names", () => {
+test("returns people with uniq names", () => {
   expect(uniqueBy(PEOPLE, (p) => p.name)).toStrictEqual([
     { name: "John", age: 42 },
     { name: "Jörn", age: 30 },
@@ -31,7 +31,7 @@ it("returns people with uniq names", () => {
   ]);
 });
 
-it("returns people with uniq ages", () => {
+test("returns people with uniq ages", () => {
   expect(uniqueBy(PEOPLE, (p) => p.age)).toStrictEqual([
     { name: "John", age: 42 },
     { name: "Jörn", age: 30 },
@@ -41,7 +41,7 @@ it("returns people with uniq ages", () => {
   ]);
 });
 
-it("returns people with uniq first letter of name", () => {
+test("returns people with uniq first letter of name", () => {
   expect(uniqueBy(PEOPLE, (p) => p.name.slice(0, 1))).toStrictEqual([
     { name: "John", age: 42 },
     { name: "Sarah", age: 33 },
@@ -52,7 +52,7 @@ it("returns people with uniq first letter of name", () => {
 
 // eslint-disable-next-line vitest/valid-title -- This seems to be a bug in the rule, @see https://github.com/vitest-dev/eslint-plugin-vitest/issues/692
 describe(pipe, () => {
-  it("gets executed until target length is reached", () => {
+  test("gets executed until target length is reached", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 2, 5, 1, 6, 7],
@@ -65,7 +65,7 @@ describe(pipe, () => {
     expect(result).toStrictEqual([1, 2, 5]);
   });
 
-  it("get executed 3 times when take before uniqueBy", () => {
+  test("get executed 3 times when take before uniqueBy", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [1, 2, 2, 5, 1, 6, 7],

--- a/packages/remeda/src/uniqueBy.test.ts
+++ b/packages/remeda/src/uniqueBy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { identity } from "./identity";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/uniqueWith.test.ts
+++ b/packages/remeda/src/uniqueWith.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { isDeepEqual } from "./isDeepEqual";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/uniqueWith.test.ts
+++ b/packages/remeda/src/uniqueWith.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { isDeepEqual } from "./isDeepEqual";
 import { pipe } from "./pipe";
@@ -21,7 +21,7 @@ describe("data_first", () => {
     expect(uniqueWith(source, isDeepEqual)).toStrictEqual(expected);
   });
 
-  it("should return items that are not equal to themselves", () => {
+  test("should return items that are not equal to themselves", () => {
     // test case based on https://github.com/remeda/remeda/issues/999
     const data = [
       { id: 1, reason: "No name" },
@@ -52,7 +52,7 @@ describe("data_last", () => {
     expect(uniqueWith(isDeepEqual)(source)).toStrictEqual(expected);
   });
 
-  it("lazy", () => {
+  test("lazy", () => {
     const counter = createLazyInvocationCounter();
     const result = pipe(
       [{ a: 1 }, { a: 2 }, { a: 2 }, { a: 5 }, { a: 1 }, { a: 6 }, { a: 7 }],
@@ -65,7 +65,7 @@ describe("data_last", () => {
     expect(result).toStrictEqual([{ a: 1 }, { a: 2 }, { a: 5 }]);
   });
 
-  it("take before uniq", () => {
+  test("take before uniq", () => {
     // bug from https://github.com/remeda/remeda/issues/14
     const counter = createLazyInvocationCounter();
     const result = pipe(

--- a/packages/remeda/src/values.test-d.ts
+++ b/packages/remeda/src/values.test-d.ts
@@ -1,44 +1,44 @@
-import { expectTypeOf, it } from "vitest";
+import { expectTypeOf, test } from "vitest";
 import { doNothing } from "./doNothing";
 import { values } from "./values";
 
-it("should correctly types indexed types", () => {
+test("should correctly types indexed types", () => {
   const result = values<Record<string, string>>({ a: "b" });
 
   expectTypeOf(result).toEqualTypeOf<Array<string>>();
 });
 
-it("should correctly type functions", () => {
+test("should correctly type functions", () => {
   const result = values(doNothing());
 
   expectTypeOf(result).toEqualTypeOf<Array<never>>();
 });
 
-it("should correctly type arrays", () => {
+test("should correctly type arrays", () => {
   const results = values([1, 2, 3]);
 
   expectTypeOf(results).toEqualTypeOf<Array<number>>();
 });
 
-it("should correctly type const arrays", () => {
+test("should correctly type const arrays", () => {
   const results = values([1, 2, 3] as const);
 
   expectTypeOf(results).toEqualTypeOf<Array<1 | 2 | 3>>();
 });
 
-it("should correctly type objects", () => {
+test("should correctly type objects", () => {
   const result = values({ a: true });
 
   expectTypeOf(result).toEqualTypeOf<Array<boolean>>();
 });
 
-it("should correctly type Records", () => {
+test("should correctly type Records", () => {
   const result = values<Record<string, boolean>>({ a: true });
 
   expectTypeOf(result).toEqualTypeOf<Array<boolean>>();
 });
 
-it("should correctly type union of Records", () => {
+test("should correctly type union of Records", () => {
   const result = values({
     a: "cat",
   } as Record<PropertyKey, "cat"> | Record<PropertyKey, "dog">);
@@ -46,7 +46,7 @@ it("should correctly type union of Records", () => {
   expectTypeOf(result).toEqualTypeOf<Array<"cat"> | Array<"dog">>();
 });
 
-it("should correctly type typed objects", () => {
+test("should correctly type typed objects", () => {
   const result = values<{ type: "cat" | "dog"; age: number }>({
     type: "cat",
     age: 7,
@@ -55,13 +55,13 @@ it("should correctly type typed objects", () => {
   expectTypeOf(result).toEqualTypeOf<Array<number | "cat" | "dog">>();
 });
 
-it("should skip symbol keys", () => {
+test("should skip symbol keys", () => {
   const result = values({ [Symbol("a")]: true, a: "b", 123: 456 });
 
   expectTypeOf(result).toEqualTypeOf<Array<number | string>>();
 });
 
-it("should return a useful type when all keys are symbols", () => {
+test("should return a useful type when all keys are symbols", () => {
   const result = values({ [Symbol("a")]: true, [Symbol("b")]: "c" });
 
   expectTypeOf(result).toEqualTypeOf<Array<never>>();

--- a/packages/remeda/src/values.test-d.ts
+++ b/packages/remeda/src/values.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, it } from "vitest";
 import { doNothing } from "./doNothing";
 import { values } from "./values";
 

--- a/packages/remeda/src/values.test.ts
+++ b/packages/remeda/src/values.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "vitest";
 import { values } from "./values";
 
 it("works with arrays", () => {

--- a/packages/remeda/src/values.test.ts
+++ b/packages/remeda/src/values.test.ts
@@ -1,19 +1,19 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { values } from "./values";
 
-it("works with arrays", () => {
+test("works with arrays", () => {
   expect(values(["x", "y", "z"])).toStrictEqual(["x", "y", "z"]);
 });
 
-it("should return values of object", () => {
+test("should return values of object", () => {
   expect(values({ a: "x", b: "y", c: "z" })).toStrictEqual(["x", "y", "z"]);
 });
 
-it("should skip symbol keys", () => {
+test("should skip symbol keys", () => {
   expect(values({ [Symbol("a")]: "x" })).toStrictEqual([]);
 });
 
-it("shouldn't skip symbol values", () => {
+test("shouldn't skip symbol values", () => {
   const mySymbol = Symbol("mySymbol");
 
   expect(values({ a: mySymbol })).toStrictEqual([mySymbol]);

--- a/packages/remeda/src/when.test-d.ts
+++ b/packages/remeda/src/when.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { constant } from "./constant";
 import { isString } from "./isString";
 import { map } from "./map";
@@ -15,7 +15,7 @@ describe("dataFirst", () => {
         });
       });
 
-      it("return type is not narrowed", () => {
+      test("return type is not narrowed", () => {
         const data = "hello" as number | string;
         const result = when(data, constant(true), constant({ a: 1 }));
 
@@ -24,7 +24,7 @@ describe("dataFirst", () => {
         expectTypeOf(result).toEqualTypeOf<typeof data | { a: number }>();
       });
 
-      it("passes extra args to the functions", () => {
+      test("passes extra args to the functions", () => {
         const data = "hello" as number | string;
         when(
           data,
@@ -44,14 +44,14 @@ describe("dataFirst", () => {
     });
 
     describe("type-guards", () => {
-      it("narrows the mapper's param", () => {
+      test("narrows the mapper's param", () => {
         const data = "hello" as number | string;
         when(data, isString, (x) => {
           expectTypeOf(x).toEqualTypeOf<string>();
         });
       });
 
-      it("removes narrowed types from the output", () => {
+      test("removes narrowed types from the output", () => {
         const data = "hello" as number | string;
         const result = when(data, isString, constant("cat" as const));
 
@@ -60,7 +60,7 @@ describe("dataFirst", () => {
         expectTypeOf(result).toEqualTypeOf<number | "cat">();
       });
 
-      it("passes extra args to the functions (workaround)", () => {
+      test("passes extra args to the functions (workaround)", () => {
         const data = "hello" as number | string;
         when(
           data,
@@ -94,7 +94,7 @@ describe("dataFirst", () => {
         });
       });
 
-      it("returns the union of the branch return types", () => {
+      test("returns the union of the branch return types", () => {
         const data = "hello" as number | string;
         const result = when(data, constant(true), {
           onTrue: constant("cat" as const),
@@ -104,7 +104,7 @@ describe("dataFirst", () => {
         expectTypeOf(result).toEqualTypeOf<"cat" | "dog">();
       });
 
-      it("passes extra args to the functions (workaround)", () => {
+      test("passes extra args to the functions (workaround)", () => {
         const data = "hello" as number | string;
         when(
           data,
@@ -132,7 +132,7 @@ describe("dataFirst", () => {
     });
 
     describe("type-guards", () => {
-      it("narrows the mapper's param", () => {
+      test("narrows the mapper's param", () => {
         const data = "hello" as number | string;
         when(data, isString, {
           onTrue: (x) => {
@@ -146,7 +146,7 @@ describe("dataFirst", () => {
         });
       });
 
-      it("returns the union of the branch return types", () => {
+      test("returns the union of the branch return types", () => {
         const data = "hello" as number | string;
         const result = when(data, isString, {
           onTrue: constant("cat" as const),
@@ -156,7 +156,7 @@ describe("dataFirst", () => {
         expectTypeOf(result).toEqualTypeOf<"cat" | "dog">();
       });
 
-      it("passes extra args to the functions (workaround)", () => {
+      test("passes extra args to the functions (workaround)", () => {
         const data = "hello" as number | string;
         when(
           data,
@@ -200,7 +200,7 @@ describe("dataLast", () => {
         );
       });
 
-      it("return type is not narrowed", () => {
+      test("return type is not narrowed", () => {
         const data = "hello" as number | string;
         const result = pipe(data, when(constant(true), constant({ a: 1 })));
 
@@ -209,7 +209,7 @@ describe("dataLast", () => {
         expectTypeOf(result).toEqualTypeOf<typeof data | { a: number }>();
       });
 
-      it("passes extra args to the functions", () => {
+      test("passes extra args to the functions", () => {
         const data = [] as Array<number | string>;
         map(
           data,
@@ -223,7 +223,7 @@ describe("dataLast", () => {
     });
 
     describe("type-guards", () => {
-      it("narrows the mapper's param", () => {
+      test("narrows the mapper's param", () => {
         const data = "hello" as number | string;
         pipe(
           data,
@@ -233,7 +233,7 @@ describe("dataLast", () => {
         );
       });
 
-      it("removes narrowed types from the output", () => {
+      test("removes narrowed types from the output", () => {
         const data = "hello" as number | string;
         const result = pipe(data, when(isString, constant("cat" as const)));
 
@@ -243,7 +243,7 @@ describe("dataLast", () => {
       });
     });
 
-    it("passes extra args to the functions", () => {
+    test("passes extra args to the functions", () => {
       const data = [] as Array<number | string>;
       map(
         data,
@@ -273,7 +273,7 @@ describe("dataLast", () => {
         );
       });
 
-      it("returns the union of the branch return types", () => {
+      test("returns the union of the branch return types", () => {
         const data = "hello" as number | string;
         const result = pipe(
           data,
@@ -286,7 +286,7 @@ describe("dataLast", () => {
         expectTypeOf(result).toEqualTypeOf<"cat" | "dog">();
       });
 
-      it("passes extra args to the functions", () => {
+      test("passes extra args to the functions", () => {
         const data = [] as Array<number | string>;
         map(
           data,
@@ -307,7 +307,7 @@ describe("dataLast", () => {
     });
 
     describe("type-guards", () => {
-      it("narrows the mapper's param", () => {
+      test("narrows the mapper's param", () => {
         const data = "hello" as number | string;
         pipe(
           data,
@@ -324,7 +324,7 @@ describe("dataLast", () => {
         );
       });
 
-      it("returns the union of the branch return types", () => {
+      test("returns the union of the branch return types", () => {
         const data = "hello" as number | string;
         const result = pipe(
           data,
@@ -337,7 +337,7 @@ describe("dataLast", () => {
         expectTypeOf(result).toEqualTypeOf<"cat" | "dog">();
       });
 
-      it("passes extra args to the functions", () => {
+      test("passes extra args to the functions", () => {
         const data = [] as Array<number | string>;
         map(
           data,
@@ -424,7 +424,7 @@ describe("typing mismatches", () => {
 });
 
 describe("recipes", () => {
-  it("handles api response union response objects", () => {
+  test("handles api response union response objects", () => {
     someApi({
       onFoo: when(isErrorPayload, {
         onTrue: ({ error }) => handleError(error),

--- a/packages/remeda/src/when.test-d.ts
+++ b/packages/remeda/src/when.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, it, test } from "vitest";
 import { constant } from "./constant";
 import { isString } from "./isString";
 import { map } from "./map";

--- a/packages/remeda/src/when.test.ts
+++ b/packages/remeda/src/when.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { constant } from "./constant";
 import { isDefined } from "./isDefined";
 import { isNot } from "./isNot";

--- a/packages/remeda/src/when.test.ts
+++ b/packages/remeda/src/when.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { constant } from "./constant";
 import { isDefined } from "./isDefined";
 import { isNot } from "./isNot";
@@ -11,19 +11,19 @@ import { when } from "./when";
 
 describe("dataFirst", () => {
   describe("without else", () => {
-    it("returns the happy path when true", () => {
+    test("returns the happy path when true", () => {
       expect(when("hello", isStrictEqual("hello"), constant("was true"))).toBe(
         "was true",
       );
     });
 
-    it("returns the identity when false", () => {
+    test("returns the identity when false", () => {
       expect(when("hello", isStrictEqual("olleh"), constant("was true"))).toBe(
         "hello",
       );
     });
 
-    it("passes extra args to the functions", () => {
+    test("passes extra args to the functions", () => {
       expect(
         when(
           "20",
@@ -37,13 +37,13 @@ describe("dataFirst", () => {
   });
 
   describe("with else", () => {
-    it("returns the happy path when true", () => {
+    test("returns the happy path when true", () => {
       expect(when("hello", isStrictEqual("hello"), constant("was true"))).toBe(
         "was true",
       );
     });
 
-    it("returns the else path when false", () => {
+    test("returns the else path when false", () => {
       expect(
         when("hello", isStrictEqual("olleh"), {
           onTrue: constant("was true"),
@@ -52,7 +52,7 @@ describe("dataFirst", () => {
       ).toBe("was false");
     });
 
-    it("passes extra args to the functions", () => {
+    test("passes extra args to the functions", () => {
       expect(
         when(
           123,
@@ -71,19 +71,19 @@ describe("dataFirst", () => {
 
 describe("dataLast", () => {
   describe("without else", () => {
-    it("returns the happy path when true", () => {
+    test("returns the happy path when true", () => {
       expect(
         pipe("hello", when(isStrictEqual("hello"), constant("was true"))),
       ).toBe("was true");
     });
 
-    it("returns the identity when false", () => {
+    test("returns the identity when false", () => {
       expect(
         pipe("hello", when(isStrictEqual("olleh"), constant("was true"))),
       ).toBe("hello");
     });
 
-    it("passes extra args to the functions", () => {
+    test("passes extra args to the functions", () => {
       expect(
         map(
           [1, 2, 3, 4],
@@ -97,13 +97,13 @@ describe("dataLast", () => {
   });
 
   describe("with else", () => {
-    it("returns the happy path when true", () => {
+    test("returns the happy path when true", () => {
       expect(
         pipe("hello", when(isStrictEqual("hello"), constant("was true"))),
       ).toBe("was true");
     });
 
-    it("returns the else path when false", () => {
+    test("returns the else path when false", () => {
       expect(
         pipe(
           "hello",
@@ -116,7 +116,7 @@ describe("dataLast", () => {
     });
   });
 
-  it("passes extra args to the functions", () => {
+  test("passes extra args to the functions", () => {
     expect(
       map(
         [1, 2, 3, 4],
@@ -129,7 +129,7 @@ describe("dataLast", () => {
   });
 });
 
-it("can return other types", () => {
+test("can return other types", () => {
   expect(
     when(
       "hello",
@@ -148,7 +148,7 @@ it("can return other types", () => {
 });
 
 describe("recipes", () => {
-  it("acts as a coalesce tool", () => {
+  test("acts as a coalesce tool", () => {
     expect(
       map(
         [0, 1, 2, undefined, 4, undefined, 6],
@@ -157,7 +157,7 @@ describe("recipes", () => {
     ).toStrictEqual([0, 1, 2, "missing", 4, "missing", 6]);
   });
 
-  it("can replace defaultTo", () => {
+  test("can replace defaultTo", () => {
     // Nullish
     expect(
       map([undefined, null, 1], when(isNullish, constant(42))),

--- a/packages/remeda/src/zip.test-d.ts
+++ b/packages/remeda/src/zip.test-d.ts
@@ -1,3 +1,4 @@
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { zip } from "./zip";
 

--- a/packages/remeda/src/zip.test.ts
+++ b/packages/remeda/src/zip.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test, vi } from "vitest";
 import { first } from "./first";
 import { map } from "./map";
 import { pipe } from "./pipe";

--- a/packages/remeda/src/zipWith.test-d.ts
+++ b/packages/remeda/src/zipWith.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { zipWith } from "./zipWith";
 

--- a/packages/remeda/src/zipWith.test.ts
+++ b/packages/remeda/src/zipWith.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { pipe } from "./pipe";
 import { zipWith } from "./zipWith";
 

--- a/packages/remeda/test/lazyInvocationCounter.ts
+++ b/packages/remeda/test/lazyInvocationCounter.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { map } from "../src/map";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types

--- a/packages/remeda/tsconfig.json
+++ b/packages/remeda/tsconfig.json
@@ -20,7 +20,6 @@
     // MODULES
     "module": "Preserve",
     "moduleResolution": "Bundler",
-    "types": ["vitest/globals"],
 
     // EMIT
     "noEmit": true,

--- a/packages/remeda/vitest.config.ts
+++ b/packages/remeda/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    globals: true,
     coverage: {
       include: ["src/**"],
       exclude: [


### PR DESCRIPTION
Following recent changes to the vitest eslint plugin it became apparent that we should prefer importing vitest tools instead of using globals (it also makes it easier for LLMs to provide higher quality suggestions without requiring greater context).

Following that change, I also opted to standardize the usage of test/it so that we don't start bikeshedding on this.

Finally cleaned up some other smaller rules.