### PR TITLE
ci: add property testing to the library CI

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -163,6 +163,9 @@ jobs:
     needs:
       - test-runtime
     runs-on: ubuntu-latest
+    permissions:
+      # Reports its findings as review comments on the PR
+      pull-requests: write
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
We want to run the tests on every PR, after making sure runtime tests pass. We also want to make sure that we only release once these tests pass too