### PR TITLE
fix: prevent redundant type computation paths

### DIFF
--- a/packages/remeda/src/internal/types/ArrayAt.ts
+++ b/packages/remeda/src/internal/types/ArrayAt.ts
@@ -3,7 +3,6 @@ import type { ClampedIntegerSubtract } from "./ClampedIntegerSubtract";
 import type { IntRangeInclusive } from "./IntRangeInclusive";
 import type { IterableContainer } from "./IterableContainer";
 import type { TupleParts } from "./TupleParts";
-import type { If } from "./If";
 
 /**
  * The type for the I'th element in the tuple T. This type corrects some of the
@@ -11,64 +10,59 @@ import type { If } from "./If";
  * and tuples with fixed suffixes, and for primitive indices where we don't know
  * if the index is out of bounds.
  */
-export type ArrayAt<T extends IterableContainer, I extends keyof T> = If<
+export type ArrayAt<T extends IterableContainer, I extends keyof T> =
   // Only literals pose a challenge to the typing system because they refer to a
   // specific element within the array.
-  IsNumericLiteral<I>,
-  // The result of a union of indices is a union of the results for each one, so
-  // we distribute the union.
-  I extends unknown
-    ? // We memoize the prefix (made of the required and optional parts) so we
-      // can reuse it several times within this type.
-      [
-        ...TupleParts<T>["required"],
-        ...TupleParts<T>["optional"],
-      ] extends infer Prefix extends ReadonlyArray<unknown>
-      ? If<
-          // The first two parts of the tuple, the required and the optional
+  IsNumericLiteral<I> extends true
+    ? // The result of a union of indices is a union of the results for each
+      // one, so we distribute the union.
+      I extends unknown
+      ? // We memoize the prefix (made of the required and optional parts) so we
+        // can reuse it several times within this type.
+        [
+          ...TupleParts<T>["required"],
+          ...TupleParts<T>["optional"],
+        ] extends infer Prefix extends ReadonlyArray<unknown>
+        ? // The first two parts of the tuple, the required and the optional
           // prefixes, are simple and TypeScript does a good job of typing them
           // based on indexing the tuple directly.
-          HasIndex<Prefix, I>,
-          T[I],
-          // The index is larger than the prefix so the result has to consider
-          // the rest element item type.
-          | TupleParts<T>["item"]
-          // We subtract the prefix length from the index to get the index
-          // within the suffix.
-          | (ClampedIntegerSubtract<
-              I,
-              Prefix["length"]
-            > extends infer SuffixIndex extends number
-              ? If<
-                  // If the index falls within the suffix it means that the item
-                  // might be of that element's type, but it also could be any
-                  // value that came before it in the suffix, because the rest
-                  // element part of the array could be any length: e.g.,
-                  // for `[...0[], 1, 2, 3]` the tuple could have the
-                  // shape: `[1, 2, 3]`, `[0, 1, 2, 3]`, `[0, 0, 1, 2, 3]`,
-                  // etc... if we look at a single index within the suffix we
-                  // can see the the rest param acts as a window into the
-                  // suffix, but only the prefixes up to that index. e.g., if
-                  // index is 1, in the example above the item could be of type
-                  // `2 | 1 | 0`.
-                  HasIndex<TupleParts<T>["suffix"], SuffixIndex>,
-                  TupleParts<T>["suffix"][IntRangeInclusive<0, SuffixIndex>],
-                  // But if the index is out of the suffix it can be out-of-
-                  // bounds, resulting in `undefined`, or it could be any of the
-                  // items in the suffix (depending on how long the rest part of
-                  // the tuple is).
-                  TupleParts<T>["suffix"][number] | undefined
-                >
-              : never)
-        >
+          HasIndex<Prefix, I> extends true
+          ? T[I]
+          : // The index is larger than the prefix so the result has to consider
+            // the rest element item type.
+            | TupleParts<T>["item"]
+              // We subtract the prefix length from the index to get the index
+              // within the suffix.
+              | (ClampedIntegerSubtract<
+                  I,
+                  Prefix["length"]
+                > extends infer SuffixIndex extends number
+                  ? // If the index falls within the suffix it means that the
+                    // item might be of that element's type, but it also could
+                    // be any value that came before it in the suffix, because
+                    // the rest element part of the array could be any length:
+                    // e.g., for `[...0[], 1, 2, 3]` the tuple could have the
+                    // shape: `[1, 2, 3]`, `[0, 1, 2, 3]`, `[0, 0, 1, 2, 3]`,
+                    // etc... if we look at a single index within the suffix we
+                    // can see the the rest param acts as a window into the
+                    // suffix, but only the prefixes up to that index. e.g., if
+                    // index is 1, in the example above the item could be of
+                    // type `2 | 1 | 0`.
+                    HasIndex<TupleParts<T>["suffix"], SuffixIndex> extends true
+                    ? TupleParts<T>["suffix"][IntRangeInclusive<0, SuffixIndex>]
+                    : // But if the index is out of the suffix it can be out-of-
+                      // bounds, resulting in `undefined`, or it could be any
+                      // of the items in the suffix (depending on how long the
+                      // rest part of the tuple is).
+                      TupleParts<T>["suffix"][number] | undefined
+                  : never)
+        : never
       : never
