### PR TITLE
fix(release): revert OIDC release (for now) + jsr provenance

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -303,6 +303,7 @@ jobs:
         run: npm --workspace=remeda run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: We should be able to migrate to an OIDC based release once issues in semantic-release/npm are resolved: https://github.com/semantic-release/npm/issues/958
           NPM_CONFIG_PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -302,8 +302,9 @@ jobs:
       - name: 🚀 Release
         run: npm --workspace=remeda run release
         env:
-          # Required by semantic-release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-jsr:
     name: 🦕 Publish to JSR.io

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -50,7 +50,7 @@
     "check:dist": "tsc --project tsconfig.dist.json",
     "format": "prettier . --write",
     "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/",
-    "publish:jsr": "jsr publish --no-provenance",
+    "publish:jsr": "jsr publish",
     "publish:preview": "pkg-pr-new publish --compact --template ../stackblitz-template/",
     "release": "semantic-release",
     "test": "tsc --project tsconfig.tests.json && vitest --typecheck.enabled --typecheck.ignoreSourceErrors",


### PR DESCRIPTION
Not supported yet: https://github.com/semantic-release/npm/issues/958