### PR TITLE
chore: remove local caching for eslint

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
     "check": "astro check",
     "dev": "astro dev",
     "format": "prettier . --write",
-    "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/",
+    "lint": "eslint --fix --max-warnings 0",
     "preview": "astro preview",
     "sync": "astro sync"
   },

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -50,7 +50,7 @@
     "check": "tsc --project tsconfig.source.json",
     "check:dist": "tsc --project tsconfig.dist.json",
     "format": "prettier . --write",
-    "lint": "eslint --fix --max-warnings 0 --cache --cache-location ./node_modules/.cache/eslint/",
+    "lint": "eslint --fix --max-warnings 0",
     "publish:jsr": "jsr publish",
     "publish:preview": "pkg-pr-new publish --compact --template ../stackblitz-template/",
     "test": "vitest",


### PR DESCRIPTION
This was a premature optimization and it is causing issues where the cache isn't invalidated on some changes, hiding issues until they explode in CI
