### PR TITLE
chore(jsr): workaround for deno issue 29671

### DIFF
--- a/.github/workflows/ci-library.yml
+++ b/.github/workflows/ci-library.yml
@@ -1,4 +1,5 @@
-name: 📦 CI - Library
+# TODO [jsr@>0.14.3]: We can't use an emoji in the workflow name because of https://github.com/denoland/deno/issues/29671
+name: CI - Library
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Internal helpers: `src/internal/`. Type utilities: `src/internal/types/`.
 - **Code as copy-paste source**: This is MIT-licensed code that gets copied verbatim into other projects and then expanded or remixed. The base that gets copied must be high quality — clean, idiomatic, well-commented. Variable and parameter names must be descriptive, unabbreviated, and fitting for the algorithm (e.g., `comparator` not `cmp`, `accumulator` not `acc`). Comments explain **why**, never **what**; focus on complex types and non-obvious algorithmic choices. Never state the obvious; this is a canonical utility library, not a tutorial. The code itself should be clear enough that "what" comments are redundant
 - **Expiring TODOs**: Use `TODO [>N]` syntax to surface stale TODOs at lint time. **Never use date-based expiration** (those explode unexpectedly for whoever runs lint that day). Two forms:
   - `TODO [>2]` — Remeda package version; marks work for the next major bump (e.g., `[>2]` = "do this for v3")
-  - `TODO [typescript>5.5]` — dependency version; for workarounds tied to bugs/missing features in a specific dep version
+  - `TODO [typescript@>5.5]` — dependency version; for workarounds tied to bugs/missing features in a specific dep version
 
 ### PR & Commit Titles
 


### PR DESCRIPTION
https://github.com/denoland/deno/issues/29671 returned to fail our CI almost a year after publishing. This time claude came to the rescue to find the root cause so we can work around it.