### PR TITLE
chore(jsr): remove version from jsr.json

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -167,7 +167,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: 🐢 Slow Types
-        run: npm --workspace=remeda run publish:jsr -- --dry-run
+        run: npm --workspace=remeda run publish:jsr -- --dry-run --set-version 0.0.0
 
   preview:
     name: 🧑‍🔬 Preview

--- a/packages/remeda/jsr.json
+++ b/packages/remeda/jsr.json
@@ -2,7 +2,6 @@
   "$schema": "https://jsr.io/schema/config-file.v1.json",
 
   "name": "@remeda/remeda",
-  "version": "2.0.0",
   "exports": "./src/index.ts",
   "publish": {
     "include": ["./src/**/*.ts", "./LICENSE", "./README.md"],


### PR DESCRIPTION
We inject the version manually via a cli flag, but it would fail if the jsr.json file itself already has a version.