### PR TITLE
chore(canary): Add the concrete version to the summary

### DIFF
--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm --workspace=remeda install -D typescript@${{ matrix.typescript-version }}
 
       - name: 🎯 Concrete version
-        run: npx --workspace=remeda tsc --version
+        run: npx --workspace=remeda tsc --version | tee -a $GITHUB_STEP_SUMMARY
 
       - name: 🚨 Type check
         run: npm --workspace=remeda run check


### PR DESCRIPTION
Instead of going to the logs manually and looking for the concrete version step, it should now show up above the test results in the github UI