### PR TITLE
fix(isFunction): force stricter function type

### DIFF
--- a/packages/remeda/src/isFunction.test-d.ts
+++ b/packages/remeda/src/isFunction.test-d.ts
@@ -3,25 +3,74 @@ import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
   type AllTypesDataProviderTypes,
+  type TestClass,
+  type TypedArray,
 } from "../test/typesDataProvider";
 import { isFunction } from "./isFunction";
 
 test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.function as AllTypesDataProviderTypes;
+
   if (isFunction(data)) {
     expectTypeOf(data).toEqualTypeOf<() => void>();
+  } else {
+    expectTypeOf(data).toEqualTypeOf<
+      | Array<number>
+      | Date
+      | Error
+      | Map<string, string>
+      | Promise<number>
+      | RegExp
+      | Set<string>
+      | TestClass
+      | TypedArray
+      | boolean
+      | number
+      | string
+      | symbol
+      | 1n
+      | { readonly a: "asd" }
+      | [number, number, number]
+      | null
+      | undefined
+    >();
   }
+});
 
-  let maybeFunction: string | ((a: number) => string) | undefined;
-  if (isFunction(maybeFunction)) {
-    maybeFunction(1);
+test("union with non-function types", () => {
+  let data: string | ((a: number) => string) | undefined;
 
-    expectTypeOf(maybeFunction).toEqualTypeOf<(a: number) => string>();
+  if (isFunction(data)) {
+    expectTypeOf(data).toEqualTypeOf<(a: number) => string>();
+  } else {
+    expectTypeOf(data).toEqualTypeOf<string | undefined>();
   }
 });
 
 test("should work as type guard in filter", () => {
-  const data = ALL_TYPES_DATA_PROVIDER.filter(isFunction);
+  expectTypeOf(ALL_TYPES_DATA_PROVIDER.filter(isFunction)).toEqualTypeOf<
+    Array<() => void>
+  >();
+});
 
-  expectTypeOf(data).toEqualTypeOf<Array<() => void>>();
+test("unknown", () => {
+  const data = "Hello, world!" as unknown;
+
+  if (isFunction(data)) {
+    expectTypeOf(data).toEqualTypeOf<(...args: never) => unknown>();
+  } else {
+    expectTypeOf(data).toEqualTypeOf<unknown>();
+  }
+});
+
+test("any", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any -- Intentional!
+  const data = "Hello, world!" as any;
+
+  if (isFunction(data)) {
+    expectTypeOf(data).toEqualTypeOf<(...args: never) => unknown>();
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentional!
+    expectTypeOf(data).toEqualTypeOf<any>();
+  }
 });

--- a/packages/remeda/src/isFunction.ts
+++ b/packages/remeda/src/isFunction.ts
@@ -1,10 +1,14 @@
-/* eslint-disable @typescript-eslint/no-unsafe-function-type --
- * Function is used generically in this file to define any type of function, so
- * this lint error is not relevant for it.
- */
+import type { NarrowedTo } from "./internal/types/NarrowedTo";
 
-type DefinitelyFunction<T> =
-  Extract<T, Function> extends never ? Function : Extract<T, Function>;
+// Contrary to intuition, because TypeScript compares function params using
+// contra-variance and not co-variance, in order to accept any function we need
+// the most "limiting" type for the argument list, and not the most permissive
+// one (which would be `readonly unknown[]`); now when any function is compared
+// against this signature it will always match because `never` **everything**
+// extends everything!
+// @see https://www.typescriptlang.org/play/?#code/C4TwDgpgBA6glsAFgJQgQwCYHsB2AbEAVRwGscsB3HAHgBUA+KAXilqggA9gIcMBnKAAoAdKLQAnAOZ8AXFHHps+EFACupclQDaAXQCUzRurKUcAKChQA-FGDjVEC1DkAzNHj4QA3GbOhIsAiIAII4IHSMLGyc3LwCImJSslBoYQZMRhqm1rb20K7unj5+4NDwSAByEABuEOIRzKzsXDz8QqLCEtJyODV16ZkmVDl2Ds5Qbh7evv7QtBB8wABi6gDGjYJoPaoAtgBG-YZQi+JwOJLFs1AAGgAMjeUoirgExEM084srOKv0PgD0-0sUAAelYZqUbgBGB5BULhT7LNZ-MyA4FgiEBa4AJlhlT69UR31+AKBljBQA
+type StrictFunction = (...args: never) => unknown;
+
 /**
  * A function that checks if the passed parameter is a Function and narrows its type accordingly.
  *
@@ -17,8 +21,6 @@ type DefinitelyFunction<T> =
  *    R.isFunction('somethingElse') //=> false
  * @category Guard
  */
-export function isFunction<T>(
-  data: Function | T,
-): data is DefinitelyFunction<T> {
-  return typeof data === "function";
-}
+export const isFunction = <T>(
+  data: StrictFunction | T,
+): data is NarrowedTo<T, StrictFunction> => typeof data === "function";


### PR DESCRIPTION
Fixes: #778

Improve generic function type with `never` as the argument list, and `unknown` for the return type (instead of `any`) so that we don't loosen the type on generic functions, and use the NarrowedTo helper to support `any` and `unknown` inputs.