### PR TITLE
fix(funnel): Avoid calling setTimeout with negative numbers

### DIFF
--- a/packages/remeda/src/funnel.ts
+++ b/packages/remeda/src/funnel.ts
@@ -279,7 +279,7 @@ export function funnel<Args extends RestArguments = [], R = never>(
                 minQuietPeriodMs ?? maxBurstDurationMs,
                 // We need to account for the time already spent so that we
                 // don't wait longer than the maxDelay.
-                maxBurstDurationMs - (now - burstStartTimestamp),
+                Math.max(0, maxBurstDurationMs - (now - burstStartTimestamp)),
               );
 
         burstTimeoutId = setTimeout(handleBurstEnd, burstRemainingMs);


### PR DESCRIPTION
This happened in one of our tests and caused node to complain and log about it. It makes sense that we prevent it if we can, although I don't think there's any runtime consequences to using a negative number, it's probably clamped to 0 internally too.