### PR TITLE
feat(stringToPath): improve compability with Lodash

### DIFF
--- a/packages/remeda/src/pathOr.test-d.ts
+++ b/packages/remeda/src/pathOr.test-d.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { stringToPath } from "./stringToPath";
+import { pathOr } from "./pathOr";
+
+// @see https://github.com/remeda/remeda/issues/779
+describe("examples from lodash migration (issue #779)", () => {
+  test("using stringToPath", () => {
+    expectTypeOf(
+      pathOr({ a: [{ b: 123 }] }, stringToPath("a[0].b"), 456),
+    ).toEqualTypeOf<number>();
+  });
+});

--- a/packages/remeda/src/stringToPath.test-d.ts
+++ b/packages/remeda/src/stringToPath.test-d.ts
@@ -21,13 +21,15 @@ test("single array index", () => {
 
 describe("dynamic strings are not inferred", () => {
   test("primitive string", () => {
-    expectTypeOf(stringToPath("foo" as string)).toEqualTypeOf<never>();
+    expectTypeOf(stringToPath("foo" as string)).toEqualTypeOf<
+      Array<string | number>
+    >();
   });
 
   test("template literals", () => {
-    expectTypeOf(
-      stringToPath(`foo.${"bar" as string}[baz]`),
-    ).toEqualTypeOf<never>();
+    expectTypeOf(stringToPath(`foo.${"bar" as string}[baz]`)).toEqualTypeOf<
+      Array<string | number>
+    >();
   });
 });
 

--- a/packages/remeda/src/stringToPath.test-d.ts
+++ b/packages/remeda/src/stringToPath.test-d.ts
@@ -1,41 +1,259 @@
-import { expectTypeOf, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { stringToPath } from "./stringToPath";
 
-test("should convert a string to a deeply nested path", () => {
-  const result = stringToPath("a.b[0].c");
-
-  expectTypeOf(result).toEqualTypeOf<["a", "b", "0", "c"]>();
+test("empty string", () => {
+  expectTypeOf(stringToPath("")).toEqualTypeOf<[]>();
 });
 
-test("simple const string are inferred", () => {
-  const result = stringToPath("foo[bar.baz].qui");
-
-  expectTypeOf(result).toEqualTypeOf<["foo", "bar.baz", "qui"]>();
+test("single property", () => {
+  expectTypeOf(stringToPath("foo")).toEqualTypeOf<["foo"]>();
 });
 
-test("should handle long paths", () => {
-  const result = stringToPath(
-    "lorem.ipsum[dolor.sit].amet.con.sec.tetur[adi.pisc.ing].elit.42",
-  );
-
-  expectTypeOf(result).toEqualTypeOf<
-    [
-      "lorem",
-      "ipsum",
-      "dolor.sit",
-      "amet",
-      "con",
-      "sec",
-      "tetur",
-      "adi.pisc.ing",
-      "elit",
-      "42",
-    ]
-  >();
+test("single array index", () => {
+  expectTypeOf(stringToPath("123")).toEqualTypeOf<[123]>();
 });
 
-test("dynamic strings cannot be inferred", () => {
-  const result = stringToPath(`foo.${"bar" as string}[baz]`);
+describe("dynamic strings are not inferred", () => {
+  test("primitive string", () => {
+    expectTypeOf(stringToPath("foo" as string)).toEqualTypeOf<never>();
+  });
 
-  expectTypeOf(result).toEqualTypeOf<never>();
+  test("template literals", () => {
+    expectTypeOf(
+      stringToPath(`foo.${"bar" as string}[baz]`),
+    ).toEqualTypeOf<never>();
+  });
+});
+
+describe("dot notation", () => {
+  test("short chain", () => {
+    expectTypeOf(stringToPath("foo.bar")).toEqualTypeOf<["foo", "bar"]>();
+  });
+
+  test("long chain", () => {
+    expectTypeOf(
+      stringToPath("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z"),
+    ).toEqualTypeOf<
+      [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "y",
+        "z",
+      ]
+    >();
+  });
+
+  test("array index before", () => {
+    expectTypeOf(stringToPath("123.foo")).toEqualTypeOf<[123, "foo"]>();
+  });
+
+  test("array index after", () => {
+    expectTypeOf(stringToPath("foo.123")).toEqualTypeOf<["foo", 123]>();
+  });
+});
+
+describe("square bracket notation", () => {
+  test("array index", () => {
+    expectTypeOf(stringToPath("foo[123]")).toEqualTypeOf<["foo", 123]>();
+  });
+
+  test("array index with dot notation after access", () => {
+    expectTypeOf(stringToPath("foo[123].bar")).toEqualTypeOf<
+      ["foo", 123, "bar"]
+    >();
+  });
+
+  test("array index with dot notation before access", () => {
+    expectTypeOf(stringToPath("foo.bar[123]")).toEqualTypeOf<
+      ["foo", "bar", 123]
+    >();
+  });
+
+  test("sequential array index accesses", () => {
+    expectTypeOf(stringToPath("foo[123][456]")).toEqualTypeOf<
+      ["foo", 123, 456]
+    >();
+  });
+
+  test("complex mix of array index and chained properties", () => {
+    expectTypeOf(stringToPath("foo[123].bar.baz[456][789].qux")).toEqualTypeOf<
+      ["foo", 123, "bar", "baz", 456, 789, "qux"]
+    >();
+  });
+
+  test("unquoted object property access", () => {
+    expectTypeOf(stringToPath("foo[bar]")).toEqualTypeOf<["foo", "bar"]>();
+    expectTypeOf(stringToPath("foo[bar].baz")).toEqualTypeOf<
+      ["foo", "bar", "baz"]
+    >();
+  });
+
+  test("single quoted object property access", () => {
+    expectTypeOf(stringToPath("foo['bar']")).toEqualTypeOf<["foo", "bar"]>();
+    expectTypeOf(stringToPath("foo['bar'].baz")).toEqualTypeOf<
+      ["foo", "bar", "baz"]
+    >();
+  });
+
+  test("double quoted object property access", () => {
+    expectTypeOf(stringToPath('foo["bar"]')).toEqualTypeOf<["foo", "bar"]>();
+    expectTypeOf(stringToPath('foo["bar"].baz')).toEqualTypeOf<
+      ["foo", "bar", "baz"]
+    >();
+  });
+
+  test("recursive chained properties", () => {
+    expectTypeOf(stringToPath("foo[bar.baz]")).toEqualTypeOf<
+      ["foo", "bar", "baz"]
+    >();
+  });
+
+  test("2d array access", () => {
+    expectTypeOf(stringToPath("123[456]")).toEqualTypeOf<[123, 456]>();
+  });
+
+  test("square bracket for a number", () => {
+    expectTypeOf(stringToPath("[123]")).toEqualTypeOf<[123]>();
+  });
+
+  test("properties with numbers", () => {
+    expectTypeOf(stringToPath("foo[abc123]")).toEqualTypeOf<
+      ["foo", "abc123"]
+    >();
+    expectTypeOf(stringToPath("foo[123abc]")).toEqualTypeOf<
+      ["foo", "123abc"]
+    >();
+  });
+});
+
+describe("quoted properties edge-cases", () => {
+  test("hyphens", () => {
+    expectTypeOf(stringToPath("foo['bar-baz']")).toEqualTypeOf<
+      ["foo", "bar-baz"]
+    >();
+  });
+
+  test("underscores", () => {
+    expectTypeOf(stringToPath("foo['bar_baz']")).toEqualTypeOf<
+      ["foo", "bar_baz"]
+    >();
+  });
+
+  test("spaces", () => {
+    expectTypeOf(stringToPath("foo['bar baz']")).toEqualTypeOf<
+      ["foo", "bar baz"]
+    >();
+  });
+
+  test("dots", () => {
+    expectTypeOf(stringToPath("foo['bar.baz']")).toEqualTypeOf<
+      ["foo", "bar.baz"]
+    >();
+  });
+
+  test("square brackets", () => {
+    expectTypeOf(stringToPath("foo['bar[baz]']")).toEqualTypeOf<
+      ["foo", "bar[baz]"]
+    >();
+  });
+
+  test("numbers", () => {
+    expectTypeOf(stringToPath("foo['123']")).toEqualTypeOf<["foo", "123"]>();
+  });
+});
+
+describe("empty segments edge-cases", () => {
+  test("empty quoted access", () => {
+    expectTypeOf(stringToPath("foo[''].bar")).toEqualTypeOf<
+      ["foo", "", "bar"]
+    >();
+  });
+});
+
+describe("known limitations", () => {
+  test("nested object access", () => {
+    expectTypeOf(stringToPath("foo[bar[baz]]")).toEqualTypeOf<
+      // @ts-expect-error [ts2344] -- This is TypeScript! we can't count parentheses (can we? would it be crazy complex?)
+      ["foo", "bar", "baz"]
+    >();
+  });
+
+  test("two sequential dots", () => {
+    // @ts-expect-error [ts2344] -- Is this even valuable to support?! What does an empty property even mean, can an object have an empty property?! If users need this kind of access they can use the quoted access syntax which does work (e.g., `foo[''].bar`).
+    expectTypeOf(stringToPath("foo..bar")).toEqualTypeOf<["foo", "", "bar"]>();
+  });
+
+  test("empty unquoted access", () => {
+    // @ts-expect-error [ts2344] -- Is this even valuable to support?! What does an empty property even mean, can an object have an empty property?! If users need this kind of access they can use the quoted access syntax which does work (e.g., `foo[''].bar`).
+    expectTypeOf(stringToPath("foo[].bar")).toEqualTypeOf<["foo", "", "bar"]>();
+  });
+
+  test("using slash as an escape character", () => {
+    expectTypeOf(stringToPath(String.raw`a['b\'c']`)).toEqualTypeOf<
+      // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+      ["a", "b'c"]
+    >();
+
+    expectTypeOf(stringToPath(String.raw`a["b\\"c"]`)).toEqualTypeOf<
+      // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+      ["a", 'b"c']
+    >();
+
+    expectTypeOf(stringToPath(String.raw`a['b\\c']`)).toEqualTypeOf<
+      // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+      // eslint-disable-next-line unicorn/prefer-string-raw
+      ["a", "b\\c"]
+    >();
+  });
+
+  test("whitespace handling", () => {
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[ 'bar' ]")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[' bar']")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo['bar ']")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[' bar ']")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[ bar]")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[bar ]")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[ bar ]")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo[ 123 ]")).toEqualTypeOf<["foo", 123]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo. bar")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo .bar")).toEqualTypeOf<["foo", "bar"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath(" foo")).toEqualTypeOf<["foo"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath("foo ")).toEqualTypeOf<["foo"]>();
+    // @ts-expect-error [ts2344] -- This is TypeScript! we are not going to build a whole text parser!
+    expectTypeOf(stringToPath(" foo ")).toEqualTypeOf<["foo"]>();
+  });
 });

--- a/packages/remeda/src/stringToPath.test.ts
+++ b/packages/remeda/src/stringToPath.test.ts
@@ -1,61 +1,243 @@
+/* eslint-disable unicorn/prefer-string-raw --
+ * We want to have the same inputs as the type-tests.
+ */
+
 import { describe, expect, test } from "vitest";
 import { stringToPath } from "./stringToPath";
 
-test("empty path", () => {
+//! IMPORTANT: The tests in this file need to be synced with the type tests so that we can ensure that the function's runtime implementation returns the same values as the functions type computes. This is critical for this utility because its main purpose is to couple the path string parsing logic with the type so that it could be used in utility functions that take a strictly typed path array as input (e.g. `pathOr`, `setPath`, etc...).
+
+test("empty string", () => {
   expect(stringToPath("")).toStrictEqual([]);
 });
 
-test("single propName", () => {
-  expect(stringToPath("a")).toStrictEqual(["a"]);
+test("single property", () => {
+  expect(stringToPath("foo")).toStrictEqual(["foo"]);
 });
 
-test("single index", () => {
-  expect(stringToPath("[0]")).toStrictEqual(["0"]);
+test("single array index", () => {
+  expect(stringToPath("123")).toStrictEqual([123]);
 });
 
-test("should handle short path with only bracket access", () => {
-  expect(stringToPath("foo[bar]")).toStrictEqual(["foo", "bar"]);
-});
-
-test("should handle bracket access at the end", () => {
-  const res = stringToPath("foo.bar[3]");
-
-  expect(res).toStrictEqual(["foo", "bar", "3"]);
-});
-
-test("should convert a string to a deeply nested path", () => {
-  expect(stringToPath("foo.bar[3].baz")).toStrictEqual([
-    "foo",
-    "bar",
-    "3",
-    "baz",
-  ]);
-});
-
-test("should handle nested dot paths", () => {
-  expect(stringToPath("foo[bar.baz].qui.che")).toStrictEqual([
-    "foo",
-    "bar.baz",
-    "qui",
-    "che",
-  ]);
-});
-
-describe("erroneous edge-cases", () => {
-  test("index with string value", () => {
-    // The function accepts these, is this a valid input?
-    expect(stringToPath("[a]")).toStrictEqual(["a"]);
+describe("dot notation", () => {
+  test("short chain", () => {
+    expect(stringToPath("foo.bar")).toStrictEqual(["foo", "bar"]);
   });
 
-  test("prop name with numbers", () => {
-    // The function accepts these, is this a valid input?
-    expect(stringToPath("1")).toStrictEqual(["1"]);
+  test("long chain", () => {
+    expect(
+      stringToPath("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z"),
+    ).toStrictEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+      "q",
+      "r",
+      "s",
+      "t",
+      "u",
+      "v",
+      "w",
+      "x",
+      "y",
+      "z",
+    ]);
   });
 
-  test.each(
-    // ¯\_(ツ)_/¯
-    [".", "..", "[", "]", "[[", "]]", "[.", "].", ".[", ".]"],
-  )("malformed input: %s", (input) => {
-    expect(stringToPath(input)).toStrictEqual([input]);
+  test("array index before", () => {
+    expect(stringToPath("123.foo")).toStrictEqual([123, "foo"]);
+  });
+
+  test("array index after", () => {
+    expect(stringToPath("foo.123")).toStrictEqual(["foo", 123]);
+  });
+});
+
+describe("square bracket notation", () => {
+  test("array index", () => {
+    expect(stringToPath("foo[123]")).toStrictEqual(["foo", 123]);
+  });
+
+  test("array index with dot notation after access", () => {
+    expect(stringToPath("foo[123].bar")).toStrictEqual(["foo", 123, "bar"]);
+  });
+
+  test("array index with dot notation before access", () => {
+    expect(stringToPath("foo.bar[123]")).toStrictEqual(["foo", "bar", 123]);
+  });
+
+  test("sequential array index accesses", () => {
+    expect(stringToPath("foo[123][456]")).toStrictEqual(["foo", 123, 456]);
+  });
+
+  test("complex mix of array index and chained properties", () => {
+    expect(stringToPath("foo[123].bar.baz[456][789].qux")).toStrictEqual([
+      "foo",
+      123,
+      "bar",
+      "baz",
+      456,
+      789,
+      "qux",
+    ]);
+  });
+
+  test("unquoted object property access", () => {
+    expect(stringToPath("foo[bar]")).toStrictEqual(["foo", "bar"]);
+    expect(stringToPath("foo[bar].baz")).toStrictEqual(["foo", "bar", "baz"]);
+  });
+
+  test("single quoted object property access", () => {
+    expect(stringToPath("foo['bar']")).toStrictEqual(["foo", "bar"]);
+    expect(stringToPath("foo['bar'].baz")).toStrictEqual(["foo", "bar", "baz"]);
+  });
+
+  test("double quoted object property access", () => {
+    expect(stringToPath('foo["bar"]')).toStrictEqual(["foo", "bar"]);
+    expect(stringToPath('foo["bar"].baz')).toStrictEqual(["foo", "bar", "baz"]);
+  });
+
+  test("recursive chained properties", () => {
+    expect(stringToPath("foo[bar.baz]")).toStrictEqual(["foo", "bar", "baz"]);
+  });
+
+  test("2d array access", () => {
+    expect(stringToPath("123[456]")).toStrictEqual([123, 456]);
+  });
+
+  test("square bracket for a number", () => {
+    expect(stringToPath("[123]")).toStrictEqual([123]);
+  });
+
+  test("properties with numbers", () => {
+    expect(stringToPath("foo[abc123]")).toStrictEqual(["foo", "abc123"]);
+    expect(stringToPath("foo[123abc]")).toStrictEqual(["foo", "123abc"]);
+  });
+});
+
+describe("quoted properties edge-cases", () => {
+  test("hyphens", () => {
+    expect(stringToPath("foo['bar-baz']")).toStrictEqual(["foo", "bar-baz"]);
+  });
+
+  test("underscores", () => {
+    expect(stringToPath("foo['bar_baz']")).toStrictEqual(["foo", "bar_baz"]);
+  });
+
+  test("spaces", () => {
+    expect(stringToPath("foo['bar baz']")).toStrictEqual(["foo", "bar baz"]);
+    expect(stringToPath("foo[' bar']")).toStrictEqual(["foo", " bar"]);
+    expect(stringToPath("foo['bar ']")).toStrictEqual(["foo", "bar "]);
+    expect(stringToPath("foo[' bar ']")).toStrictEqual(["foo", " bar "]);
+  });
+
+  test("dots", () => {
+    expect(stringToPath("foo['bar.baz']")).toStrictEqual(["foo", "bar.baz"]);
+  });
+
+  test("square brackets", () => {
+    expect(stringToPath("foo['bar[baz]']")).toStrictEqual(["foo", "bar[baz]"]);
+  });
+
+  test("numbers", () => {
+    expect(stringToPath("foo['123']")).toStrictEqual(["foo", "123"]);
+  });
+
+  test("non-matching quotes", () => {
+    expect(stringToPath("foo['bar\"]")).toStrictEqual(["foo", "'bar\""]);
+    expect(stringToPath("foo[\"bar']")).toStrictEqual(["foo", "\"bar'"]);
+  });
+
+  test("missing quote", () => {
+    expect(stringToPath("foo['bar]")).toStrictEqual(["foo", "'bar"]);
+    expect(stringToPath('foo["bar]')).toStrictEqual(["foo", '"bar']);
+    expect(stringToPath("foo[bar']")).toStrictEqual(["foo", "bar'"]);
+    expect(stringToPath('foo[bar"]')).toStrictEqual(["foo", 'bar"']);
+  });
+});
+
+describe("empty segments edge-cases", () => {
+  test("empty quoted access", () => {
+    expect(stringToPath("foo[''].bar")).toStrictEqual(["foo", "", "bar"]);
+  });
+});
+
+// We make sure that our limitations from the type system are always reflected
+// by the runtime implementation, so that our type reflects the real output of
+// our function. Because the type is more complicated than the runtime
+// implementation we use the type tests as the specification for the
+// runtime implementation.
+describe("known type limitations", () => {
+  test.todo("nested object access", () => {
+    expect(stringToPath("foo[bar[baz]]")).toStrictEqual([
+      "foo",
+      "bar[baz",
+      "]",
+    ]);
+  });
+
+  test("two sequential dots", () => {
+    expect(stringToPath("foo..bar")).toStrictEqual(["foo", "bar"]);
+  });
+
+  test("empty unquoted access", () => {
+    expect(stringToPath("foo[].bar")).toStrictEqual(["foo", "bar"]);
+  });
+
+  test("using backslash to escape a quote", () => {
+    expect(stringToPath("a['b\\'c']")).toStrictEqual(["a", "b\\'c"]);
+  });
+
+  test("using backslash to escape a double-quote", () => {
+    expect(stringToPath('a["b\\"c"]')).toStrictEqual(["a", 'b\\"c']);
+  });
+
+  test("using a backslash to escape a backslash", () => {
+    expect(stringToPath("a['b\\\\c']")).toStrictEqual(["a", "b\\\\c"]);
+  });
+
+  describe("whitespace handling", () => {
+    test("between the brackets and the quotes", () => {
+      expect(stringToPath("foo[ 'bar']")).toStrictEqual(["foo", " 'bar'"]);
+      expect(stringToPath("foo['bar' ]")).toStrictEqual(["foo", "'bar' "]);
+      expect(stringToPath("foo[ 'bar' ]")).toStrictEqual(["foo", " 'bar' "]);
+    });
+
+    test("between the brackets and the property", () => {
+      expect(stringToPath("foo[ bar]")).toStrictEqual(["foo", " bar"]);
+      expect(stringToPath("foo[bar ]")).toStrictEqual(["foo", "bar "]);
+      expect(stringToPath("foo[ bar ]")).toStrictEqual(["foo", " bar "]);
+    });
+
+    test("between the brackets and an array index", () => {
+      expect(stringToPath("foo[ 123]")).toStrictEqual(["foo", " 123"]);
+      expect(stringToPath("foo[123 ]")).toStrictEqual(["foo", "123 "]);
+      expect(stringToPath("foo[ 123 ]")).toStrictEqual(["foo", " 123 "]);
+    });
+
+    test("around dots", () => {
+      expect(stringToPath("foo .bar")).toStrictEqual(["foo ", "bar"]);
+      expect(stringToPath("foo. bar")).toStrictEqual(["foo", " bar"]);
+      expect(stringToPath("foo . bar")).toStrictEqual(["foo ", " bar"]);
+    });
+
+    test("around prop names", () => {
+      expect(stringToPath("foo ")).toStrictEqual(["foo "]);
+      expect(stringToPath(" foo")).toStrictEqual([" foo"]);
+      expect(stringToPath(" foo ")).toStrictEqual([" foo "]);
+    });
   });
 });

--- a/packages/remeda/src/stringToPath.ts
+++ b/packages/remeda/src/stringToPath.ts
@@ -1,4 +1,4 @@
-import type { IsStringLiteral } from "type-fest";
+import type { IsNumericLiteral, IsStringLiteral } from "type-fest";
 import type { If } from "./internal/types/If";
 
 const PATH_RE = /^(?:\.?(?<propName>[^.[\]]+)|\[(?<index>.+?)\])(?<rest>.*)$/u;
@@ -20,7 +20,7 @@ type StringToPath<T> = If<
           : "" extends T
             ? []
             : T extends `${infer N extends number}`
-              ? [N]
+              ? [If<IsNumericLiteral<N>, N, T>]
               : [T],
   never
 >;

--- a/packages/remeda/src/stringToPath.ts
+++ b/packages/remeda/src/stringToPath.ts
@@ -15,23 +15,54 @@ type StringToPath<S> = If<
 >;
 
 type StringToPathImpl<S> =
+  // We start by checking the 2 quoted variants of the square bracket access
+  // syntax. We do this in a single check and not in a subsequent check that
+  // would only extract the quoted part so that we can catch cases where the
+  // quoted part itself contains square brackets. This allows TypeScript to be
+  // "greedy" about what it infers into Quoted and DoubleQuoted.
   S extends `${infer Head}['${infer Quoted}']${infer Tail}`
     ? [...StringToPath<Head>, Quoted, ...StringToPath<Tail>]
     : S extends `${infer Head}["${infer DoubleQuoted}"]${infer Tail}`
       ? [...StringToPath<Head>, DoubleQuoted, ...StringToPath<Tail>]
-      : S extends `${infer Head}[${infer Unquoted}]${infer Tail}`
+      : // If we have an unquoted property access we also need to run the
+        // contents recursively too (unlike the quoted variants above).
+        S extends `${infer Head}[${infer Unquoted}]${infer Tail}`
         ? [
             ...StringToPath<Head>,
             ...StringToPath<Unquoted>,
             ...StringToPath<Tail>,
           ]
-        : S extends `${infer Head}.${infer Tail}`
+        : // Finally, we process any dots one after the other from left to
+          // right. TypeScript will be non-greedy here, putting *everything*
+          // after the first dot into the Tail.
+          S extends `${infer Head}.${infer Tail}`
           ? [...StringToPath<Head>, ...StringToPath<Tail>]
-          : "" extends S
-            ? []
-            : S extends `${infer N extends number}`
-              ? [If<IsNumericLiteral<N>, N, S>]
-              : [S];
+          : // Finally we need to handle the few cases of simple literals.
+            "" extends S
+            ? // There are some edge-cases where Lodash will try to access an
+              // empty property, but those seem nonsensical in practice so we
+              // prefer just skipping these cases.
+              []
+            : // We differ from Lodash in the way we handle numbers. Lodash
+              // returns everything in the path as a string, and relies on JS to
+              // coerce array accessors to numbers (or the other way around in
+              // practice, e.g., `myArray[123] === `myArray[123]`), but from a
+              // typing perspective the two are not the same and we need the
+              // path to be accurate about it.
+              S extends `${infer N extends number}`
+              ? [
+                  If<
+                    // TypeScript considers " 123 " to still extend `${number}`,
+                    // but would type is as `string` instead of a literal. We
+                    // can use that fact to make sure we only consider simple
+                    // number literals as numbers, and take the rest as strings.
+                    IsNumericLiteral<N>,
+                    N,
+                    S
+                  >,
+                ]
+              : // This simplest form of a path is just a single string literal.
+                [S];
 
 /**
  * Converts a path string to an array of string keys (including array index

--- a/packages/remeda/src/stringToPath.ts
+++ b/packages/remeda/src/stringToPath.ts
@@ -65,18 +65,31 @@ type StringToPathImpl<S> =
                 [S];
 
 /**
- * Converts a path string to an array of string keys (including array index
- * access keys).
+ * A utility to allow JSONPath-like strings to be used in other utilities which
+ * take an array of path segments as input (e.g. `pathOr`, `setPath`, etc...).
+ * The main purpose of this utility is to act as a bridge between the runtime
+ * implementation that converts the path to an array, and the type-system that
+ * parses the path string **type** into an array **type**. This type allows us
+ * to return fine-grained types and to enforce correctness at the type-level.
  *
- * ! IMPORTANT: Attempting to pass a simple `string` type will result in the
- * result being inferred as `never`. This is intentional to help with type-
- * safety as this function is primarily intended to help with other "object path
- * access" functions like `pathOr` or `setPath`.
+ * This utility helps bridge the gap for legacy code that already contains these
+ * path strings (which are accepted by Lodash for similar utilities). We
+ * strongly recommend using array paths instead as they can provide a better
+ * developer experience via fine-grained error messages and automatic typeahead
+ * suggestions for each segment of the path.
+ *
+ * **There are a bunch of limitations to this utility derived from the
+ * limitations of the type itself, these are usually edge-cases around deeply
+ * nested paths, escaping, whitespaces, and empty segments. This is true even
+ * in cases where the runtime implementation can better handle them, this is
+ * intentional. See the tests for this utility for more details and the
+ * expected outputs**.
  *
  * @param path - A string path.
- * @signature R.stringToPath(path)
+ * @signature
+ *   R.stringToPath(path)
  * @example
- *   R.stringToPath('a.b[0].c') // => ['a', 'b', '0', 'c']
+ *   R.stringToPath('a.b[0].c') // => ['a', 'b', 0, 'c']
  * @dataFirst
  * @category Utility
  */


### PR DESCRIPTION
Fixes: #779

stringToPath didn't handle numbers correctly for our use-case. Our path-accepting utilities expect array access to be typed as `number` and not as `${number}` which is what it previously returned.
Also we weren't handling certain edge-cases and complexities of parsing a string path accuratly enough to how lodash does it.

I'm sending this out as a feat and not a fix so we bump the minor version, as this would change runtime and typing behaviour for existing call sites and can't be considered just a bug fix, even though it probably only improves the types and surfaces existing bugs.