### PR TITLE
feat(includesAny): add includesAny utility

### DIFF
--- a/packages/remeda/src/includesAny.test.ts
+++ b/packages/remeda/src/includesAny.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { includesAny } from "./includesAny";
+import { pipe } from "./pipe";
+
+describe("data first", () => {
+  test("should return true when any candidate is found", () => {
+    expect(includesAny([1, 2, 3], [2, 4])).toBe(true);
+  });
+
+  test("should return false when no candidates are found", () => {
+    expect(includesAny([1, 2, 3], [4, 5])).toBe(false);
+  });
+
+  test("should work with strings", () => {
+    expect(includesAny(["a", "b", "c"], ["b", "d"])).toBe(true);
+    expect(includesAny(["a", "b", "c"], ["d", "e"])).toBe(false);
+  });
+
+  test("should work with empty arrays", () => {
+    expect(includesAny([], [1, 2])).toBe(false);
+    expect(includesAny([1, 2], [])).toBe(false);
+    expect(includesAny([], [])).toBe(false);
+  });
+
+  test("should return true when multiple candidates are found", () => {
+    expect(includesAny([1, 2, 3, 4], [2, 3])).toBe(true);
+  });
+
+  test("should work with mixed types", () => {
+    expect(includesAny([1, "a", true] as Array<string | number | boolean>, ["a", false])).toBe(true);
+    expect(includesAny([1, "a", true] as Array<string | number | boolean>, [2, false])).toBe(false);
+  });
+
+  test("should use reference equality", () => {
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    const obj3 = { id: 1 }; // different reference but same content
+
+    expect(includesAny([obj1, obj2], [obj1])).toBe(true);
+    expect(includesAny([obj1, obj2], [obj3])).toBe(false);
+  });
+});
+
+describe("data last", () => {
+  test("should return true when any candidate is found", () => {
+    expect(pipe([1, 2, 3], includesAny([2, 4]))).toBe(true);
+  });
+
+  test("should return false when no candidates are found", () => {
+    expect(pipe([1, 2, 3], includesAny([4, 5]))).toBe(false);
+  });
+
+  test("should work with strings", () => {
+    expect(pipe(["a", "b", "c"], includesAny(["b", "d"]))).toBe(true);
+    expect(pipe(["a", "b", "c"], includesAny(["d", "e"]))).toBe(false);
+  });
+
+  test("should work with empty arrays", () => {
+    expect(pipe([], includesAny([1, 2]))).toBe(false);
+    expect(pipe([1, 2], includesAny([]))).toBe(false);
+    expect(pipe([], includesAny([]))).toBe(false);
+  });
+
+  test("should return true when multiple candidates are found", () => {
+    expect(pipe([1, 2, 3, 4], includesAny([2, 3]))).toBe(true);
+  });
+
+  test("should work with mixed types", () => {
+    expect(pipe([1, "a", true] as Array<string | number | boolean>, includesAny(["a", false]))).toBe(true);
+    expect(pipe([1, "a", true] as Array<string | number | boolean>, includesAny([2, false]))).toBe(false);
+  });
+
+  test("should use reference equality", () => {
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    const obj3 = { id: 1 }; // different reference but same content
+
+    expect(pipe([obj1, obj2], includesAny([obj1]))).toBe(true);
+    expect(pipe([obj1, obj2], includesAny([obj3]))).toBe(false);
+  });
+});

--- a/packages/remeda/src/includesAny.ts
+++ b/packages/remeda/src/includesAny.ts
@@ -1,0 +1,57 @@
+import type { IterableContainer } from "./internal/types/IterableContainer";
+import { purry } from "./purry";
+
+/**
+ * Checks if any of the items in the candidate array are included in the data
+ * array. This is a wrapper around `Array.prototype.includes` and thus relies
+ * on the same equality checks (reference equality, e.g. `===`).
+ *
+ * @param data - The array to search in.
+ * @param candidates - The items to look for.
+ * @returns `true` if any of the candidates are found in the data array,
+ * `false` otherwise.
+ * @signature
+ *   R.includesAny(data, candidates)
+ * @example
+ *   R.includesAny([1, 2, 3], [2, 4]); // => true
+ *   R.includesAny([1, 2, 3], [4, 5]); // => false
+ *   R.includesAny(['a', 'b'], ['c', 'd']); // => false
+ *   R.includesAny(['a', 'b'], ['a', 'c']); // => true
+ * @dataFirst
+ * @category Array
+ */
+export function includesAny<T>(
+  data: IterableContainer<T>,
+  candidates: IterableContainer,
+): boolean;
+
+/**
+ * Checks if any of the items in the candidate array are included in the data
+ * array. This is a wrapper around `Array.prototype.includes` and thus relies
+ * on the same equality checks (reference equality, e.g. `===`).
+ *
+ * @param candidates - The items to look for.
+ * @returns A function that takes a data array and returns `true` if any of the
+ * candidates are found in the data array, `false` otherwise.
+ * @signature
+ *   R.includesAny(candidates)(data)
+ * @example
+ *   R.pipe([1, 2, 3], R.includesAny([2, 4])); // => true
+ *   R.pipe([1, 2, 3], R.includesAny([4, 5])); // => false
+ *   R.pipe(['a', 'b'], R.includesAny(['c', 'd'])); // => false
+ *   R.pipe(['a', 'b'], R.includesAny(['a', 'c'])); // => true
+ * @dataLast
+ * @category Array
+ */
+export function includesAny<T>(
+  candidates: IterableContainer,
+): (data: IterableContainer<T>) => boolean;
+
+export function includesAny(...args: ReadonlyArray<unknown>): unknown {
+  return purry(includesAnyImplementation, args);
+}
+
+const includesAnyImplementation = (
+  data: ReadonlyArray<unknown>,
+  candidates: ReadonlyArray<unknown>,
+): boolean => candidates.some((candidate) => data.includes(candidate));

--- a/packages/remeda/src/index.ts
+++ b/packages/remeda/src/index.ts
@@ -45,6 +45,7 @@ export * from "./groupByProp";
 export * from "./hasAtLeast";
 export * from "./hasSubObject";
 export * from "./identity";
+export * from "./includesAny";
 export * from "./indexBy";
 export * from "./intersection";
 export * from "./intersectionWith";


### PR DESCRIPTION
Adds a new `includesAny` function that checks if any of the items in a candidate array are included in the data array. This provides a convenient way to check for the presence of multiple values without writing verbose `||` chains or using `some()` with `includes()`.

Example usage:

```javascript
// Before
const canUseGoogleFeatures = env.includes(googleCalendarFeature) || env.includes(gmailFeature) || env.includes(googleDriveFeature);

// After
const canUseGoogleFeatures = includesAny(env, [googleCalendarFeature, gmailFeature, googleDriveFeature]);
```

The function supports both data-first and data-last forms and uses the same reference equality checks as `Array.prototype.includes`.

Proposal based on personal usage unsure if there is broad interest, it appears it's a somewhat common utility based on a [quick search](https://grep.app/search?f.lang=TypeScript&f.lang=JavaScript&q=includesAny%28)

---

Make sure that you:

- [x] Typedoc added for new methods and updated for changed
- [x] Tests added for new methods and updated for changed
- [x] New methods added to `src/index.ts`
- [ ] ~New methods added to `docs/src/content/mapping` for both Lodash and Ramda.~ N/A
