### PR TITLE
chore: create typescript-playground-viewer skill

### DIFF
--- a/.claude/skills/playground/SKILL.md
+++ b/.claude/skills/playground/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: playground
+description: Decode a TypeScript Playground URL to reveal the source code, compiler options, and TypeScript diagnostics (errors/warnings). Use this whenever you encounter a typescriptlang.org/play link anywhere — pasted in chat, in GitHub issues, in source code comments, on websites, or in any other context where you need to see what the playground contains.
+---
+
+# TypeScript Playground Viewer
+
+Decode a TypeScript Playground link and type-check the embedded code — giving
+you the same view of errors and warnings the user sees in the playground.
+
+## Usage
+
+```
+npx @remeda/typescript-playground-viewer "$ARGUMENTS"
+```
+
+The tool handles everything automatically: it extracts the TypeScript version
+from the URL's `ts` query param (defaulting to `latest`), installs it into a
+local cache on first use, and loads it via the compiler API.
+
+## What It Outputs
+
+A markdown document with YAML frontmatter:
+
+1. **Frontmatter** — TypeScript version and any compiler option overrides.
+2. **Source** — the decoded source code from the LZString-compressed `#code/`
+   hash fragment.
+3. **Diagnostics** — errors and warnings from the TypeScript compiler API, with
+   line numbers and TS error codes (e.g. `TS2322`), matching what the playground
+   shows as red/yellow squiggly lines.
+
+## After Decoding
+
+Analyze the output in the context of the conversation:
+
+- **Errors are the main signal.** The diagnostics section shows exactly what the
+  user sees. Use the error codes and line numbers to understand the problem.
+- If it's a bug reproduction, identify which error is unexpected (shouldn't
+  happen) or which error is missing (should happen but doesn't).
+- If it contains `// ^?` (twoslash queries), explain what type TypeScript would
+  infer at those positions.
+- If compiler options are set, note how they affect the behavior (e.g.,
+  `noUncheckedIndexedAccess` adds `| undefined` to index signatures).

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 node_modules
 
-# For AI tools:
-.claude
-CLAUDE.local.md
-# dotenv file used for MCP secrets
-.env.local
+# Local files which should never be committed (.env, claude.md, etc...)
+*.local.*
+*.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,10 @@
       "name": "remeda",
       "version": "2.0.0",
       "workspaces": [
-        "packages/remeda",
         "packages/docs",
-        "packages/stackblitz-template"
+        "packages/remeda",
+        "packages/stackblitz-template",
+        "packages/typescript-playground-viewer"
       ],
       "dependencies": {
         "husky": "^9.1.7"
@@ -3826,6 +3827,10 @@
       "resolved": "packages/stackblitz-template",
       "link": true
     },
+    "node_modules/@remeda/typescript-playground-viewer": {
+      "resolved": "packages/typescript-playground-viewer",
+      "link": true
+    },
     "node_modules/@reteps/dockerfmt": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@reteps/dockerfmt/-/dockerfmt-0.3.6.tgz",
@@ -5441,9 +5446,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
-      "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -5505,17 +5510,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
-      "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz",
+      "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/type-utils": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/type-utils": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -5528,7 +5533,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.54.0",
+        "@typescript-eslint/parser": "^8.55.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -5544,16 +5549,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
-      "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
+      "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5569,14 +5574,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
-      "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.55.0.tgz",
+      "integrity": "sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.54.0",
-        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/tsconfig-utils": "^8.55.0",
+        "@typescript-eslint/types": "^8.55.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5591,14 +5596,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
-      "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz",
+      "integrity": "sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0"
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5609,9 +5614,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
-      "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.55.0.tgz",
+      "integrity": "sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5626,15 +5631,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
-      "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.55.0.tgz",
+      "integrity": "sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -5651,9 +5656,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
+      "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5665,16 +5670,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-      "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.55.0.tgz",
+      "integrity": "sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.54.0",
-        "@typescript-eslint/tsconfig-utils": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/project-service": "8.55.0",
+        "@typescript-eslint/tsconfig-utils": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/visitor-keys": "8.55.0",
         "debug": "^4.4.3",
         "minimatch": "^9.0.5",
         "semver": "^7.7.3",
@@ -5693,16 +5698,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
-      "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.55.0.tgz",
+      "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0"
+        "@typescript-eslint/scope-manager": "8.55.0",
+        "@typescript-eslint/types": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5717,13 +5722,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-      "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.55.0.tgz",
+      "integrity": "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/types": "8.55.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -20326,16 +20331,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.54.0.tgz",
-      "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.55.0.tgz",
+      "integrity": "sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.54.0",
-        "@typescript-eslint/parser": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0"
+        "@typescript-eslint/eslint-plugin": "8.55.0",
+        "@typescript-eslint/parser": "8.55.0",
+        "@typescript-eslint/typescript-estree": "8.55.0",
+        "@typescript-eslint/utils": "8.55.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -22602,6 +22607,29 @@
         "@types/node": "^25.2.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
+      }
+    },
+    "packages/typescript-playground-viewer": {
+      "name": "@remeda/typescript-playground-viewer",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "remeda": "*"
+      },
+      "bin": {
+        "typescript-playground-viewer": "src/index.ts"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@types/node": "^25.2.3",
+        "eslint": "^9.39.2",
+        "eslint-plugin-unicorn": "^62.0.0",
+        "globals": "^17.3.0",
+        "prettier": "^3.8.1",
+        "prettier-plugin-pkg": "^0.21.2",
+        "prettier-plugin-sh": "^0.18.0",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.55.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "private": true,
   "workspaces": [
-    "packages/remeda",
     "packages/docs",
-    "packages/stackblitz-template"
+    "packages/remeda",
+    "packages/stackblitz-template",
+    "packages/typescript-playground-viewer"
   ],
   "scripts": {
     "docs:build": "npm run build --workspaces",

--- a/packages/typescript-playground-viewer/.gitignore
+++ b/packages/typescript-playground-viewer/.gitignore
@@ -1,0 +1,1 @@
+.ts-cache

--- a/packages/typescript-playground-viewer/eslint.config.ts
+++ b/packages/typescript-playground-viewer/eslint.config.ts
@@ -1,27 +1,21 @@
-import js from "@eslint/js";
+import eslint from "@eslint/js";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default defineConfig([
-  {
-    files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
-    plugins: {
-      js,
-    },
-    extends: ["js/recommended"],
-    languageOptions: {
-      globals: globals.nodeBuiltin,
-    },
-  },
-
+  eslint.configs.recommended,
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   eslintPluginUnicorn.configs.all,
 
   {
     languageOptions: {
+      globals: {
+        ...globals.nodeBuiltin,
+      },
+
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,

--- a/packages/typescript-playground-viewer/eslint.config.ts
+++ b/packages/typescript-playground-viewer/eslint.config.ts
@@ -1,0 +1,42 @@
+import js from "@eslint/js";
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default defineConfig([
+  {
+    files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
+    plugins: {
+      js,
+    },
+    extends: ["js/recommended"],
+    languageOptions: {
+      globals: globals.nodeBuiltin,
+    },
+  },
+
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  eslintPluginUnicorn.configs.all,
+
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+
+  {
+    rules: {
+      curly: "warn",
+      eqeqeq: "warn",
+
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+      "unicorn/prevent-abbreviations": "off",
+      "unicorn/switch-case-braces": ["error", "avoid"],
+    },
+  },
+]);

--- a/packages/typescript-playground-viewer/package.json
+++ b/packages/typescript-playground-viewer/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@remeda/typescript-playground-viewer",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Decode TypeScript Playground URLs and view source code, compiler options, and diagnostics",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/remeda/remeda.git"
+  },
+  "homepage": "https://github.com/remeda/remeda#readme",
+  "bugs": {
+    "url": "https://github.com/remeda/remeda/issues"
+  },
+  "author": "Eran Hirsch",
+  "license": "MIT",
+  "private": true,
+  "bin": {
+    "typescript-playground-viewer": "src/index.ts"
+  },
+  "keywords": [
+    "typescript",
+    "playground",
+    "decoder",
+    "cli"
+  ],
+  "scripts": {
+    "check": "tsc",
+    "format": "prettier . --write",
+    "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/",
+    "start": "node src/index.ts"
+  },
+  "dependencies": {
+    "remeda": "*"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^25.2.3",
+    "eslint": "^9.39.2",
+    "eslint-plugin-unicorn": "^62.0.0",
+    "globals": "^17.3.0",
+    "prettier": "^3.8.1",
+    "prettier-plugin-pkg": "^0.21.2",
+    "prettier-plugin-sh": "^0.18.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.55.0"
+  }
+}

--- a/packages/typescript-playground-viewer/prettier.config.js
+++ b/packages/typescript-playground-viewer/prettier.config.js
@@ -1,0 +1,4 @@
+/** @type {import('prettier').Config} */
+export default {
+  plugins: ["prettier-plugin-pkg", "prettier-plugin-sh"],
+};

--- a/packages/typescript-playground-viewer/src/compiler-options.ts
+++ b/packages/typescript-playground-viewer/src/compiler-options.ts
@@ -1,0 +1,119 @@
+import { fromEntries, mapValues, omit, pipe } from "remeda";
+
+// The playground encodes enum options as numeric strings. These maps translate
+// them back to the string values tsconfig.json expects.
+const ENUM_MAPS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  target: {
+    1: "ES5",
+    2: "ES2015",
+    3: "ES2016",
+    4: "ES2017",
+    5: "ES2018",
+    6: "ES2019",
+    7: "ES2020",
+    8: "ES2021",
+    9: "ES2022",
+    10: "ES2023",
+    99: "ESNext",
+  },
+  module: {
+    0: "None",
+    1: "CommonJS",
+    2: "AMD",
+    3: "UMD",
+    4: "System",
+    5: "ES2015",
+    6: "ES2020",
+    7: "ES2022",
+    99: "ESNext",
+    100: "Node16",
+    199: "NodeNext",
+  },
+  moduleResolution: {
+    1: "Classic",
+    2: "Node",
+    3: "Node16",
+    99: "NodeNext",
+    100: "Bundler",
+  },
+  jsx: {
+    1: "preserve",
+    2: "react",
+    3: "react-native",
+    4: "react-jsx",
+    5: "react-jsxdev",
+  },
+} satisfies Record<string, Record<`${number}`, string>>;
+
+const SERIALIZED_BOOLEAN: Readonly<Record<string, boolean>> = {
+  true: true,
+  false: false,
+} as const;
+
+// Playground UI params that aren't compiler options.
+const IGNORED_PARAMS = ["ts", "filetype", "install-plugin"] as const;
+
+// Defaults from the TypeScript playground source code:
+// https://github.com/microsoft/TypeScript-Website/blob/v2/packages/sandbox/src/compilerOptions.ts
+const PLAYGROUND_DEFAULT_OPTIONS = {
+  // Type checking
+  strict: true,
+  noImplicitAny: true,
+  strictNullChecks: true,
+  strictFunctionTypes: true,
+  strictPropertyInitialization: true,
+  strictBindCallApply: true,
+  noImplicitThis: true,
+  noImplicitReturns: true,
+  noUncheckedIndexedAccess: false,
+  useDefineForClassFields: false,
+  alwaysStrict: true,
+  allowUnreachableCode: false,
+  allowUnusedLabels: false,
+  noStrictGenericChecks: false,
+  noUnusedLocals: false,
+  noUnusedParameters: false,
+
+  // Modules
+  module: "ESNext",
+  moduleResolution: "Node",
+  esModuleInterop: true,
+
+  // Emit
+  downlevelIteration: false,
+  noEmitHelpers: false,
+  noEmit: true,
+  declaration: true,
+  preserveConstEnums: false,
+  removeComments: false,
+  importHelpers: false,
+
+  // Environment
+  target: "ES2017",
+  jsx: "react",
+  experimentalDecorators: true,
+  emitDecoratorMetadata: true,
+  lib: ["ES2017", "DOM"],
+
+  // Other
+  noLib: false,
+  skipLibCheck: false,
+  checkJs: false,
+  allowJs: false,
+} as const;
+
+export function computeCompilerOptions(
+  searchParams: URLSearchParams,
+): Record<string, unknown> {
+  const overrides = pipe(
+    [...searchParams.entries()],
+    fromEntries(),
+    mapValues(
+      (value, key) =>
+        ENUM_MAPS[key]?.[value] ?? SERIALIZED_BOOLEAN[value] ?? value,
+    ),
+    omit(IGNORED_PARAMS),
+  );
+
+  return { ...PLAYGROUND_DEFAULT_OPTIONS, ...overrides };
+}

--- a/packages/typescript-playground-viewer/src/compiler-options.ts
+++ b/packages/typescript-playground-viewer/src/compiler-options.ts
@@ -1,119 +1,183 @@
-import { fromEntries, mapValues, omit, pipe } from "remeda";
+/* eslint-disable @typescript-eslint/no-deprecated --
+ * The playground still supports legacy TypeScript versions and thus also supports deprecated options and values. This is OK.
+ */
 
-// The playground encodes enum options as numeric strings. These maps translate
-// them back to the string values tsconfig.json expects.
-const ENUM_MAPS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  target: {
-    1: "ES5",
-    2: "ES2015",
-    3: "ES2016",
-    4: "ES2017",
-    5: "ES2018",
-    6: "ES2019",
-    7: "ES2020",
-    8: "ES2021",
-    9: "ES2022",
-    10: "ES2023",
-    99: "ESNext",
-  },
-  module: {
-    0: "None",
-    1: "CommonJS",
-    2: "AMD",
-    3: "UMD",
-    4: "System",
-    5: "ES2015",
-    6: "ES2020",
-    7: "ES2022",
-    99: "ESNext",
-    100: "Node16",
-    199: "NodeNext",
-  },
-  moduleResolution: {
-    1: "Classic",
-    2: "Node",
-    3: "Node16",
-    99: "NodeNext",
-    100: "Bundler",
-  },
-  jsx: {
-    1: "preserve",
-    2: "react",
-    3: "react-native",
-    4: "react-jsx",
-    5: "react-jsxdev",
-  },
-} satisfies Record<string, Record<`${number}`, string>>;
+import { keys } from "remeda";
+import {
+  JsxEmit,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptTarget,
+  type CompilerOptions,
+} from "typescript";
 
-const SERIALIZED_BOOLEAN: Readonly<Record<string, boolean>> = {
-  true: true,
-  false: false,
-} as const;
-
-// Playground UI params that aren't compiler options.
-const IGNORED_PARAMS = ["ts", "filetype", "install-plugin"] as const;
-
-// Defaults from the TypeScript playground source code:
-// https://github.com/microsoft/TypeScript-Website/blob/v2/packages/sandbox/src/compilerOptions.ts
+// Default compiler options copied from the playground UI.
 const PLAYGROUND_DEFAULT_OPTIONS = {
-  // Type checking
+  target: ScriptTarget.ES2017,
+  jsx: JsxEmit.React,
+  module: ModuleKind.ESNext,
+
+  // Output Formatting
+  preserveWatchOutput: false,
+  pretty: false,
+  noErrorTruncation: false,
+
+  // Emit
+  declaration: true,
+  inlineSourceMap: false,
+  removeComments: false,
+  importHelpers: false,
+  downlevelIteration: false,
+  inlineSources: false,
+  stripInternal: false,
+  noEmitHelpers: false,
+  preserveConstEnums: false,
+
+  // Compiler Diagnostics
+  noCheck: false,
+
+  // Interop Constraints
+  isolatedModules: false,
+  verbatimModuleSyntax: false,
+  isolatedDeclarations: false,
+  erasableSyntaxOnly: false,
+  allowSyntheticDefaultImports: false,
+  esModuleInterop: true,
+
+  // Language and Environment
+  libReplacement: false,
+  experimentalDecorators: false,
+  emitDecoratorMetadata: false,
+  noLib: false,
+  useDefineForClassFields: false,
+
+  // Type Checking
   strict: true,
   noImplicitAny: true,
   strictNullChecks: true,
   strictFunctionTypes: true,
-  strictPropertyInitialization: true,
   strictBindCallApply: true,
+  strictPropertyInitialization: true,
+  strictBuiltinIteratorReturn: false,
   noImplicitThis: true,
-  noImplicitReturns: true,
-  noUncheckedIndexedAccess: false,
-  useDefineForClassFields: false,
+  useUnknownInCatchVariables: false,
   alwaysStrict: true,
-  allowUnreachableCode: false,
-  allowUnusedLabels: false,
-  noStrictGenericChecks: false,
   noUnusedLocals: false,
   noUnusedParameters: false,
+  exactOptionalPropertyTypes: false,
+  noImplicitReturns: true,
+  noFallthroughCasesInSwitch: false,
+  noUncheckedIndexedAccess: false,
+  noImplicitOverride: false,
+  noPropertyAccessFromIndexSignature: false,
+  allowUnusedLabels: false,
+  allowUnreachableCode: false,
 
   // Modules
-  module: "ESNext",
-  moduleResolution: "Node",
-  esModuleInterop: true,
+  allowUmdGlobalAccess: false,
+  allowImportingTsExtensions: false,
+  rewriteRelativeImportExtensions: false,
+  resolvePackageJsonExports: false,
+  resolvePackageJsonImports: false,
+  noUncheckedSideEffectImports: false,
+  allowArbitraryExtensions: false,
+
+  // Projects
+  disableSourceOfProjectReferenceRedirect: false,
+
+  // Backwards Compatibility
+  noImplicitUseStrict: false,
+  suppressExcessPropertyErrors: false,
+  suppressImplicitAnyIndexErrors: false,
+  noStrictGenericChecks: false,
+  preserveValueImports: false,
+  keyofStringsOnly: false,
+} as const satisfies CompilerOptions;
+
+// Defaults from the TypeScript playground source code which are not configurable via the UI.
+// @see https://github.com/microsoft/TypeScript-Website/blob/v2/packages/sandbox/src/compilerOptions.ts
+const PLAYGROUND_IMPLICIT_DEFAULTS = {
+  // Type checking
+  moduleResolution: ModuleResolutionKind.NodeJs,
 
   // Emit
-  downlevelIteration: false,
-  noEmitHelpers: false,
   noEmit: true,
-  declaration: true,
-  preserveConstEnums: false,
-  removeComments: false,
-  importHelpers: false,
 
   // Environment
-  target: "ES2017",
-  jsx: "react",
-  experimentalDecorators: true,
-  emitDecoratorMetadata: true,
   lib: ["ES2017", "DOM"],
 
   // Other
-  noLib: false,
   skipLibCheck: false,
   checkJs: false,
   allowJs: false,
-} as const;
+} as const satisfies Omit<
+  CompilerOptions,
+  keyof typeof PLAYGROUND_DEFAULT_OPTIONS
+>;
 
-export function computeCompilerOptions(
+export const computeCompilerOptions = (
   searchParams: URLSearchParams,
-): Record<string, unknown> {
-  const overrides = pipe(
-    [...searchParams.entries()],
-    fromEntries(),
-    mapValues(
-      (value, key) =>
-        ENUM_MAPS[key]?.[value] ?? SERIALIZED_BOOLEAN[value] ?? value,
-    ),
-    omit(IGNORED_PARAMS),
-  );
+): CompilerOptions => ({
+  ...PLAYGROUND_DEFAULT_OPTIONS,
+  ...PLAYGROUND_IMPLICIT_DEFAULTS,
+  ...extractCustomOptions(searchParams),
+});
 
-  return { ...PLAYGROUND_DEFAULT_OPTIONS, ...overrides };
+function extractCustomOptions(
+  searchParams: URLSearchParams,
+): Partial<CompilerOptions> {
+  const customOptions: CompilerOptions = {};
+
+  for (const option of keys(PLAYGROUND_DEFAULT_OPTIONS)) {
+    // We only allow modifying the options that are available in the UX to begin with, to avoid opening up the query param as a way to inject other settings.
+    const value = searchParams.get(option);
+    if (value === null) {
+      // Option isn't provided in the query.
+      continue;
+    }
+
+    switch (option) {
+      case "target":
+        customOptions.target = parseEnum(ScriptTarget, value);
+        break;
+
+      case "jsx":
+        customOptions.jsx = parseEnum(JsxEmit, value);
+        break;
+
+      case "module":
+        customOptions.module = parseEnum(ModuleKind, value);
+        break;
+
+      default:
+        // A boolean option
+        if (value === "true") {
+          customOptions[option] = true;
+        } else if (value === "false") {
+          customOptions[option] = false;
+        } else {
+          throw new Error(
+            `Invalid value for boolean compiler option "${option}": expected "true" or "false" but got: ${value}`,
+          );
+        }
+    }
+  }
+
+  return customOptions;
+}
+
+function parseEnum<E extends Readonly<Record<number, unknown>>>(
+  enumObject: E,
+  value: string,
+): E[keyof E & string] {
+  const parsed = Number(value);
+
+  if (!(parsed in enumObject)) {
+    throw new Error(
+      `Invalid value for enum compiler option, expected: ${JSON.stringify(enumObject)}, got: ${value}`,
+    );
+  }
+
+  // @ts-expect-error [ts2322] -- TypeScript isn't inferring that parsed is a valid key of E although it satisfies the condition that it is **in** E.
+  return parsed;
 }

--- a/packages/typescript-playground-viewer/src/diagnostics.ts
+++ b/packages/typescript-playground-viewer/src/diagnostics.ts
@@ -1,39 +1,19 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { CompilerOptions } from "typescript";
 
-const TS_CACHE_DIR = path.join(import.meta.dirname, "..", ".ts-cache");
-
 const RE_IMPORT =
   /(?:import|export)\s.*?from\s+["']([^"'./][^"']*)["']|require\(\s*["']([^"'./][^"']*)["']\s*\)/g;
 
-export function runPlayground(
-  version: string,
-  code: string,
-  compilerOptions: Record<string, unknown>,
-) {
-  const typeScript = loadTypeScript(version);
+const PLAYGROUND_FILENAME = "playground.ts";
 
-  // Merge playground defaults with URL overrides, then let TypeScript
-  // convert the JSON representation to proper CompilerOptions (enums etc.).
-  const { options } = typeScript.convertCompilerOptionsFromJson(
-    compilerOptions,
-    "." /* basePath */,
-  );
-
-  return getDiagnostics(typeScript, code, options);
-}
-
-function getDiagnostics(
+export function getDiagnostics(
   ts: typeof import("typescript"),
   code: string,
   compilerOptions: CompilerOptions,
 ): string {
-  const fileName = "playground.ts";
-
   // For ATA: if the code imports packages, install them into a temp dir so
   // module resolution can find their types.
   const imports = extractBareImports(code);
@@ -54,18 +34,23 @@ function getDiagnostics(
     // Virtual playground.ts — no need to write it to disk.
     const originalGetSourceFile = host.getSourceFile.bind(host);
     host.getSourceFile = (name, languageVersionOrOptions, ...rest) => {
-      if (name === fileName) {
-        return ts.createSourceFile(fileName, code, languageVersionOrOptions);
+      if (name === PLAYGROUND_FILENAME) {
+        return ts.createSourceFile(
+          PLAYGROUND_FILENAME,
+          code,
+          languageVersionOrOptions,
+        );
       }
       return originalGetSourceFile(name, languageVersionOrOptions, ...rest);
     };
 
     const originalFileExists = host.fileExists.bind(host);
-    host.fileExists = (name) => name === fileName || originalFileExists(name);
+    host.fileExists = (name) =>
+      name === PLAYGROUND_FILENAME || originalFileExists(name);
 
     const originalReadFile = host.readFile.bind(host);
     host.readFile = (name) =>
-      name === fileName ? code : originalReadFile(name);
+      name === PLAYGROUND_FILENAME ? code : originalReadFile(name);
 
     // Point module resolution at the temp dir so tsc finds installed packages.
     if (tempDir !== undefined) {
@@ -73,7 +58,11 @@ function getDiagnostics(
       host.getCurrentDirectory = () => dir;
     }
 
-    const program = ts.createProgram([fileName], compilerOptions, host);
+    const program = ts.createProgram(
+      [PLAYGROUND_FILENAME],
+      compilerOptions,
+      host,
+    );
     const diagnostics = ts.getPreEmitDiagnostics(program);
 
     if (diagnostics.length === 0) {
@@ -93,22 +82,6 @@ function getDiagnostics(
       rmSync(tempDir, { recursive: true, force: true });
     }
   }
-}
-
-function loadTypeScript(version: string): typeof import("typescript") {
-  const prefix = path.join(TS_CACHE_DIR, version);
-  const modulePath = path.join(prefix, "node_modules", "typescript");
-
-  // Install into the cache on first use.
-  if (!existsSync(modulePath)) {
-    execSync(`npm install --prefix ${prefix} typescript@${version}`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    });
-  }
-
-  const require = createRequire(path.join(prefix, "_"));
-  return require(modulePath) as typeof import("typescript");
 }
 
 /**

--- a/packages/typescript-playground-viewer/src/index.ts
+++ b/packages/typescript-playground-viewer/src/index.ts
@@ -3,7 +3,7 @@
 import { main } from "./main.js";
 
 try {
-  main(process.argv.slice(2));
+  await main(process.argv.slice(1));
   process.exit(0);
 } catch (error) {
   console.error("Unexpected error:", error);

--- a/packages/typescript-playground-viewer/src/index.ts
+++ b/packages/typescript-playground-viewer/src/index.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { main } from "./main.js";
+
+try {
+  main(process.argv.slice(2));
+  process.exit(0);
+} catch (error) {
+  console.error("Unexpected error:", error);
+  process.exit(1);
+}

--- a/packages/typescript-playground-viewer/src/lzstring.ts
+++ b/packages/typescript-playground-viewer/src/lzstring.ts
@@ -21,13 +21,13 @@ export function* decompressLZString(
     switch (bits) {
       case 0:
         // read word marker.
-        current = String.fromCharCode(readBits(stream, 8 /* numBits */));
+        current = String.fromCodePoint(readBits(stream, 8 /* numBits */));
         dictionary.push(current);
         break;
 
       case 1:
         // read dword marker.
-        current = String.fromCharCode(readBits(stream, 16 /* numBits */));
+        current = String.fromCodePoint(readBits(stream, 16 /* numBits */));
         dictionary.push(current);
         break;
 

--- a/packages/typescript-playground-viewer/src/lzstring.ts
+++ b/packages/typescript-playground-viewer/src/lzstring.ts
@@ -1,0 +1,97 @@
+const LZ_STRING_ENCODING =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
+
+// LZString algorithm based on lz-string by Pieroxy (MIT license).
+// https://github.com/pieroxy/lz-string
+export function* decompressLZString(
+  charactersStream: Iterable<string>,
+): Generator<string> {
+  const stream = bitsStream(charactersStream);
+
+  // Initialize the dictionary with the 3 special markers.
+  const dictionary = ["<readWord>", "<readDWord>", "<endStream>"];
+
+  let previous;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const numBits = Math.ceil(Math.log2(dictionary.length + 1));
+    const bits = readBits(stream, numBits);
+
+    let current;
+    switch (bits) {
+      case 0:
+        // read word marker.
+        current = String.fromCharCode(readBits(stream, 8 /* numBits */));
+        dictionary.push(current);
+        break;
+
+      case 1:
+        // read dword marker.
+        current = String.fromCharCode(readBits(stream, 16 /* numBits */));
+        dictionary.push(current);
+        break;
+
+      case 2:
+        // End of stream marker.
+        return;
+
+      case dictionary.length:
+        // KwKwK edge case: code references the entry about to be added.
+        if (previous === undefined) {
+          throw new Error(
+            "Invalid LZString encoding: reference to previous character before it is defined",
+          );
+        }
+        current = previous + (previous.at(0) ?? "");
+        break;
+
+      default:
+        // Back-reference to an existing dictionary entry.
+        current = dictionary[bits];
+        if (current === undefined) {
+          throw new Error(
+            `Invalid dictionary reference at index ${String(bits)}`,
+          );
+        }
+    }
+
+    yield current;
+    if (previous !== undefined) {
+      dictionary.push(previous + (current.at(0) ?? ""));
+    }
+
+    previous = current;
+  }
+}
+
+function* bitsStream(input: Iterable<string>): Generator<boolean> {
+  for (const char of input) {
+    const encoding = LZ_STRING_ENCODING.indexOf(char);
+    if (encoding === -1) {
+      throw new Error(`Invalid character in encoded string: ${char}`);
+    }
+
+    for (let bitMask = 0b10_0000; bitMask > 0; bitMask >>= 1) {
+      yield (encoding & bitMask) !== 0;
+    }
+  }
+}
+
+function readBits(source: Generator<boolean>, numBits: number): number {
+  let bits = 0b0;
+
+  for (let i = 0; i < numBits; i++) {
+    const bit = source.next();
+    if (bit.done) {
+      throw new Error(
+        `Unexpected end of input while reading bits (expected ${numBits.toString()} bits)`,
+      );
+    }
+
+    if (bit.value) {
+      bits |= 0b1 << i;
+    }
+  }
+
+  return bits;
+}

--- a/packages/typescript-playground-viewer/src/main.ts
+++ b/packages/typescript-playground-viewer/src/main.ts
@@ -1,8 +1,9 @@
 import { computeCompilerOptions } from "./compiler-options.js";
+import { getDiagnostics } from "./diagnostics.js";
 import { decompressLZString } from "./lzstring.js";
 import { outputMarkdown } from "./markdown.js";
-import { runPlayground } from "./playground.js";
 import { resolveNPMVersionAlias } from "./resolve-npm-alias.js";
+import { loadTypeScript } from "./typescript-loader.js";
 
 // We only support absolute URLs which resolve cleanly to the official
 // playground!
@@ -64,7 +65,8 @@ export async function main([
 
   const compilerOptions = computeCompilerOptions(searchParams);
 
-  const diagnostics = runPlayground(effectiveVersion, code, compilerOptions);
+  const typeScript = loadTypeScript(effectiveVersion);
+  const diagnostics = getDiagnostics(typeScript, code, compilerOptions);
 
   outputMarkdown({ code, diagnostics, effectiveVersion, compilerOptions });
 }

--- a/packages/typescript-playground-viewer/src/main.ts
+++ b/packages/typescript-playground-viewer/src/main.ts
@@ -1,0 +1,57 @@
+// Decodes a TypeScript Playground URL and type-checks the embedded code using
+// the TypeScript compiler API. Outputs the source code, compiler options, and
+// any diagnostics — giving Claude the same view the user sees in the
+// playground.
+
+import { computeCompilerOptions } from "./compiler-options.js";
+import { decompressLZString } from "./lzstring.js";
+import { outputMarkdown } from "./markdown.js";
+import { runPlayground } from "./playground.js";
+
+// We only support absolute URLs which resolve cleanly to the official
+// playground!
+const PLAYGROUND_ORIGIN = "https://www.typescriptlang.org";
+const PLAYGROUND_PATHNAME = "/play";
+const PLAYGROUND_CODE_HASH_PREFIX = "#code/";
+
+export function main([urlString]: readonly string[]): void {
+  if (urlString === undefined) {
+    throw new Error("Usage: decode-playground.ts <playground-url>");
+  }
+
+  const url = new URL(urlString);
+  if (
+    url.origin !== PLAYGROUND_ORIGIN ||
+    url.pathname !== PLAYGROUND_PATHNAME
+  ) {
+    throw new Error("Usage: decode-playground.ts <playground-url>");
+  }
+
+  const code = extractPlaygroundCode(url);
+
+  // Install and load the TypeScript version specified in the URL's `ts` query
+  // param (or `latest` if absent), caching each version in `.ts-cache/`.
+  const version = url.searchParams.get("ts") ?? "latest";
+
+  const compilerOptions = computeCompilerOptions(url.searchParams);
+
+  const { effectiveVersion, diagnostics } = runPlayground(
+    version,
+    code,
+    compilerOptions,
+  );
+
+  outputMarkdown({ code, diagnostics, effectiveVersion, compilerOptions });
+}
+
+function extractPlaygroundCode({ hash }: URL) {
+  const [preamble, encoded] = hash.split(
+    PLAYGROUND_CODE_HASH_PREFIX,
+    2 /* parts */,
+  );
+  if (preamble !== "" || encoded === undefined) {
+    throw new Error(`Failed to extract encoded code from hash: ${hash}`);
+  }
+
+  return [...decompressLZString(encoded)].join("");
+}

--- a/packages/typescript-playground-viewer/src/main.ts
+++ b/packages/typescript-playground-viewer/src/main.ts
@@ -1,12 +1,8 @@
-// Decodes a TypeScript Playground URL and type-checks the embedded code using
-// the TypeScript compiler API. Outputs the source code, compiler options, and
-// any diagnostics — giving Claude the same view the user sees in the
-// playground.
-
 import { computeCompilerOptions } from "./compiler-options.js";
 import { decompressLZString } from "./lzstring.js";
 import { outputMarkdown } from "./markdown.js";
 import { runPlayground } from "./playground.js";
+import { resolveNPMVersionAlias } from "./resolve-npm-alias.js";
 
 // We only support absolute URLs which resolve cleanly to the official
 // playground!
@@ -14,44 +10,61 @@ const PLAYGROUND_ORIGIN = "https://www.typescriptlang.org";
 const PLAYGROUND_PATHNAME = "/play";
 const PLAYGROUND_CODE_HASH_PREFIX = "#code/";
 
-export function main([urlString]: readonly string[]): void {
+export async function main([
+  scriptName,
+  urlString,
+]: readonly string[]): Promise<void> {
   if (urlString === undefined) {
-    throw new Error("Usage: decode-playground.ts <playground-url>");
+    throw new Error(`Usage: ${scriptName ?? "<script>"} <playground-url>`);
   }
 
-  const url = new URL(urlString);
-  if (
-    url.origin !== PLAYGROUND_ORIGIN ||
-    url.pathname !== PLAYGROUND_PATHNAME
-  ) {
-    throw new Error("Usage: decode-playground.ts <playground-url>");
+  const { origin, pathname, searchParams, hash } = new URL(urlString);
+  if (origin !== PLAYGROUND_ORIGIN) {
+    throw new Error(
+      `Invalid playground URL origin: expected ${PLAYGROUND_ORIGIN} but got ${origin}`,
+    );
   }
 
-  const code = extractPlaygroundCode(url);
+  if (pathname !== PLAYGROUND_PATHNAME) {
+    throw new Error(
+      `Invalid playground URL pathname: expected ${PLAYGROUND_PATHNAME} but got ${pathname}`,
+    );
+  }
 
-  // Install and load the TypeScript version specified in the URL's `ts` query
-  // param (or `latest` if absent), caching each version in `.ts-cache/`.
-  const version = url.searchParams.get("ts") ?? "latest";
-
-  const compilerOptions = computeCompilerOptions(url.searchParams);
-
-  const { effectiveVersion, diagnostics } = runPlayground(
-    version,
-    code,
-    compilerOptions,
-  );
-
-  outputMarkdown({ code, diagnostics, effectiveVersion, compilerOptions });
-}
-
-function extractPlaygroundCode({ hash }: URL) {
   const [preamble, encoded] = hash.split(
     PLAYGROUND_CODE_HASH_PREFIX,
     2 /* parts */,
   );
-  if (preamble !== "" || encoded === undefined) {
-    throw new Error(`Failed to extract encoded code from hash: ${hash}`);
+  if (preamble !== "") {
+    throw new Error(
+      `Invalid playground URL hash: expected to start with ${PLAYGROUND_CODE_HASH_PREFIX} but got ${hash}`,
+    );
   }
 
-  return [...decompressLZString(encoded)].join("");
+  if (encoded === undefined) {
+    throw new Error(
+      `Invalid playground URL hash: missing encoded code after ${PLAYGROUND_CODE_HASH_PREFIX}`,
+    );
+  }
+
+  const fileType = searchParams.get("filetype") ?? "ts";
+  if (fileType !== "ts") {
+    // For now we only support the basic mode...
+    throw new Error(
+      `Unsupported filetype: expected "ts" or no filetype but got ${fileType}`,
+    );
+  }
+
+  const code = [...decompressLZString(encoded)].join("");
+
+  const effectiveVersion = await resolveNPMVersionAlias(
+    "typescript",
+    searchParams.get("ts"),
+  );
+
+  const compilerOptions = computeCompilerOptions(searchParams);
+
+  const diagnostics = runPlayground(effectiveVersion, code, compilerOptions);
+
+  outputMarkdown({ code, diagnostics, effectiveVersion, compilerOptions });
 }

--- a/packages/typescript-playground-viewer/src/markdown.ts
+++ b/packages/typescript-playground-viewer/src/markdown.ts
@@ -1,0 +1,39 @@
+type Output = {
+  readonly code: string;
+  readonly diagnostics: string;
+  readonly effectiveVersion: string;
+  readonly compilerOptions: Record<string, unknown>;
+};
+
+export function outputMarkdown({
+  code,
+  diagnostics,
+  effectiveVersion,
+  compilerOptions,
+}: Output): void {
+  // -- Frontmatter --
+  console.log("---");
+  console.log(`typeScriptVersion: ${effectiveVersion}`);
+  const compilerOptionOverrides = Object.entries(compilerOptions).filter(
+    ([key]) => key !== "ts",
+  );
+  if (compilerOptionOverrides.length > 0) {
+    console.log("compilerOptions:");
+    for (const [key, value] of compilerOptionOverrides) {
+      console.log(`  ${key}: ${JSON.stringify(value)}`);
+    }
+  }
+  console.log("---\n");
+
+  // -- Source --
+  console.log("# Source\n");
+  console.log(`\`\`\`typescript\n${code}\n\`\`\`\n`);
+
+  // -- Diagnostics --
+  console.log("# Diagnostics\n");
+  if (diagnostics === "") {
+    console.log("No errors or warnings.");
+  } else {
+    console.log(diagnostics);
+  }
+}

--- a/packages/typescript-playground-viewer/src/playground.ts
+++ b/packages/typescript-playground-viewer/src/playground.ts
@@ -24,12 +24,7 @@ export function runPlayground(
     "." /* basePath */,
   );
 
-  const diagnostics = getDiagnostics(typeScript, code, options);
-
-  return {
-    effectiveVersion: typeScript.version,
-    diagnostics,
-  };
+  return getDiagnostics(typeScript, code, options);
 }
 
 function getDiagnostics(

--- a/packages/typescript-playground-viewer/src/playground.ts
+++ b/packages/typescript-playground-viewer/src/playground.ts
@@ -1,0 +1,158 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { CompilerOptions } from "typescript";
+
+const TS_CACHE_DIR = path.join(import.meta.dirname, "..", ".ts-cache");
+
+const RE_IMPORT =
+  /(?:import|export)\s.*?from\s+["']([^"'./][^"']*)["']|require\(\s*["']([^"'./][^"']*)["']\s*\)/g;
+
+export function runPlayground(
+  version: string,
+  code: string,
+  compilerOptions: Record<string, unknown>,
+) {
+  const typeScript = loadTypeScript(version);
+
+  // Merge playground defaults with URL overrides, then let TypeScript
+  // convert the JSON representation to proper CompilerOptions (enums etc.).
+  const { options } = typeScript.convertCompilerOptionsFromJson(
+    compilerOptions,
+    "." /* basePath */,
+  );
+
+  const diagnostics = getDiagnostics(typeScript, code, options);
+
+  return {
+    effectiveVersion: typeScript.version,
+    diagnostics,
+  };
+}
+
+function getDiagnostics(
+  ts: typeof import("typescript"),
+  code: string,
+  compilerOptions: CompilerOptions,
+): string {
+  const fileName = "playground.ts";
+
+  // For ATA: if the code imports packages, install them into a temp dir so
+  // module resolution can find their types.
+  const imports = extractBareImports(code);
+  let tempDir: string | undefined;
+
+  if (imports.length > 0) {
+    tempDir = mkdtempSync(path.join(tmpdir(), "playground-"));
+    writeFileSync(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ private: true }),
+    );
+    installPackages(tempDir, imports);
+  }
+
+  try {
+    const host = ts.createCompilerHost(compilerOptions);
+
+    // Virtual playground.ts — no need to write it to disk.
+    const originalGetSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, languageVersionOrOptions, ...rest) => {
+      if (name === fileName) {
+        return ts.createSourceFile(fileName, code, languageVersionOrOptions);
+      }
+      return originalGetSourceFile(name, languageVersionOrOptions, ...rest);
+    };
+
+    const originalFileExists = host.fileExists.bind(host);
+    host.fileExists = (name) => name === fileName || originalFileExists(name);
+
+    const originalReadFile = host.readFile.bind(host);
+    host.readFile = (name) =>
+      name === fileName ? code : originalReadFile(name);
+
+    // Point module resolution at the temp dir so tsc finds installed packages.
+    if (tempDir !== undefined) {
+      const dir = tempDir;
+      host.getCurrentDirectory = () => dir;
+    }
+
+    const program = ts.createProgram([fileName], compilerOptions, host);
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+
+    if (diagnostics.length === 0) {
+      return "";
+    }
+
+    // Format diagnostics with just the filename, not full paths.
+    return ts
+      .formatDiagnostics(diagnostics, {
+        getCurrentDirectory: () => "",
+        getCanonicalFileName: (f) => f,
+        getNewLine: () => "\n",
+      })
+      .trim();
+  } finally {
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function loadTypeScript(version: string): typeof import("typescript") {
+  const prefix = path.join(TS_CACHE_DIR, version);
+  const modulePath = path.join(prefix, "node_modules", "typescript");
+
+  // Install into the cache on first use.
+  if (!existsSync(modulePath)) {
+    execSync(`npm install --prefix ${prefix} typescript@${version}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+  }
+
+  const require = createRequire(path.join(prefix, "_"));
+  return require(modulePath) as typeof import("typescript");
+}
+
+/**
+ * Import detection — replicate the playground's ATA.
+ */
+function extractBareImports(code: string): string[] {
+  // Match import/export specifiers and require() calls that reference bare
+  // modules (not relative paths starting with . or /).
+
+  const packages = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = RE_IMPORT.exec(code)) !== null) {
+    const specifier = match[1] ?? match[2];
+    if (specifier === undefined) {
+      continue;
+    }
+
+    // Extract the package name: "lodash/fp" → "lodash", "@scope/pkg/sub" → "@scope/pkg"
+    const parts = specifier.split("/");
+    const name = specifier.startsWith("@")
+      ? parts.slice(0, 2).join("/")
+      : parts[0];
+    if (name !== undefined) {
+      packages.add(name);
+    }
+  }
+
+  return [...packages];
+}
+
+function installPackages(dir: string, packages: string[]): void {
+  if (packages.length === 0) {
+    return;
+  }
+
+  const pkgList = packages.join(" ");
+  execSync(`npm install --ignore-scripts ${pkgList}`, {
+    cwd: dir,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}

--- a/packages/typescript-playground-viewer/src/resolve-npm-alias.ts
+++ b/packages/typescript-playground-viewer/src/resolve-npm-alias.ts
@@ -1,0 +1,30 @@
+// This includes regular versions like `1.2.3`, and dev versions like `1.2.3-dev.20240606`
+const RE_SEMANTIC_VERSION = /^\d+\.\d+\.(\d+-\w+\.)?\d+$/gu;
+
+export async function resolveNPMVersionAlias(
+  packageName: string,
+  alias: string | null,
+): Promise<string> {
+  if (alias !== null && RE_SEMANTIC_VERSION.test(alias)) {
+    // Already a version-like string.
+    return alias;
+  }
+
+  const response = await fetch(
+    `https://registry.npmjs.org/-/package/${packageName}/dist-tags`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${packageName} dist-tags: ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+
+  const { [alias ?? "latest"]: version } = (await response.json()) as Readonly<
+    Record<string, string>
+  >;
+  if (version === undefined) {
+    throw new Error(`Unknown TypeScript dist-tag "${alias ?? ""}".`);
+  }
+
+  return version;
+}

--- a/packages/typescript-playground-viewer/src/resolve-npm-alias.ts
+++ b/packages/typescript-playground-viewer/src/resolve-npm-alias.ts
@@ -1,11 +1,14 @@
+export type SemanticVersion =
+  `${number}.${number}.${number}${`-${string}.${number}` | ""}`;
+
 // This includes regular versions like `1.2.3`, and dev versions like `1.2.3-dev.20240606`
-const RE_SEMANTIC_VERSION = /^\d+\.\d+\.(\d+-\w+\.)?\d+$/gu;
+const RE_SEMANTIC_VERSION = /^\d+\.\d+\.\d+(-\w+\.\d+)?$/gu;
 
 export async function resolveNPMVersionAlias(
   packageName: string,
   alias: string | null,
-): Promise<string> {
-  if (alias !== null && RE_SEMANTIC_VERSION.test(alias)) {
+): Promise<SemanticVersion> {
+  if (alias !== null && isSemantic(alias)) {
     // Already a version-like string.
     return alias;
   }
@@ -26,5 +29,14 @@ export async function resolveNPMVersionAlias(
     throw new Error(`Unknown TypeScript dist-tag "${alias ?? ""}".`);
   }
 
+  if (!isSemantic(version)) {
+    throw new Error(
+      `Invalid version string "${version}" resolved from dist-tag "${alias ?? ""}".`,
+    );
+  }
+
   return version;
 }
+
+const isSemantic = (version: string): version is SemanticVersion =>
+  RE_SEMANTIC_VERSION.test(version);

--- a/packages/typescript-playground-viewer/src/typescript-loader.ts
+++ b/packages/typescript-playground-viewer/src/typescript-loader.ts
@@ -1,0 +1,39 @@
+import {
+  execFileSync,
+  type ExecFileSyncOptionsWithStringEncoding,
+} from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { SemanticVersion } from "./resolve-npm-alias.js";
+
+const TYPESCRIPT_VERSIONS_CACHE_BASE = path.join(
+  import.meta.dirname,
+  "..",
+  ".ts-cache",
+);
+
+const EXEC_OPTIONS = {
+  encoding: "utf8",
+  stdio: "pipe",
+} satisfies ExecFileSyncOptionsWithStringEncoding;
+
+export function loadTypeScript(
+  version: SemanticVersion,
+): typeof import("typescript") {
+  const versionCacheDir = path.join(TYPESCRIPT_VERSIONS_CACHE_BASE, version);
+
+  // Install into the cache on first use.
+  if (!existsSync(versionCacheDir)) {
+    execFileSync(
+      "npm",
+      ["install", "--prefix", versionCacheDir, `typescript@${version}`],
+      EXEC_OPTIONS,
+    );
+  }
+
+  const require = createRequire(path.join(versionCacheDir, "_"));
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return require(path.join(versionCacheDir, "node_modules", "typescript"));
+}

--- a/packages/typescript-playground-viewer/tsconfig.json
+++ b/packages/typescript-playground-viewer/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "include": ["src", "*.config.ts", "*.config.js"],
+
+  "compilerOptions": {
+    "noEmit": true,
+
+    "module": "nodenext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+
+    "allowJs": true
+  }
+}

--- a/remeda.code-workspace
+++ b/remeda.code-workspace
@@ -5,13 +5,16 @@
       "path": ".",
     },
     {
-      "path": "packages/remeda",
-    },
-    {
       "path": "packages/docs",
     },
     {
+      "path": "packages/remeda",
+    },
+    {
       "path": "packages/stackblitz-template",
+    },
+    {
+      "path": "packages/typescript-playground-viewer",
     },
   ],
 


### PR DESCRIPTION
We work extensively with playground links in issues and in our source code, but agents are not able to view these links because they render in the monaco editor after the page loads.

This cli tool and the skill that uses it provides the agent with a local alternative that extracts the code, runs the compiler on it, and inlines all type comments so that the agent can have the same view of the playground as a human would.