### PR TITLE
fix(keys,entries): support branded keys

### DIFF
--- a/packages/remeda/src/entries.test-d.ts
+++ b/packages/remeda/src/entries.test-d.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from "vitest";
 import { entries } from "./entries";
+import type { Tagged } from "type-fest";
 
 test("with known properties", () => {
   const actual = entries({ a: 1, b: 2, c: 3 });
@@ -59,4 +60,11 @@ test("object with combined symbols and keys", () => {
   const actual = entries({ a: 1, [Symbol("b")]: "world", 123: true });
 
   expectTypeOf(actual).toEqualTypeOf<Array<["123", boolean] | ["a", number]>>();
+});
+
+// @see https://github.com/remeda/remeda/issues/752
+test("branded keys (issue #752)", () => {
+  expectTypeOf(
+    entries({} as Record<Tagged<string, "color">, string>),
+  ).toEqualTypeOf<Array<[Tagged<string, "color">, string]>>();
 });

--- a/packages/remeda/src/entries.ts
+++ b/packages/remeda/src/entries.ts
@@ -2,17 +2,23 @@
  * We want to match the typing of the built-in Object.entries as much as
  * possible!
  */
-
-import type { Simplify } from "type-fest";
+import type { Simplify, ValueOf } from "type-fest";
 import { purry } from "./purry";
+import type { ToString } from "./internal/types/ToString";
 
-// Object.entries only returns enumerable keys, skipping symbols. It also
-// only returns string keys, translating numbers to strings.
-type EntryForKey<T, Key extends keyof T> = Key extends number | string
-  ? [key: `${Key}`, value: Required<T>[Key]]
-  : never;
-
-type Entry<T> = Simplify<{ [P in keyof T]-?: EntryForKey<T, P> }[keyof T]>;
+type Entry<T> = Simplify<
+  ValueOf<{
+    // Object.entries only returns enumerable keys, skipping symbols.
+    [P in Exclude<keyof T, symbol>]-?: [
+      //  It also only returns string keys, translating numbers to strings.
+      key: ToString<P>,
+      // Optionality doesn't play a factor in the result of entries because its
+      // a typing thing, not a runtime thing. We need to remove any `undefined`
+      // added just because the prop is optional.
+      value: Required<T>[P],
+    ];
+  }>
+>;
 
 /**
  * Returns an array of key/values of the enumerable properties of an object.

--- a/packages/remeda/src/internal/types/EnumerableStringKeyOf.test-d.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyOf.test-d.ts
@@ -4,55 +4,90 @@ import type { EnumerableStringKeyOf } from "./EnumerableStringKeyOf";
 
 declare const SymbolFoo: unique symbol;
 
+declare function enumerableStringKeyOf<T>(data: T): EnumerableStringKeyOf<T>;
+
 test("string keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<string, unknown>>
-  >().toEqualTypeOf<string>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<string, unknown>),
+  ).toEqualTypeOf<string>();
 });
 
 test("number keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<number, unknown>>
-  >().toEqualTypeOf<`${number}`>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<number, unknown>),
+  ).toEqualTypeOf<`${number}`>();
 });
 
 test("union of records", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<
-      Record<`prefix_${string}`, unknown> | Record<number, unknown>
-    >
-  >().toEqualTypeOf<`${number}` | `prefix_${string}`>();
+  expectTypeOf(
+    enumerableStringKeyOf(
+      {} as Record<`prefix_${string}`, unknown> | Record<number, unknown>,
+    ),
+  ).toEqualTypeOf<`${number}` | `prefix_${string}`>();
 });
 
 test("union keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<number | `prefix_${string}`, unknown>>
-  >().toEqualTypeOf<`${number}` | `prefix_${string}`>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<number | `prefix_${string}`, unknown>),
+  ).toEqualTypeOf<`${number}` | `prefix_${string}`>();
+});
+
+test("union of records with branded keys", () => {
+  expectTypeOf(
+    enumerableStringKeyOf(
+      {} as
+        | Record<Tagged<string, "coke">, unknown>
+        | Record<Tagged<string, "pepsi">, unknown>,
+    ),
+  ).toEqualTypeOf<Tagged<string, "coke"> | Tagged<string, "pepsi">>();
+});
+
+test("union of branded keys", () => {
+  expectTypeOf(
+    enumerableStringKeyOf(
+      {} as Record<Tagged<string, "coke"> | Tagged<string, "pepsi">, unknown>,
+    ),
+  ).toEqualTypeOf<Tagged<string, "coke"> | Tagged<string, "pepsi">>();
+});
+
+test("union with a mix of branded and number keys", () => {
+  expectTypeOf(
+    enumerableStringKeyOf(
+      {} as Record<Tagged<string, "brand"> | number, unknown>,
+    ),
+  ).toEqualTypeOf<Tagged<string, "brand"> | `${number}`>();
+});
+
+test("union of records with branded key and number key", () => {
+  expectTypeOf(
+    enumerableStringKeyOf(
+      {} as Record<Tagged<string, "brand">, unknown> | Record<number, unknown>,
+    ),
+  ).toEqualTypeOf<Tagged<string, "brand"> | `${number}`>();
 });
 
 test("symbol keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<string | symbol, unknown>>
-  >().toEqualTypeOf<string>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<string | symbol, unknown>),
+  ).toEqualTypeOf<string>();
 
-  expectTypeOf<
-    EnumerableStringKeyOf<{ [SymbolFoo]: number; a: unknown }>
-  >().toEqualTypeOf<"a">();
+  expectTypeOf(
+    enumerableStringKeyOf({ [SymbolFoo]: "hello", a: "world" }),
+  ).toEqualTypeOf<"a">();
 
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<string | typeof SymbolFoo, unknown>>
-  >().toEqualTypeOf<string>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<string | typeof SymbolFoo, unknown>),
+  ).toEqualTypeOf<string>();
 });
 
 test("optional keys", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<{ a: unknown; b?: unknown }>
-  >().toEqualTypeOf<"a" | "b">();
+  expectTypeOf(
+    enumerableStringKeyOf({ a: "hello" } as { a: unknown; b?: unknown }),
+  ).toEqualTypeOf<"a" | "b">();
 });
 
 test("branded types", () => {
-  expectTypeOf<
-    EnumerableStringKeyOf<Record<Tagged<string, symbol>, unknown>>
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-template-expression -- TODO: I'm not sure what's going on here, are we doing something wrong or is this code needed so we can test it properly?
-  >().toEqualTypeOf<`${Tagged<string, symbol>}`>();
+  expectTypeOf(
+    enumerableStringKeyOf({} as Record<Tagged<string, "brand">, unknown>),
+  ).toEqualTypeOf<Tagged<string, "brand">>();
 });

--- a/packages/remeda/src/internal/types/EnumerableStringKeyOf.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyOf.ts
@@ -1,3 +1,5 @@
+import type { ToString } from "./ToString";
+
 /**
  * A union of all keys of T which are not symbols, and where number keys are
  * converted to strings, following the definition of `Object.keys` and
@@ -8,12 +10,4 @@
  * @see EnumerableStringKeyedValueOf
  */
 export type EnumerableStringKeyOf<T> =
-  Required<T> extends Record<infer K, unknown>
-    ? K extends symbol
-      ? never
-      : K extends number
-        ? `${K}`
-        : K extends string
-          ? K
-          : never
-    : never;
+  Required<T> extends Record<infer K, unknown> ? ToString<K> : never;

--- a/packages/remeda/src/internal/types/EnumerableStringKeyOf.ts
+++ b/packages/remeda/src/internal/types/EnumerableStringKeyOf.ts
@@ -9,5 +9,11 @@
  */
 export type EnumerableStringKeyOf<T> =
   Required<T> extends Record<infer K, unknown>
-    ? `${Exclude<K, symbol>}`
+    ? K extends symbol
+      ? never
+      : K extends number
+        ? `${K}`
+        : K extends string
+          ? K
+          : never
     : never;

--- a/packages/remeda/src/internal/types/ToString.test-d.ts
+++ b/packages/remeda/src/internal/types/ToString.test-d.ts
@@ -1,0 +1,81 @@
+import type { Tagged } from "type-fest";
+import { expectTypeOf, test, describe } from "vitest";
+import type { ToString } from "./ToString";
+
+declare function toString<const T>(data: T): ToString<T>;
+
+test("primitive strings", () => {
+  expectTypeOf(toString("" as string)).toEqualTypeOf<string>();
+});
+
+test("literal string", () => {
+  expectTypeOf(toString("hello")).toEqualTypeOf<"hello">();
+});
+
+test("primitive numbers", () => {
+  expectTypeOf(toString(123 as number)).toEqualTypeOf<`${number}`>();
+});
+
+test("template string", () => {
+  expectTypeOf(
+    toString("prefix_123" as `prefix_${number}`),
+  ).toEqualTypeOf<`prefix_${number}`>();
+});
+
+test("union of literal numbers", () => {
+  expectTypeOf(toString(123 as 123 | 456)).toEqualTypeOf<"123" | "456">();
+});
+
+test("union of number and template string", () => {
+  expectTypeOf(toString(123 as number | `prefix_${number}`)).toEqualTypeOf<
+    `${number}` | `prefix_${number}`
+  >();
+});
+
+test("branded type", () => {
+  expectTypeOf(toString("hello" as Tagged<string, "greeting">)).toEqualTypeOf<
+    Tagged<string, "greeting">
+  >();
+});
+
+test("union of branded types", () => {
+  expectTypeOf(
+    toString("cola" as Tagged<string, "coke"> | Tagged<string, "pepsi">),
+  ).toEqualTypeOf<Tagged<string, "coke"> | Tagged<string, "pepsi">>();
+});
+
+test("union with a mix of branded and number keys", () => {
+  expectTypeOf(toString(123 as 123 | Tagged<string, "brand">)).toEqualTypeOf<
+    "123" | Tagged<string, "brand">
+  >();
+});
+
+describe("symbols", () => {
+  test("primitive", () => {
+    expectTypeOf(toString(Symbol("foo"))).toEqualTypeOf<never>();
+  });
+
+  test("union with primitive string", () => {
+    expectTypeOf(toString("hello" as string | symbol)).toEqualTypeOf<string>();
+  });
+
+  test("union with primitive number", () => {
+    expectTypeOf(toString(123 as number | symbol)).toEqualTypeOf<`${number}`>();
+  });
+
+  test("union with literal number", () => {
+    expectTypeOf(toString(123 as 123 | symbol)).toEqualTypeOf<"123">();
+  });
+
+  test("union with template string", () => {
+    expectTypeOf(
+      toString("prefix_123" as `prefix_${number}` | symbol),
+    ).toEqualTypeOf<`prefix_${number}`>();
+  });
+
+  test("union with branded type", () => {
+    expectTypeOf(
+      toString("hello" as Tagged<string, "greeting"> | symbol),
+    ).toEqualTypeOf<Tagged<string, "greeting">>();
+  });
+});

--- a/packages/remeda/src/internal/types/ToString.ts
+++ b/packages/remeda/src/internal/types/ToString.ts
@@ -1,0 +1,15 @@
+/**
+ * A utility to preserve strings as-is, convert numbers to strings, and fail on
+ * anything else. This happens a lot in JS when accessing objects or when
+ * enumerating over keys.
+ *
+ * Notice that symbols are not supported, which is consistent with how built-in
+ * functions like `Object.keys` and `Object.entries` behave.
+ */
+export type ToString<T> = T extends unknown
+  ? T extends number
+    ? `${T}`
+    : T extends string
+      ? T
+      : never
+  : never;

--- a/packages/remeda/src/keys.test-d.ts
+++ b/packages/remeda/src/keys.test-d.ts
@@ -1,3 +1,4 @@
+import type { Tagged } from "type-fest";
 import { describe, expectTypeOf, test } from "vitest";
 import { keys } from "./keys";
 import { pipe } from "./pipe";
@@ -172,4 +173,11 @@ describe("object types", () => {
 
     expectTypeOf(actual).toEqualTypeOf<Array<"123" | "a">>();
   });
+});
+
+// @see https://github.com/remeda/remeda/issues/752
+test("branded keys (issue #752)", () => {
+  expectTypeOf(
+    keys({} as Record<Tagged<string, "color">, string>),
+  ).toEqualTypeOf<Array<Tagged<string, "color">>>();
 });

--- a/packages/remeda/src/mapValues.test-d.ts
+++ b/packages/remeda/src/mapValues.test-d.ts
@@ -83,8 +83,7 @@ describe("branded types", () => {
 
     mapValues(userValues, (value, key) => {
       expectTypeOf(value).toEqualTypeOf<number>();
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-template-expression -- TODO: I'm not sure what's going on here, are we doing something wrong or is this code needed so we can test it properly?
-      expectTypeOf(key).toEqualTypeOf<`${UserID}`>();
+      expectTypeOf(key).toEqualTypeOf<UserID>();
     });
   });
 });


### PR DESCRIPTION
Fix: #752

Return the branded type as-is (not wrapped with a string template) when used as a record key.