### PR TITLE
docs: Prefer same page results in search

### DIFF
--- a/packages/docs/src/components/header.astro
+++ b/packages/docs/src/components/header.astro
@@ -36,7 +36,11 @@ const NAVLINK_CLASS =
     </MigrationSelector>
     <div class="flex-1"></div>
     <search>
-      <Search client:only="react" url={Astro.url} />
+      <Search
+        client:only="react"
+        pathname={Astro.url.pathname}
+        site={Astro.site}
+      />
     </search>
     <a
       class:list={buttonVariants({ variant: "ghost", size: "icon" })}

--- a/packages/docs/src/components/header.astro
+++ b/packages/docs/src/components/header.astro
@@ -36,7 +36,7 @@ const NAVLINK_CLASS =
     </MigrationSelector>
     <div class="flex-1"></div>
     <search>
-      <Search client:only="react" />
+      <Search client:only="react" url={Astro.url} />
     </search>
     <a
       class:list={buttonVariants({ variant: "ghost", size: "icon" })}

--- a/packages/docs/src/components/search.tsx
+++ b/packages/docs/src/components/search.tsx
@@ -11,7 +11,13 @@ const REPO_URL = "https://github.com/remeda/remeda/";
 // We use a label to make it easier to filter issues coming from this flow...
 const LABELS = "docsearch";
 
-export function Search({ url }: { readonly url: URL }): ReactNode {
+export function Search({
+  site,
+  pathname,
+}: {
+  readonly site: URL | undefined;
+  readonly pathname: string;
+}): ReactNode {
   return (
     <DocSearch
       apiKey={API_KEY}
@@ -26,14 +32,14 @@ export function Search({ url }: { readonly url: URL }): ReactNode {
       indices={[
         {
           name: INDEX_NAME,
-          ...(url.pathname !== "/" && {
+          ...(pathname !== "/" && {
             searchParameters: {
               // We allow the index to boost results based on the current page
               // url so that results within the same page are preferred. We
               // avoid this for the homepage because it is largely a marketing
               // page without substantial content users might be searching for.
               optionalFilters: [
-                `url_without_anchor:${url.origin}${url.pathname}`,
+                `url_without_anchor:${site?.origin ?? ""}${pathname}`,
               ],
             },
           }),

--- a/packages/docs/src/components/search.tsx
+++ b/packages/docs/src/components/search.tsx
@@ -11,12 +11,11 @@ const REPO_URL = "https://github.com/remeda/remeda/";
 // We use a label to make it easier to filter issues coming from this flow...
 const LABELS = "docsearch";
 
-export function Search(): ReactNode {
+export function Search({ url }: { readonly url: URL }): ReactNode {
   return (
     <DocSearch
       apiKey={API_KEY}
       appId={APP_ID}
-      indices={[INDEX_NAME]}
       // eslint-disable-next-line react/jsx-no-bind -- This callback doesn't need to be stable because it is only used during render. @see https://github.com/algolia/docsearch/blob/104f7d1a986d1aef3d85f8dbca3e7197e66bf067/packages/docsearch-react/src/NoResultsScreen.tsx#L65-L74
       getMissingResultsUrl={({ query }) => {
         const issuesUrl = new URL("issues/new", REPO_URL);
@@ -24,6 +23,22 @@ export function Search(): ReactNode {
         issuesUrl.searchParams.set("labels", LABELS);
         return issuesUrl.toString();
       }}
+      indices={[
+        {
+          name: INDEX_NAME,
+          ...(url.pathname !== "/" && {
+            // We allow the index to filter results based on the current page
+            // url so that results within the same page are preferred. We avoid
+            // this for the homepage because it is largely a marketing page
+            // without substantial content users might be searching for.
+            searchParameters: {
+              optionalFilters: [
+                `url_without_anchor:${url.origin}${url.pathname}`,
+              ],
+            },
+          }),
+        },
+      ]}
       navigator={{
         // When navigating to another hash on the same page via "Enter" there
         // is a bug (in Algolia or Astro) where the scroll position is reset to

--- a/packages/docs/src/components/search.tsx
+++ b/packages/docs/src/components/search.tsx
@@ -27,11 +27,11 @@ export function Search({ url }: { readonly url: URL }): ReactNode {
         {
           name: INDEX_NAME,
           ...(url.pathname !== "/" && {
-            // We allow the index to filter results based on the current page
-            // url so that results within the same page are preferred. We avoid
-            // this for the homepage because it is largely a marketing page
-            // without substantial content users might be searching for.
             searchParameters: {
+              // We allow the index to boost results based on the current page
+              // url so that results within the same page are preferred. We
+              // avoid this for the homepage because it is largely a marketing
+              // page without substantial content users might be searching for.
               optionalFilters: [
                 `url_without_anchor:${url.origin}${url.pathname}`,
               ],


### PR DESCRIPTION
we don't have per page search and we use the global docsearch for both site-wide searches and local searches. To allow local searches to bubble up we need to provide additional data to the index based on the URL