### PR TITLE
docs: fix alignment issue caused by search modal

### DIFF
--- a/packages/docs/src/layouts/base.astro
+++ b/packages/docs/src/layouts/base.astro
@@ -27,9 +27,11 @@ const { title } = Astro.props;
     <title>{`${title === undefined ? "" : `${title} - `}Remeda`}</title>
     <script is:inline src="/dist/scripts/init-theme.js"></script>
   </head>
-  <body class="container mx-auto flex flex-col items-stretch">
-    <Header />
-    <slot />
+  <body>
+    <div class="container mx-auto flex flex-col items-stretch">
+      <Header />
+      <slot />
+    </div>
     <script is:inline fetchpriority="low" src="/sandbox.js" type="module"
     ></script>
   </body>


### PR DESCRIPTION
When the search modal disables scrolling, it messes with the alignment of the primary content because it uses the body-tag to for its `container mx-auto` classes. Moving these to a child allows the algoria search modal to disable the scroll without messing with the content.

Resolves #1147.