### PR TITLE
chore(node): explicitly limit node engine to 18+

### DIFF
--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -14,6 +14,9 @@
   "author": "Łukasz Sentkiewicz",
   "funding": "https://github.com/sponsors/remeda",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {


### PR DESCRIPTION
This is the de-facto lowest version we support, but publint surfaced an issue that it needs to be explicitly mentioned in the package.json file so that older node versions warn about it when installing.

This is technically a breaking change for those versions, but not worth the version bump for all users - it will go out the next time we release a fix/feat level PR