### PR TITLE
chore(jsr): fix workflow to fetch tags

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -262,6 +262,8 @@ jobs:
     steps:
       - name: ⬇️ Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: 🏷️ Repo Latest Released Version?
         id: latest-released


### PR DESCRIPTION
the workflow relies on tag data being available, but the default fetch action has an explicit --no-tags flag when fetching.