### PR TITLE
fix(sample): typechecking perf issue with large literal tuples

### DIFF
--- a/.agents/skills/remeda-utility/reference/implementation.md
+++ b/.agents/skills/remeda-utility/reference/implementation.md
@@ -63,6 +63,16 @@ These three "empty-ish" values are not interchangeable in Remeda:
 - Non-obvious type choices in internal code must have an inline comment explaining the reasoning (the **why**, not the what).
 - Complex type utility files should open with a comment describing what each exported utility does.
 
+### Type-level performance
+
+Combinatorial / recursive types can blow `tsc` up 100x+ in symbols, memory, and check time in ways that pass all tests but make consumer editors unusable. Two patterns to reach for, and one technique to confirm:
+
+- **Keep recursion accumulators opaque.** When recursing with an accumulator, track _count_ (a tuple of `unknown`) rather than the actual elements being built. Sibling branches at the same depth share an opaque accumulator's type, which TS dedupes; carrying real types makes every path structurally unique and explodes the intermediate state space from `O(M * N)` to `O(M * 2^M)`. Stitch real elements together on unwind via `[Head, ...recurse]`.
+
+- **Grow accumulators on pick; don't pre-build and shrink.** `Counter["length"] extends N` with a counter that grows by `[unknown, ...Counter]` is cheaper than pre-building `NTuple<unknown, N>` and destructuring `[unknown, ...infer Rest]` at every step. Skips the upfront build (N type-construction steps) and replaces a per-step destructure-and-infer with a constant-cost length lookup. Small win (~1-4% on instantiations) but consistent across N and M.
+
+- **Measure with `tsc --extendedDiagnostics`.** Set up a small consumer-style repro that imports from the _built_ `dist/index.d.ts` (not source - source-mode compiles all of remeda and drowns the signal in ~115K symbols of baseline overhead). Rebuild (`npm run build`), warm up once (discard), then run 2-3 timed passes - numbers are stable across runs. Watch `Symbols`, `Types`, `Instantiations`, `Memory used`, `Check time`. `Instantiations` is the most sensitive early indicator - regressions show up there before time/memory budge.
+
 ## File Layout
 
 - Exported items first, then non-exported ("private") items — readers scan top-to-bottom.

--- a/packages/remeda/src/sample.test-d.ts
+++ b/packages/remeda/src/sample.test-d.ts
@@ -874,6 +874,98 @@ describe("literal sampleSize > n", () => {
       | [true, true, true, true, true, true, true, true, true, true]
     >();
   });