-    : never,
-  // Even with `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`
-  // enabled TypeScript still types T[number] without considering that number
-  // might be out of bounds. We need to manually add the `undefined` case to
-  // make the type accurate.
-  T[number] | undefined
->;
+    : // Even with `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`
+      // enabled TypeScript still types T[number] without considering that
+      // number might be out of bounds. We need to manually add the `undefined`
+      // case to make the type accurate.
+      T[number] | undefined;
 
 type HasIndex<T extends ReadonlyArray<unknown>, I> =
   I extends ArrayIndices<T> ? true : false;

--- a/packages/remeda/src/internal/types/BoundedPartial.ts
+++ b/packages/remeda/src/internal/types/BoundedPartial.ts
@@ -1,4 +1,3 @@
-import type { If } from "./If";
 import type { IsBoundedRecord } from "./IsBoundedRecord";
 
 /**
@@ -10,4 +9,5 @@ import type { IsBoundedRecord } from "./IsBoundedRecord";
  *    BoundedPartial<{ a: number }>; //=> { a?: number }
  *    BoundedPartial<Record<string, number>>; //=> Record<string, number>
  */
-export type BoundedPartial<T> = If<IsBoundedRecord<T>, Partial<T>, T>;
+export type BoundedPartial<T> =
+  IsBoundedRecord<T> extends true ? Partial<T> : T;

--- a/packages/remeda/src/internal/types/If.ts
+++ b/packages/remeda/src/internal/types/If.ts
@@ -1,9 +1,0 @@
-import type { IsNever } from "type-fest";
-
-// TODO [type-fest@>=5] -- This type is shipping in type-fest v5 and standardizes all IfXXX types. We backported it so that we can already use it before v5 is shipped.
-export type If<Type extends boolean, IfBranch, ElseBranch> =
-  IsNever<Type> extends true
-    ? ElseBranch
-    : Type extends true
-      ? IfBranch
-      : ElseBranch;

--- a/packages/remeda/src/internal/types/StringLength.ts
+++ b/packages/remeda/src/internal/types/StringLength.ts
@@ -1,5 +1,4 @@
 import type { IsStringLiteral } from "type-fest";
