### PR TITLE
chore: don't store the raw scorecard artifact

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,13 +32,6 @@ jobs:
           results_format: sarif
           publish_results: true
 
-      - name: 🗃️ Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: SARIF-results
-          path: results.sarif
-          retention-days: 7
-
       - name: 🛡️ Upload to code-scanning
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:


### PR DESCRIPTION
It serves no purpose and doesn't add any value over the existing publishing channels the scorecard already uses (github, api)