### PR TITLE
fix(setPath): support interfaces

### DIFF
--- a/packages/remeda/src/setPath.test-d.ts
+++ b/packages/remeda/src/setPath.test-d.ts
@@ -29,12 +29,22 @@ describe("data first", () => {
     setPath(TEST_OBJECT, ["a", "z"], 123);
   });
 
-  test("should correctly type partial paths", () => {
+  test("should correctly type partial paths (objects)", () => {
     // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
     setPath(TEST_OBJECT, ["a", "b"] as const, 123);
 
     // Like this:
     setPath(TEST_OBJECT, ["a", "b"] as const, { c: 123 });
+  });
+
+  test("should correctly type partial paths (arrays)", () => {
+    const DATA = [[]] as Array<Array<{ c: number }>>;
+
+    // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
+    setPath(DATA, [1, 2] as const, 123);
+
+    // Like this:
+    setPath(DATA, [1, 2] as const, { c: 123 });
   });
 });
 
@@ -62,4 +72,13 @@ describe("data last", () => {
     // Like this:
     pipe(TEST_OBJECT, setPath(["a", "b"] as const, { c: 123 }));
   });
+});
+
+// @see https://github.com/remeda/remeda/issues/990
+test("support interfaces (issue #990)", () => {
+  interface User {
+    name: { first: string };
+  }
+
+  setPath({ name: { first: "John" } } as User, ["name", "first"], "Jane");
 });

--- a/packages/remeda/src/setPath.test-d.ts
+++ b/packages/remeda/src/setPath.test-d.ts
@@ -46,6 +46,15 @@ describe("data first", () => {
     // Like this:
     setPath(DATA, [1, 2] as const, { c: 123 });
   });
+
+  test("should correctly type an empty path", () => {
+    // @ts-expect-error [ts2345] - this path should yield a type of
+    // typeof TEST_OBJECT
+    setPath(TEST_OBJECT, [] as const, 123);
+
+    // Like this:
+    setPath(TEST_OBJECT, [] as const, { a: { b: { c: 123 }, e: [] } });
+  });
 });
 
 describe("data last", () => {

--- a/packages/remeda/src/setPath.test-d.ts
+++ b/packages/remeda/src/setPath.test-d.ts
@@ -12,49 +12,47 @@ declare const TEST_OBJECT: {
   y?: number;
 };
 
-describe("data first", () => {
-  test("should correctly type value argument", () => {
-    // @ts-expect-error [ts2345] - this path should yield a type of number
-    setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], "hello");
+test("should correctly type value argument", () => {
+  // @ts-expect-error [ts2345] - this path should yield a type of number
+  setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], "hello");
 
-    // Like this:
-    setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], 123);
-  });
+  // Like this:
+  setPath(TEST_OBJECT, ["a", "e", 1, "f", "g"], 123);
+});
 
-  test("should correctly type path argument", () => {
-    // @ts-expect-error [ts2322] - 'hello' isn't a valid path
-    setPath(TEST_OBJECT, ["a", "hello"], "hello");
+test("should correctly type path argument", () => {
+  // @ts-expect-error [ts2322] - 'hello' isn't a valid path
+  setPath(TEST_OBJECT, ["a", "hello"], "hello");
 
-    // Like this:
-    setPath(TEST_OBJECT, ["a", "z"], 123);
-  });
+  // Like this:
+  setPath(TEST_OBJECT, ["a", "z"], 123);
+});
 
-  test("should correctly type partial paths (objects)", () => {
-    // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
-    setPath(TEST_OBJECT, ["a", "b"] as const, 123);
+test("should correctly type partial paths (objects)", () => {
+  // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
+  setPath(TEST_OBJECT, ["a", "b"] as const, 123);
 
-    // Like this:
-    setPath(TEST_OBJECT, ["a", "b"] as const, { c: 123 });
-  });
+  // Like this:
+  setPath(TEST_OBJECT, ["a", "b"] as const, { c: 123 });
+});
 
