### PR TITLE
docs: fix click surface for migration dropdown links

### DIFF
--- a/packages/docs/src/components/migration-selector-island.tsx
+++ b/packages/docs/src/components/migration-selector-island.tsx
@@ -22,12 +22,12 @@ export function MigrationSelectorIsland({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer" asChild>
           <a href={`/migrate/v1`}>Remeda@1.61.0</a>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         {libraries.map((library) => (
-          <DropdownMenuItem key={library} className="capitalize">
+          <DropdownMenuItem key={library} className="capitalize cursor-pointer" asChild>
             <a href={`/migrate/${library}`}>{library}</a>
           </DropdownMenuItem>
         ))}


### PR DESCRIPTION
The click area of the links in the migrations dropdown doesn't match it's visual space as well as its hover-state. Making it easy to miss the link, but the dropdown still closes, so it feels weird.

Example:
<img width="242" height="233" alt="image" src="https://github.com/user-attachments/assets/e541b333-8dab-431b-b128-559027eeb302" />

This makes the dropdown element be the anchor itself, so it takes all the space, and matches the visual size.