+
+  // @see https://github.com/remeda/remeda/pull/1355
+  test("large literal tuples (pr #1355)", () => {
+    // Our previous implementation computed the full set of all sub-tuples
+    // before narrowing it down to just those of size N. This meant that as the
+    // tuple grew bigger, the computation grew exponentially (`2^|T|`) and even
+    // at modest sizes would cause TypeScript to slow down and potentially blow
+    // up. This test protects against regressing on this by testing those kinds
+    // of inputs directly. We expect a `ts2590` error for the unoptimized case.
+    expectTypeOf(
+      sample(
+        [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "g",
+          "h",
+          "i",
+          "j",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "q",
+          "r",
+          "s",
+          "t",
+          "u",
+          "v",
+          "w",
+          "x",
+          "y",
+          "z",
+        ],
+        1,
+      ),
+    ).toEqualTypeOf<
+      | ["a"]
+      | ["b"]
+      | ["c"]
+      | ["d"]
+      | ["e"]
+      | ["f"]
+      | ["g"]
+      | ["h"]
+      | ["i"]
+      | ["j"]
+      | ["k"]
+      | ["l"]
+      | ["m"]
+      | ["n"]
+      | ["o"]
+      | ["p"]
+      | ["q"]
+      | ["r"]
+      | ["s"]
+      | ["t"]
+      | ["u"]
+      | ["v"]
+      | ["w"]
+      | ["x"]
+      | ["y"]
+      | ["z"]
+    >();
+  });
+});
+
+describe("literal union sampleSize", () => {
+  test("fixed tuples", () => {
+    expectTypeOf(sample(FIXED, 1 as 1 | 2)).toEqualTypeOf<
+      | ["a"]
+      | ["b"]
+      | ["c"]
+      | ["d"]
+      | ["e"]
+      | ["a", "b"]
+      | ["a", "c"]
+      | ["a", "d"]
+      | ["a", "e"]
+      | ["b", "c"]
+      | ["b", "d"]
+      | ["b", "e"]
+      | ["c", "d"]
+      | ["c", "e"]
+      | ["d", "e"]
+    >();
+  });
 });
 
 describe("primitive sampleSize", () => {
@@ -1190,47 +1282,4 @@ describe("primitive sampleSize", () => {
       | true[]
     >();
   });
-});
-
-// @see https://github.com/remeda/remeda/pull/1355
-test("large literal tuples (pr #1355)", () => {
-  // Our previous implementation computed the full set of all sub-tuples before
-  // narrowing it down to just those of size N. This meant that as the tuple
-  // grew bigger, the computation grew exponentially (`2^|T|`) and even at
-  // modest sizes would cause TypeScript to slow down and potentially blow up.
-  // This test protects against regressing on this by testing those kinds of
-  // inputs directly. We expect a `ts2590` error for the unoptimized case.
-  const LARGE = [
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "g",
-    "h",
-    "i",
-    "j",
-    "k",
-    "l",
-    "m",
-    "n",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "t",
-    "u",
-    "v",
-    "w",
-    "x",
-    "y",
-    "z",
-  ] as const;
-
-  // The mere call forces TS to compute the return type; if that requires
-  // eager sub-tuple enumeration, tsc errors with TS2590 before any
-  // assertion runs. The matchTypeOf is just a sanity check on shape.
-  expectTypeOf(sample(LARGE, 1)).toExtend<readonly [(typeof LARGE)[number]]>();
 });

--- a/packages/remeda/src/sample.test-d.ts
+++ b/packages/remeda/src/sample.test-d.ts
@@ -1191,3 +1191,45 @@ describe("primitive sampleSize", () => {
     >();
   });
 });
+
+test("large literal tuples (pr #????)", () => {
+  // Our previous implementation computed the full set of all sub-tuples before
+  // narrowing it down to just those of size N. This meant that as the tuple
+  // grew bigger, the computation grew exponentially (`2^|T|`) and even at
+  // modest sizes would cause TypeScript to slow down and potentially blow up.
+  // This test protects against regressing on this by testing those kinds of
+  // inputs directly. We expect a `ts2590` error for the unoptimized case.
+  const LARGE = [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+  ] as const;
+
+  // The mere call forces TS to compute the return type; if that requires
+  // eager sub-tuple enumeration, tsc errors with TS2590 before any
+  // assertion runs. The matchTypeOf is just a sanity check on shape.
+  expectTypeOf(sample(LARGE, 1)).toExtend<readonly [(typeof LARGE)[number]]>();
+});

--- a/packages/remeda/src/sample.test-d.ts
+++ b/packages/remeda/src/sample.test-d.ts
@@ -1192,7 +1192,8 @@ describe("primitive sampleSize", () => {
   });
 });
 
