### PR TITLE
fix(prop): add undefined for index-signature key access

### DIFF
--- a/packages/remeda/src/prop.test-d.ts
+++ b/packages/remeda/src/prop.test-d.ts
@@ -421,6 +421,110 @@ describe("optional props", () => {
   });
 });
 
+describe("simple records (Issue #1274)", () => {
+  describe("data-first", () => {
+    test("string keys add undefined", () => {
+      expectTypeOf(prop({} as Record<string, number>, "a")).toEqualTypeOf<
+        number | undefined
+      >();
+    });
+
+    test("number keys add undefined", () => {
+      expectTypeOf(prop({} as Record<number, string>, 1)).toEqualTypeOf<
+        string | undefined
+      >();
+    });
+
+    test("union keys add undefined", () => {
+      expectTypeOf(
+        prop({} as Record<string | number, boolean>, "a"),
+      ).toEqualTypeOf<boolean | undefined>();
+    });
+
+    test("template-literal keys add undefined", () => {
+      expectTypeOf(
+        prop({} as Record<`id_${number}`, string>, "id_1"),
+      ).toEqualTypeOf<string | undefined>();
+    });
+
+    test("literal values add undefined", () => {
+      expectTypeOf(prop({} as Record<string, 1 | 2>, "a")).toEqualTypeOf<
+        1 | 2 | undefined
+      >();
+    });
+
+    test("a union of keys is still missing", () => {
+      expectTypeOf(
+        prop({} as Record<string, number>, "a" as "a" | "b"),
+      ).toEqualTypeOf<number | undefined>();
+    });
+
+    test("nested records propagate undefined down the path", () => {
+      const data = {} as {
+        a: Record<string, { b: { c: "hello"; d: boolean; e: string } }>;
+      };
+
+      // The top-level key is declared, so it stays exact.
+      expectTypeOf(prop(data, "a")).toEqualTypeOf<
+        Record<string, { b: { c: "hello"; d: boolean; e: string } }>
+      >();
+      // Indexing into the record adds undefined, which then propagates.
+      expectTypeOf(prop(data, "a", "x")).toExtend<
+        { b: { c: "hello"; d: boolean; e: string } } | undefined
+      >();
+      expectTypeOf(prop(data, "a", "x", "b")).toExtend<
+        { c: "hello"; d: boolean; e: string } | undefined
+      >();
+      expectTypeOf(prop(data, "a", "x", "b", "c")).toEqualTypeOf<
+        "hello" | undefined
+      >();
+      expectTypeOf(prop(data, "a", "x", "b", "d")).toEqualTypeOf<
+        boolean | undefined
+      >();
+      expectTypeOf(prop(data, "a", "x", "b", "e")).toEqualTypeOf<
+        string | undefined
+      >();
+    });
+  });
+
+  describe("data-last", () => {
+    test("string keys add undefined", () => {
+      expectTypeOf(pipe({} as Record<string, number>, prop("a"))).toEqualTypeOf<
+        number | undefined
+      >();
+    });
+
+    test("nested records propagate undefined down the path", () => {
+      const data = {} as {
+        a: Record<string, { b: { c: "hello"; d: boolean; e: string } }>;
+      };
+
+      expectTypeOf(pipe(data, prop("a", "x", "b", "c"))).toEqualTypeOf<
+        "hello" | undefined
+      >();
+    });
+  });
+
+  describe("preserves exact types for declared keys", () => {
+    test("declared keys on object types stay exact", () => {
+      expectTypeOf(prop({} as { a: number }, "a")).toEqualTypeOf<number>();
+    });
+
+    test("declared keys win over an index signature", () => {
+      const data = {} as { a: number } & Record<string, string>;
+
+      expectTypeOf(prop(data, "a")).toEqualTypeOf<number>();
+      expectTypeOf(prop(data, "b")).toEqualTypeOf<string | undefined>();
+    });
+
+    test("literal-keyed records stay exact", () => {
+      expectTypeOf(
+        prop({} as Record<"cat" | "dog", number>, "cat"),
+      ).toEqualTypeOf<number>();
+    });
+  });
+});
+
 describe("with stringToPath", () => {
   const DATA = {} as { a: { b: { c: { d: number } }[] } };
 

--- a/packages/remeda/src/prop.ts
+++ b/packages/remeda/src/prop.ts
@@ -1,4 +1,4 @@
-import type { KeysOfUnion } from "type-fest";
+import type { KeysOfUnion, OmitIndexSignature } from "type-fest";
 import type { ArrayAt } from "./internal/types/ArrayAt";
 
 // Computes all possible keys of `T` at `Path` spread over unions, allowing
@@ -27,7 +27,16 @@ type Prop<T, Key> =
       Key extends keyof T
       ? T extends readonly unknown[]
         ? ArrayAt<T, Key>
-        : T[Key]
+        : Key extends keyof OmitIndexSignature<T>
+          ? // The key is an explicitly declared property, so it's guaranteed to
+            // be present and we can rely on the built-in indexed access type.
+            T[Key]
+          : // The key is only matched by an index signature (e.g. accessing any
+              // `string` key of a `Record<string, V>`), so there's no guarantee a
+              // value exists for it at runtime. This mirrors `noUncheckedIndexed-
+              // Access`, but we add `undefined` ourselves so the output is sound
+              // regardless of the consumer's `tsconfig`.
+              T[Key] | undefined
       : undefined
     : never;
 


### PR DESCRIPTION
## Problem
Accessing a key of a `Record<string, V>` (or any index-signature type) via `prop` returned `V` instead of `V | undefined`. That is unsound: an arbitrary `string` key is not guaranteed to exist at runtime, so the value can be `undefined`.

## Fix
Use `OmitIndexSignature<T>` to distinguish explicitly-declared properties from index-signature-only keys. Explicit keys keep their exact type (`T[Key]`); keys matched only by an index signature get `T[Key] | undefined`. This mirrors `noUncheckedIndexedAccess` but is applied within `prop` itself, so the result is sound regardless of the consumer's `tsconfig`.

## Tests
Added type tests in `prop.test-d.ts` asserting `prop` on a `Record` index access yields `V | undefined`, while access of known object properties is unchanged.

Closes #1274