-import type { If } from "./If";
 
 /**
  * Returns a literal number for literal strings.
@@ -10,10 +9,9 @@ import type { If } from "./If";
 export type StringLength<
   S extends string,
   Characters extends ReadonlyArray<string> = [],
-> = If<
-  IsStringLiteral<S>,
-  S extends `${infer Character}${infer Rest}`
-    ? StringLength<Rest, [...Characters, Character]>
-    : Characters["length"],
-  number
->;
+> =
+  IsStringLiteral<S> extends true
+    ? S extends `${infer Character}${infer Rest}`
+      ? StringLength<Rest, [...Characters, Character]>
+      : Characters["length"]
+    : number;

--- a/packages/remeda/src/omitBy.ts
+++ b/packages/remeda/src/omitBy.ts
@@ -1,7 +1,6 @@
 import type { IfNever, Simplify } from "type-fest";
 import type { EnumerableStringKeyOf } from "./internal/types/EnumerableStringKeyOf";
 import type { EnumerableStringKeyedValueOf } from "./internal/types/EnumerableStringKeyedValueOf";
-import type { If } from "./internal/types/If";
 import type { IsBoundedRecord } from "./internal/types/IsBoundedRecord";
 import { purry } from "./purry";
 
@@ -22,17 +21,15 @@ type PartialEnumerableKeys<T extends object> =
   // union into a [distributive conditional type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#distributive-conditional-types).
   T extends unknown
     ? Simplify<
-        If<
-          IsBoundedRecord<T>,
-          PickSymbolKeys<T> & {
-            -readonly [P in keyof T as P extends symbol
-              ? never
-              : P]?: Required<T>[P];
-          },
-          // This is the type you'd get from doing:
-          // `Object.fromEntries(Object.entries(x))`.
-          Record<EnumerableStringKeyOf<T>, EnumerableStringKeyedValueOf<T>>
-        >
+        IsBoundedRecord<T> extends true
+          ? PickSymbolKeys<T> & {
+              -readonly [P in keyof T as P extends symbol
+                ? never
+                : P]?: Required<T>[P];
+            }
+          : // This is the type you'd get from doing:
+            // `Object.fromEntries(Object.entries(x))`.
+            Record<EnumerableStringKeyOf<T>, EnumerableStringKeyedValueOf<T>>
       >
     : never;
 

--- a/packages/remeda/src/stringToPath.ts
+++ b/packages/remeda/src/stringToPath.ts
@@ -1,5 +1,4 @@
 import type { IsNumericLiteral, IsStringLiteral } from "type-fest";
-import type { If } from "./internal/types/If";
 
 // This is the most efficient way to check an arbitrary string if it is a simple
 // non-negative integer. We use character ranges instead of the `\d` character
@@ -7,13 +6,12 @@ import type { If } from "./internal/types/If";
 // maintaining that the regular expression supports unicode.
 const NON_NEGATIVE_INTEGER_RE = /^(?:0|[1-9][0-9]*)$/u;
 
-type StringToPath<S> = If<
+type StringToPath<S> =
   // We can only compute the path type for literals that TypeScript can
   // break down further into parts.
-  IsStringLiteral<S>,
-  StringToPathImpl<S>,
-  Array<string | number>
->;
+  IsStringLiteral<S> extends true
+    ? StringToPathImpl<S>
+    : Array<string | number>;
 
 type StringToPathImpl<S> =
   // We start by checking the 2 quoted variants of the square bracket access
@@ -52,15 +50,11 @@ type StringToPathImpl<S> =
               // path to be accurate about it.
               S extends `${infer N extends number}`
               ? [
-                  If<
-                    // TypeScript considers " 123 " to still extend `${number}`,
-                    // but would type is as `string` instead of a literal. We
-                    // can use that fact to make sure we only consider simple
-                    // number literals as numbers, and take the rest as strings.
-                    IsNumericLiteral<N>,
-                    N,
-                    S
-                  >,
+                  // TypeScript considers " 123 " to still extend `${number}`,
+                  // but would type is as `string` instead of a literal. We
+                  // can use that fact to make sure we only consider simple
+                  // number literals as numbers, and take the rest as strings.
+                  IsNumericLiteral<N> extends true ? N : S,
                 ]
               : // This simplest form of a path is just a single string literal.
                 [S];


### PR DESCRIPTION
`If` is a mistake. When I saw it in type-fest it felt like its a safer, cleaner, way to do branching logic in complex types; but it has a huge caveat that is easy to err against: it results in both branches being computed. On the contrary, TypeScript only computes the relevant branch in an `extends` statement. This means that if one of the sides of the If statement are heavy to compute, it will always be computed.

Further more, Ifs don't actually narrow the type in their branches, so each branch needs to handle wide types - this means that types need to be over protective or run the risk of infinite loops and exessive recursions.