### PR TITLE
chore(cc): fix docs local-ci hook hoisting issue

### DIFF
--- a/.claude/hooks/docs-local-ci-checks.ts
+++ b/.claude/hooks/docs-local-ci-checks.ts
@@ -62,8 +62,8 @@ await handleClaudeCodeHook(
   ]),
 );
 
-const hasFilesNewerThan = (directory: string, timestampMs: number) =>
-  readdirSync(directory, { withFileTypes: true, recursive: true })
+function hasFilesNewerThan(directory: string, timestampMs: number) {
+  return readdirSync(directory, { withFileTypes: true, recursive: true })
     .filter(
       (entry) =>
         entry.isFile() &&
@@ -79,3 +79,4 @@ const hasFilesNewerThan = (directory: string, timestampMs: number) =>
       ({ name, parentPath }) =>
         statSync(path.join(parentPath, name)).mtimeMs > timestampMs,
     );
+}


### PR DESCRIPTION
We can't use a const for this function because it's called at the module level and needs to be hoisted. We need to use the function syntax instead.