-test("large literal tuples (pr #????)", () => {
+// @see https://github.com/remeda/remeda/pull/1355
+test("large literal tuples (pr #1355)", () => {
   // Our previous implementation computed the full set of all sub-tuples before
   // narrowing it down to just those of size N. This meant that as the tuple
   // grew bigger, the computation grew exponentially (`2^|T|`) and even at

--- a/packages/remeda/src/sample.ts
+++ b/packages/remeda/src/sample.ts
@@ -101,15 +101,22 @@ type FixedSubTuples<T> = T extends readonly [infer Head, ...infer Rest]
  * Compute all combinations (sub-tuples) of T of exactly length N.
  */
 type Combinations<
-  T extends readonly unknown[],
+  T extends IterableContainer,
   N extends number,
+  // Used an an incrementor that keeps track of the depth of the recursion.
   Counter extends readonly unknown[] = [],
-> = Counter["length"] extends N
-  ? []
-  : T extends readonly [infer Head, ...infer Tail]
-    ?
-        | [Head, ...Combinations<Tail, N, [unknown, ...Counter]>]
-        | Combinations<Tail, N, Counter>
+> =
+  // Distribute over N so the result is the union for all values, otherwise we
+  // will only compute combinations for the smallest literal in the union.
+  N extends unknown
+    ? Counter["length"] extends N
+      ? []
+      : T extends readonly [infer Head, ...infer Rest]
+        ? // For each element we either take it or skip it, and recurse over
+            // the rest.
+            | [Head, ...Combinations<Rest, N, [unknown, ...Counter]>]
+            | Combinations<Rest, N, Counter>
+        : never
     : never;
 
 /**

--- a/packages/remeda/src/sample.ts
+++ b/packages/remeda/src/sample.ts
@@ -1,5 +1,4 @@
 import type {
-  FixedLengthArray,
   IsEqual,
   IsNever,
   NonNegativeInteger,
@@ -44,22 +43,19 @@ type SampledPrimitive<T extends IterableContainer> = [
  * of T that are exactly N elements long.
  */
 type SampledLiteral<T extends IterableContainer, N extends number> =
-  | Extract<
-      FixedSubTuples<
-        [
-          ...TupleParts<T>["required"],
-          // TODO: This deliberately ignores optional elements which we don't have tests for either. In order to handle optional elements we can treat the "optional" tuple-part as more required elements.
-          // We add N elements of the `item` type to the tuple so that we
-          // consider any combination possible of elements of the prefix items,
-          // any amount of rest items, and suffix items.
-          ...(IsNever<TupleParts<T>["item"]> extends true
-            ? []
-            : NTuple<TupleParts<T>["item"], N>),
-          ...TupleParts<T>["suffix"],
-        ]
-      >,
-      // This is just [unknown, unknown, ..., unknown] with N elements.
-      FixedLengthArray<unknown, N>
+  | Combinations<
+      [
+        ...TupleParts<T>["required"],
+        // TODO: This deliberately ignores optional elements which we don't have tests for either. In order to handle optional elements we can treat the "optional" tuple-part as more required elements.
+        // We add N elements of the `item` type to the tuple so that we
+        // consider any combination possible of elements of the prefix items,
+        // any amount of rest items, and suffix items.
+        ...(IsNever<TupleParts<T>["item"]> extends true
+          ? []
+          : NTuple<TupleParts<T>["item"], N>),
+        ...TupleParts<T>["suffix"],
+      ],
+      N
     >
   // In addition to all sub-tuples of length N, we also need to consider all
   // tuples where the input is shorter than N. This will contribute exactly
@@ -100,6 +96,21 @@ type FixedSubTuples<T> = T extends readonly [infer Head, ...infer Rest]
   ? // For each element we either take it or skip it, and recurse over the rest.
       FixedSubTuples<Rest> | [Head, ...FixedSubTuples<Rest>]
   : [];
+
+/**
+ * Compute all combinations (sub-tuples) of T of exactly length N.
+ */
+type Combinations<
+  T extends readonly unknown[],
+  N extends number,
+  Counter extends readonly unknown[] = [],
+> = Counter["length"] extends N
+  ? []
+  : T extends readonly [infer Head, ...infer Tail]
+    ?
+        | [Head, ...Combinations<Tail, N, [unknown, ...Counter]>]
+        | Combinations<Tail, N, Counter>
+    : never;
 
 /**
  * Returns a random subset of size `sampleSize` from `array`.


### PR DESCRIPTION
Sample currently chokes when provided a large literal tuple (`[1, 2, 3, ..., 100] as const`) because the type pre-computes all possible sub-tuples before selecting the ones at size N, this means we compute 2^|T| tuples in memory.

This fix addresses it by moving to a addiditve approach instead of the subtractive one.