-  test("should correctly type partial paths (arrays)", () => {
-    const DATA = [[]] as Array<Array<{ c: number }>>;
+test("should correctly type partial paths (arrays)", () => {
+  const DATA = [[]] as Array<Array<{ c: number }>>;
 
-    // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
-    setPath(DATA, [1, 2] as const, 123);
+  // @ts-expect-error [ts2345] - this path should yield a type of { c: number }
+  setPath(DATA, [1, 2] as const, 123);
 
-    // Like this:
-    setPath(DATA, [1, 2] as const, { c: 123 });
-  });
+  // Like this:
+  setPath(DATA, [1, 2] as const, { c: 123 });
+});
 
-  test("should correctly type an empty path", () => {
-    // @ts-expect-error [ts2345] - this path should yield a type of
-    // typeof TEST_OBJECT
-    setPath(TEST_OBJECT, [] as const, 123);
+test("should correctly type an empty path", () => {
+  // @ts-expect-error [ts2345] - this path should yield a type of
+  // typeof TEST_OBJECT
+  setPath(TEST_OBJECT, [] as const, 123);
 
-    // Like this:
-    setPath(TEST_OBJECT, [] as const, { a: { b: { c: 123 }, e: [] } });
-  });
+  // Like this:
+  setPath(TEST_OBJECT, [] as const, { a: { b: { c: 123 }, e: [] } });
 });
 
 describe("data last", () => {

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -1,15 +1,10 @@
 import { purry } from "./purry";
 
 type Path<T, Prefix extends ReadonlyArray<unknown> = []> =
-  T extends ReadonlyArray<unknown>
-    ? Path<T[number], [...Prefix, number]> | Prefix
-    : T extends Record<PropertyKey, unknown>
-      ? PathsOfObject<T, Prefix> | Prefix
-      : Prefix;
-
-type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
-  [K in keyof T]-?: Path<T[K], readonly [...Prefix, K]>;
-}[keyof T];
+  | (T extends ReadonlyArray<unknown>
+      ? Path<T[number], readonly [...Prefix, number]>
+      : { [K in keyof T]-?: Path<T[K], readonly [...Prefix, K]> }[keyof T])
+  | Prefix;
 
 type ValueAtPath<T, TPath> = TPath extends readonly [
   infer Head extends keyof T,

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -76,7 +76,7 @@ export function setPath<
   T,
   Path extends Paths<T>,
   // TODO [>2] -- TODO: The following eslint is solvable by inlining Value and wrapping the T parameter with `NoInfer` (e.g. `ValueAtPath<NoInfer<T>, TPath>); to prevent typescript from inferring it as `unknown`. This is only available in TS 5.4, which is above what we currently support (5.1).
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- Se TODO above...
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- See TODO above...
   Value extends ValueAtPath<T, Path>,
 >(path: Path, value: Value): (data: T) => T;
 

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -1,17 +1,20 @@
 import { purry } from "./purry";
 
-// IMPORTANT: All Prefix arrays need to be `readonly` because this type is used
-// to define the type for the path **param** in `setPath`, and readonly arrays
-// don't extend mutable arrays, so they won't satisfy the param.
-type Paths<T, Prefix extends ReadonlyArray<unknown> = readonly []> =
-  T extends ReadonlyArray<unknown>
-    ? Paths<T[number], readonly [...Prefix, number]> | Prefix
-    : T extends object
-      ? PathsOfObject<T, Prefix> | Prefix
-      : Prefix;
+type Paths<T, Prefix extends ReadonlyArray<unknown> = []> =
+  | Prefix
+  | (T extends ReadonlyArray<unknown>
+      ? Paths<T[number], [...Prefix, number]>
+      : T extends object
+        ? PathsOfObject<T, Prefix>
+        : never) extends infer U
+  ? // All Prefix arrays need to be `readonly` because this type is used to
+    // define the type for the path **param** in `setPath`, and readonly arrays
+    // don't extend mutable arrays, so they won't satisfy the param.
+    Readonly<U>
+  : never;
 
 type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
-  [K in keyof T]-?: Paths<T[K], readonly [...Prefix, K]>;
+  [K in keyof T]-?: Paths<T[K], [...Prefix, K]>;
 }[keyof T];
 
 type ValueAtPath<T, Path> = Path extends readonly [

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -3,16 +3,16 @@ import { purry } from "./purry";
 // IMPORTANT: All Prefix arrays need to be `readonly` because this type is used
 // to define the type for the path **param** in `setPath`, and readonly arrays
 // don't extend mutable arrays, so they won't satisfy the param.
-type Paths<T, Prefix extends ReadonlyArray<unknown> = readonly []> =
-  | Prefix
-  | (T extends ReadonlyArray<unknown>
-      ? Paths<T[number], readonly [...Prefix, number]>
-      : T extends object
-        ? PathsOfObject<T, Prefix>
-        : never);
+type Paths<T, Prefix extends ReadonlyArray<unknown> = []> = Readonly<
+  T extends ReadonlyArray<unknown>
+    ? Paths<T[number], [...Prefix, number]> | Prefix
+    : T extends object
+      ? PathsOfObject<T, Prefix> | Prefix
+      : Prefix
+>;
 
 type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
-  [K in keyof T]-?: Paths<T[K], readonly [...Prefix, K]>;
+  [K in keyof T]-?: Paths<T[K], [...Prefix, K]>;
 }[keyof T];
 
 type ValueAtPath<T, Path> = Path extends readonly [

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -3,16 +3,15 @@ import { purry } from "./purry";
 // IMPORTANT: All Prefix arrays need to be `readonly` because this type is used
 // to define the type for the path **param** in `setPath`, and readonly arrays
 // don't extend mutable arrays, so they won't satisfy the param.
-type Paths<T, Prefix extends ReadonlyArray<unknown> = []> = Readonly<
+type Paths<T, Prefix extends ReadonlyArray<unknown> = readonly []> =
   T extends ReadonlyArray<unknown>
-    ? Paths<T[number], [...Prefix, number]> | Prefix
+    ? Paths<T[number], readonly [...Prefix, number]> | Prefix
     : T extends object
       ? PathsOfObject<T, Prefix> | Prefix
-      : Prefix
->;
+      : Prefix;
 
 type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
-  [K in keyof T]-?: Paths<T[K], [...Prefix, K]>;
+  [K in keyof T]-?: Paths<T[K], readonly [...Prefix, K]>;
 }[keyof T];
 
 type ValueAtPath<T, Path> = Path extends readonly [

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -1,21 +1,36 @@
+import type { ValueOf } from "type-fest";
+import type { RemedaTypeError } from "./internal/types/RemedaTypeError";
 import { purry } from "./purry";
 
 type Paths<T, Prefix extends ReadonlyArray<unknown> = []> =
   | Prefix
-  | (T extends ReadonlyArray<unknown>
-      ? Paths<T[number], [...Prefix, number]>
-      : T extends object
-        ? PathsOfObject<T, Prefix>
-        : never) extends infer U
-  ? // All Prefix arrays need to be `readonly` because this type is used to
-    // define the type for the path **param** in `setPath`, and readonly arrays
-    // don't extend mutable arrays, so they won't satisfy the param.
-    Readonly<U>
+  | (T extends object
+      ? ValueOf<{
+          [K in ProperKeyOf<T>]-?: Paths<T[K], [...Prefix, K]>;
+        }>
+      : RemedaTypeError<
+          "setPath",
+          "Can only compute paths objects",
+          { type: never; metadata: T }
+        >) extends infer Path
+  ? // The Paths type is used to define the path param in `setPath`. In order
+    // for both mutable arrays and readonly arrays to be supported we need to
+    // make all results `readonly` (because mutable arrays extend readonly
+    // arrays, but not the other way around). Because the result of Paths is
+    // a union of arrays we need to distribute Result so that the operator is
+    // applied to each member separately.
+    Readonly<Path>
   : never;
 
-type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
-  [K in keyof T]-?: Paths<T[K], [...Prefix, K]>;
-}[keyof T];
+/**
+ * Array objects have all Array.prototype keys in their "keyof" type, which
+ * is not what we'd expect from the operator. We only want the numeric keys
+ * which represent proper elements of the array.
+ */
+type ProperKeyOf<T> = Extract<
+  keyof T,
+  T extends ReadonlyArray<unknown> ? number : keyof T
+>;
 
 type ValueAtPath<T, Path> = Path extends readonly [
   infer Head extends keyof T,
@@ -39,10 +54,10 @@ type ValueAtPath<T, Path> = Path extends readonly [
  * @dataFirst
  * @category Object
  */
-export function setPath<T, TPath extends Paths<T>>(
+export function setPath<T, Path extends Paths<T>>(
   data: T,
-  path: TPath,
-  value: ValueAtPath<T, TPath>,
+  path: Path,
+  value: ValueAtPath<T, Path>,
 ): T;
 
 /**
@@ -59,10 +74,11 @@ export function setPath<T, TPath extends Paths<T>>(
  */
 export function setPath<
   T,
-  TPath extends Paths<T>,
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- TODO: This is solvable by inlining Value and wrapping the T parameter with `NoInfer` (e.g. `ValueAtPath<NoInfer<T>, TPath>); to prevent typescript from inferring it as `unknown`. This is only available in TS 5.4, which is above what we currently support (5.1).
-  Value extends ValueAtPath<T, TPath>,
->(path: TPath, value: Value): (data: T) => T;
+  Path extends Paths<T>,
+  // TODO [>2] -- TODO: The following eslint is solvable by inlining Value and wrapping the T parameter with `NoInfer` (e.g. `ValueAtPath<NoInfer<T>, TPath>); to prevent typescript from inferring it as `unknown`. This is only available in TS 5.4, which is above what we currently support (5.1).
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- Se TODO above...
+  Value extends ValueAtPath<T, Path>,
+>(path: Path, value: Value): (data: T) => T;
 
 export function setPath(...args: ReadonlyArray<unknown>): unknown {
   return purry(setPathImplementation, args);

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -1,6 +1,9 @@
 import { purry } from "./purry";
 
-type Path<T, Prefix extends ReadonlyArray<unknown> = []> =
+// IMPORTANT: All Prefix arrays need to be `readonly` because this type is used
+// to define the type for the path **param** in `setPath`, and readonly arrays
+// don't extend mutable arrays, so they won't satisfy the param.
+type Path<T, Prefix extends ReadonlyArray<unknown> = readonly []> =
   | (T extends ReadonlyArray<unknown>
       ? Path<T[number], readonly [...Prefix, number]>
       : { [K in keyof T]-?: Path<T[K], readonly [...Prefix, K]> }[keyof T])

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -7,7 +7,9 @@ type Paths<T, Prefix extends ReadonlyArray<unknown> = readonly []> =
   | Prefix
   | (T extends ReadonlyArray<unknown>
       ? Paths<T[number], readonly [...Prefix, number]>
-      : PathsOfObject<T, Prefix>);
+      : T extends object
+        ? PathsOfObject<T, Prefix>
+        : never);
 
 type PathsOfObject<T, Prefix extends ReadonlyArray<unknown>> = {
   [K in keyof T]-?: Paths<T[K], readonly [...Prefix, K]>;


### PR DESCRIPTION
Fixes: #990

Everything in typescript is an object (kinda) so we don't need to check it in the condition and instead assume that users aren't doing something weird (but even then try to make it work for them via whatever TypeScript defines as the keyof for that thing).

Additionally we had a minor issue with arrays where a partial path wouldn't match properly because of a missing `readonly` which prevents readonly tuples from satisfying the result.