### PR TITLE
chore(release): flip `feat` and `fix` conventional label semantics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,11 +19,10 @@ PRs should be titled following using the format: `< TYPE >(< scope >)?: descript
 
 ### Available Types:
 
-- `feat`: new functions, and changes to a function's type that would impact users.
-- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type that shouldn't impact most users.
-- `test`: tests-only changes (transparent to users of the function).
+- `feat`: new functions or expanded, backwards compatible, capabilities on existing functions.
+- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type.
 - `docs`: changes to the documentation of a function **or the documentation site**.
-- `build`, `ci`, `chore`, and `revert`: are only relevant for the internals of the library.
+- `chore`: anything else that isn't noticeable to library users. This includes test-only changes.
 
 For scope put the name of the function you are working on (either new or
 existing).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ PRs should be titled following using the format: `< TYPE >(< scope >)?: descript
 ### Available Types:
 
 - `feat`: new functions or expanded, backwards compatible, capabilities on existing functions.
-- `fix`: changes to the runtime behavior of an existing function, or refinements to it's type.
+- `fix`: changes to the runtime behavior of an existing function, or refinements to its type.
 - `docs`: changes to the documentation of a function **or the documentation site**.
 - `chore`: anything else that isn't noticeable to library users. This includes test-only changes.
 

--- a/.github/workflows/pr_titles.yml
+++ b/.github/workflows/pr_titles.yml
@@ -18,14 +18,10 @@ jobs:
       - name: 📐 Conventional commit format
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
-          # We use the default types (as defined in:
-          # https://github.com/commitizen/conventional-commit-types).
-          # "feat" would trigger a patch version bump; "fix" would
-          # trigger a minor version bump; anything else would **not**
-          # trigger a release.
+          # see @semantic-release/commit-analyzer for semantics
           types: |
-            feat
             fix
+            feat 
             docs
             chore
         env:

--- a/.github/workflows/pr_titles.yml
+++ b/.github/workflows/pr_titles.yml
@@ -20,18 +20,14 @@ jobs:
         with:
           # We use the default types (as defined in:
           # https://github.com/commitizen/conventional-commit-types).
-          # "feat" would trigger a minor version bump; "fix" would
-          # trigger a patch version bump; anything else would **not**
+          # "feat" would trigger a patch version bump; "fix" would
+          # trigger a minor version bump; anything else would **not**
           # trigger a release.
           types: |
             feat
             fix
-            test
             docs
-            build
-            ci
             chore
-            revert
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Required by the action
 

--- a/.github/workflows/pr_titles.yml
+++ b/.github/workflows/pr_titles.yml
@@ -18,10 +18,9 @@ jobs:
       - name: 📐 Conventional commit format
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
-          # see @semantic-release/commit-analyzer for semantics
           types: |
             fix
-            feat 
+            feat
             docs
             chore
         env:

--- a/packages/remeda/release.config.js
+++ b/packages/remeda/release.config.js
@@ -2,7 +2,19 @@
 export default {
   branches: ["main"],
   plugins: [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        releaseRules: [
+          // Flipped from the default config, new features don't posses a risk
+          // to existing users and thus shouldn't prevent users from upgrading,
+          // but fixes usually impact how utilities already used by users work
+          // (or their typing) and can cause breakages in existing code.
+          { type: "feat", release: "patch" },
+          { type: "fix", release: "minor" },
+        ],
+      },
+    ],
 
     "@semantic-release/release-notes-generator",
 

--- a/packages/remeda/release.config.js
+++ b/packages/remeda/release.config.js
@@ -6,10 +6,10 @@ export default {
       "@semantic-release/commit-analyzer",
       {
         releaseRules: [
-          // Flipped from the default config, new features don't posses a risk
-          // to existing users and thus shouldn't prevent users from upgrading,
-          // but fixes usually impact how utilities already used by users work
-          // (or their typing) and can cause breakages in existing code.
+          // Flipped from the default config! New features don't pose a risk to
+          // existing code and thus shouldn't prevent users from upgrading, but
+          // fixes to existing utilities can impact how they work and might
+          // cause compile or runtime errors for users.
           { type: "feat", release: "patch" },
           { type: "fix", release: "minor" },
         ],


### PR DESCRIPTION
It doesn't make sense for us to release a minor version every time we add a utility or functionality, as those don't impact existing users at all. Instead, fixes to existing utilities are! This is why we decided to flip the two semantically.