### PR TITLE
fix(splice): move data-last inference to curried data param

### DIFF
--- a/packages/docs/src/content/mapping/ramda/remove.md
+++ b/packages/docs/src/content/mapping/ramda/remove.md
@@ -2,23 +2,3 @@
 category: List
 remeda: splice
 ---
-
-#### Data-first
-
-```ts
-// Ramda
-remove(2, 3, [1, 2, 3, 4, 5, 6, 7, 8]);
-
-// Remeda
-splice([1, 2, 3, 4, 5, 6, 7, 8], 2, 3);
-```
-
-#### Data-last
-
-```ts
-// Ramda
-remove(2, 3)([1, 2, 3, 4, 5, 6, 7, 8]);
-
-// Remeda
-pipe([1, 2, 3, 4, 5, 6, 7, 8], splice(2, 3));
-```

--- a/packages/docs/src/content/mapping/ramda/remove.md
+++ b/packages/docs/src/content/mapping/ramda/remove.md
@@ -2,3 +2,23 @@
 category: List
 remeda: splice
 ---
+
+#### Data-first
+
+```ts
+// Ramda
+remove(2, 3, [1, 2, 3, 4, 5, 6, 7, 8]);
+
+// Remeda
+splice([1, 2, 3, 4, 5, 6, 7, 8], 2, 3);
+```
+
+#### Data-last
+
+```ts
+// Ramda
+remove(2, 3)([1, 2, 3, 4, 5, 6, 7, 8]);
+
+// Remeda
+pipe([1, 2, 3, 4, 5, 6, 7, 8], splice(2, 3));
+```

--- a/packages/remeda/src/drop.ts
+++ b/packages/remeda/src/drop.ts
@@ -98,6 +98,11 @@ type DropFixedTuple<
 /**
  * Removes first `n` elements from the `array`.
  *
+ * Related operations:
+ * - `dropLast` - same, but from the end of the array.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `take` - to keep the first `n` instead.
+ *
  * @param array - The target array.
  * @param n - The number of elements to skip.
  * @signature
@@ -115,6 +120,11 @@ export function drop<T extends IterableContainer, N extends number>(
 
 /**
  * Removes first `n` elements from the `array`.
+ *
+ * Related operations:
+ * - `dropLast` - same, but from the end of the array.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `take` - to keep the first `n` instead.
  *
  * @param n - The number of elements to skip.
  * @signature

--- a/packages/remeda/src/dropLast.ts
+++ b/packages/remeda/src/dropLast.ts
@@ -4,6 +4,11 @@ import { purry } from "./purry";
 /**
  * Removes last `n` elements from the `array`.
  *
+ * Related operations:
+ * - `drop` - same, but from the start of the array.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `takeLast` - to keep the last `n` instead.
+ *
  * @param array - The target array.
  * @param n - The number of elements to skip.
  * @signature
@@ -20,6 +25,11 @@ export function dropLast<T extends IterableContainer>(
 
 /**
  * Removes last `n` elements from the `array`.
+ *
+ * Related operations:
+ * - `drop` - same, but from the start of the array.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `takeLast` - to keep the last `n` instead.
  *
  * @param n - The number of elements to skip.
  * @signature

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -31,6 +31,9 @@ type NonRefinedFilteredArray<
  * the elements from the given array that pass the test implemented by the
  * provided function. Equivalent to `Array.prototype.filter`.
  *
+ * Related operations:
+ * - `splice` - to shape the array by *position* rather than by *value*.
+ *
  * @param data - The array to filter.
  * @param predicate - A function to execute for each element in the array. It
  * should return `true` to keep the element in the resulting array, and `false`
@@ -64,6 +67,9 @@ export function filter<
  * Creates a shallow copy of a portion of a given array, filtered down to just
  * the elements from the given array that pass the test implemented by the
  * provided function. Equivalent to `Array.prototype.filter`.
+ *
+ * Related operations:
+ * - `splice` - to shape the array by *position* rather than by *value*.
  *
  * @param predicate - A function to execute for each element in the array. It
  * should return `true` to keep the element in the resulting array, and `false`

--- a/packages/remeda/src/internal/purryOn.ts
+++ b/packages/remeda/src/internal/purryOn.ts
@@ -1,16 +1,12 @@
 /**
  * Utility for purrying functions based on a predicate for the first argument.
  *
- * This is useful for purrying functions with a variadic argument list.
+ * This is useful for purrying functions with an optional parameter or a
+ * variadic argument list.
  */
 export function purryOn<T>(
   isArg: (firstArg: unknown) => firstArg is T,
-  implementation: (
-    data: unknown,
-    firstArg: T,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Function inference in typescript relies on `any` to work, it doesn't work with `unknown`
-    ...args: any
-  ) => unknown,
+  implementation: (data: never, firstArg: T, ...args: never) => unknown,
   args: readonly unknown[],
 ): unknown {
   return isArg(args[0])

--- a/packages/remeda/src/internal/purryOn.ts
+++ b/packages/remeda/src/internal/purryOn.ts
@@ -6,12 +6,16 @@
  */
 export function purryOn<T>(
   isArg: (firstArg: unknown) => firstArg is T,
+  // We use `never` for the params to allow **any** function to match, this
+  // works because all functions extend this shape, using `unknown` would
+  // produce the opposite effect. This is better than using `any` which simply
+  // avoids addressing the typing issue.
   implementation: (data: never, firstArg: T, ...args: never) => unknown,
   args: readonly unknown[],
 ): unknown {
   return isArg(args[0])
     ? // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
-      (data: unknown) => implementation(data, ...args)
+      (data: never) => implementation(data, ...args)
     : // @ts-expect-error [ts2556] - This is a low-level function that assumes the function declaration and setup is correct and won't result in typing issues when called dynamically.
       implementation(...args);
 }

--- a/packages/remeda/src/splice.test-d.ts
+++ b/packages/remeda/src/splice.test-d.ts
@@ -1,23 +1,167 @@
-import { expectTypeOf, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
+import { pipe } from "./pipe";
 import { splice } from "./splice";
 
-test("reflects the type of `items` in the return value", () => {
-  const items: number[] = [];
-  const result = splice(items, 0, 0, []);
+describe("data-first", () => {
+  test("regular array", () => {
+    expectTypeOf(splice([] as number[], 0, 0, [9])).toEqualTypeOf<number[]>();
+  });
 
-  expectTypeOf(result).toEqualTypeOf<number[]>();
+  test("readonly array", () => {
+    expectTypeOf(splice([] as readonly number[], 0, 0, [9])).toEqualTypeOf<
+      number[]
+    >();
+  });
+
+  test("regular array with union element type", () => {
+    expectTypeOf(
+      splice([] as (number | string)[], 0, 0, [9, "a"]),
+    ).toEqualTypeOf<(number | string)[]>();
+  });
+
+  test("empty replacement preserves element type", () => {
+    expectTypeOf(splice([] as number[], 0, 0, [])).toEqualTypeOf<number[]>();
+  });
+
+  test("prefix tuple", () => {
+    expectTypeOf(
+      splice([1] as [number, ...boolean[]], 0, 0, [true]),
+    ).toEqualTypeOf<(boolean | number)[]>();
+  });
+
+  test("suffix tuple", () => {
+    expectTypeOf(
+      splice([1] as [...boolean[], number], 0, 0, [true]),
+    ).toEqualTypeOf<(boolean | number)[]>();
+  });
+
+  test("prefix + suffix tuple", () => {
+    expectTypeOf(
+      splice([1, "a"] as [number, ...boolean[], string], 0, 0, [true]),
+    ).toEqualTypeOf<(boolean | number | string)[]>();
+  });
+
+  test("const tuple", () => {
+    expectTypeOf(splice([1, "a", true] as const, 0, 0, [1])).toEqualTypeOf<
+      ("a" | 1 | true)[]
+    >();
+  });
+
+  test("union of arrays", () => {
+    expectTypeOf(
+      splice([] as boolean[] | string[], 0, 0, [true]),
+    ).toEqualTypeOf<(boolean | string)[]>();
+  });
+
+  test("accepts replacement element subtype", () => {
+    expectTypeOf(splice([] as (number | string)[], 0, 0, [9])).toEqualTypeOf<
+      (number | string)[]
+    >();
+  });
+
+  describe("rejects invalid replacement", () => {
+    test("element type not in items' element union", () => {
+      // @ts-expect-error [ts2322] -- "a" not assignable to number
+      splice([] as number[], 0, 0, ["a"]);
+    });
+
+    test("supertype replacement element", () => {
+      // @ts-expect-error [ts2322] -- string is wider than "a" | "b"
+      splice([] as ("a" | "b")[], 0, 0, ["c" as string]);
+    });
+
+    test("literal outside const tuple's element union", () => {
+      // @ts-expect-error [ts2322] -- 4 not in 1 | "a" | true
+      splice([1, "a", true] as const, 0, 0, [4]);
+    });
+  });
+
+  test("replacement is optional", () => {
+    expectTypeOf(splice([] as number[], 0, 0)).toEqualTypeOf<number[]>();
+  });
 });
 
-test("reflects the type of `replacement` in the return value", () => {
-  const replacement: number[] = [];
-  const result = splice([], 0, 0, replacement);
+describe("data-last", () => {
+  test("regular array", () => {
+    expectTypeOf(pipe([] as number[], splice(0, 0, [9]))).toEqualTypeOf<
+      number[]
+    >();
+  });
 
-  expectTypeOf(result).toEqualTypeOf<number[]>();
-});
+  test("readonly array", () => {
+    expectTypeOf(
+      pipe([] as readonly number[], splice(0, 0, [9])),
+    ).toEqualTypeOf<number[]>();
+  });
 
-test("reflects the type of `replacement` in the return value (data-last)", () => {
-  const replacement: number[] = [];
-  const result = splice(0, 0, replacement);
+  test("regular array with union element type", () => {
+    expectTypeOf(
+      pipe([] as (number | string)[], splice(0, 0, [9, "a"])),
+    ).toEqualTypeOf<(number | string)[]>();
+  });
 
-  expectTypeOf(result).toEqualTypeOf<(items: readonly number[]) => number[]>();
+  test("empty replacement preserves element type", () => {
+    expectTypeOf(pipe([] as number[], splice(0, 0, []))).toEqualTypeOf<
+      number[]
+    >();
+  });
+
+  test("prefix tuple", () => {
+    expectTypeOf(
+      pipe([1] as [number, ...boolean[]], splice(0, 0, [true])),
+    ).toEqualTypeOf<(boolean | number)[]>();
+  });
+
+  test("suffix tuple", () => {
+    expectTypeOf(
+      pipe([1] as [...boolean[], number], splice(0, 0, [true])),
+    ).toEqualTypeOf<(boolean | number)[]>();
+  });
+
+  test("prefix + suffix tuple", () => {
+    expectTypeOf(
+      pipe([1, "a"] as [number, ...boolean[], string], splice(0, 0, [true])),
+    ).toEqualTypeOf<(boolean | number | string)[]>();
+  });
+
+  test("const tuple", () => {
+    expectTypeOf(
+      pipe([1, "a", true] as const, splice(0, 0, [1])),
+    ).toEqualTypeOf<("a" | 1 | true)[]>();
+  });
+
+  test("union of arrays", () => {
+    expectTypeOf(
+      pipe([] as boolean[] | string[], splice(0, 0, [true])),
+    ).toEqualTypeOf<(boolean | string)[]>();
+  });
+
+  describe("rejects invalid replacement", () => {
+    test("element type not in items' element union", () => {
+      // @ts-expect-error [ts2322] -- "a" not assignable to number
+      pipe([] as number[], splice(0, 0, ["a"]));
+    });
+
+    test("supertype replacement element", () => {
+      // @ts-expect-error [ts2322] -- string is wider than "a" | "b"
+      pipe([] as ("a" | "b")[], splice(0, 0, ["c" as string]));
+    });
+
+    test("literal outside const tuple's element union", () => {
+      // @ts-expect-error [ts2322] -- 4 not in 1 | "a" | true
+      pipe([1, "a", true] as const, splice(0, 0, [4]));
+    });
+  });
+
+  test("doesn't infer `never` from an empty `replacement` literal (#1359)", () => {
+    // Regression: replacement `[]` previously locked T to `never`, making the
+    // returned function require `readonly never[]`.
+    expectTypeOf(pipe([] as number[], splice(0, 0, []))).toEqualTypeOf<
+      number[]
+    >();
+  });
+
+  test("replacement is optional", () => {
+    expectTypeOf(pipe([] as number[], splice(0, 0))).toEqualTypeOf<number[]>();
+  });
 });

--- a/packages/remeda/src/splice.test-d.ts
+++ b/packages/remeda/src/splice.test-d.ts
@@ -157,9 +157,8 @@ describe("data-last", () => {
     ).toEqualTypeOf<(number | string)[]>();
   });
 
-  test("doesn't infer `never` from an empty `replacement` literal (#1359)", () => {
-    // Regression: replacement `[]` previously locked T to `never`, making the
-    // returned function require `readonly never[]`.
+  // @see https://github.com/remeda/remeda/pull/1358
+  test("doesn't infer `never` from an empty `replacement` literal (#1358)", () => {
     expectTypeOf(pipe([] as number[], splice(0, 0, []))).toEqualTypeOf<
       number[]
     >();

--- a/packages/remeda/src/splice.test-d.ts
+++ b/packages/remeda/src/splice.test-d.ts
@@ -2,83 +2,81 @@ import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { splice } from "./splice";
 
-describe("data-first", () => {
-  test("regular array", () => {
-    expectTypeOf(splice([] as number[], 0, 0, [9])).toEqualTypeOf<number[]>();
+test("regular array", () => {
+  expectTypeOf(splice([] as number[], 0, 0, [9])).toEqualTypeOf<number[]>();
+});
+
+test("readonly array", () => {
+  expectTypeOf(splice([] as readonly number[], 0, 0, [9])).toEqualTypeOf<
+    number[]
+  >();
+});
+
+test("regular array with union element type", () => {
+  expectTypeOf(splice([] as (number | string)[], 0, 0, [9, "a"])).toEqualTypeOf<
+    (number | string)[]
+  >();
+});
+
+test("empty replacement preserves element type", () => {
+  expectTypeOf(splice([] as number[], 0, 0, [])).toEqualTypeOf<number[]>();
+});
+
+test("prefix tuple", () => {
+  expectTypeOf(
+    splice([1] as [number, ...boolean[]], 0, 0, [true]),
+  ).toEqualTypeOf<(boolean | number)[]>();
+});
+
+test("suffix tuple", () => {
+  expectTypeOf(
+    splice([1] as [...boolean[], number], 0, 0, [true]),
+  ).toEqualTypeOf<(boolean | number)[]>();
+});
+
+test("prefix + suffix tuple", () => {
+  expectTypeOf(
+    splice([1, "a"] as [number, ...boolean[], string], 0, 0, [true]),
+  ).toEqualTypeOf<(boolean | number | string)[]>();
+});
+
+test("const tuple", () => {
+  expectTypeOf(splice([1, "a", true] as const, 0, 0, [1])).toEqualTypeOf<
+    ("a" | 1 | true)[]
+  >();
+});
+
+test("union of arrays", () => {
+  expectTypeOf(splice([] as boolean[] | string[], 0, 0, [true])).toEqualTypeOf<
+    (boolean | string)[]
+  >();
+});
+
+test("accepts replacement element subtype", () => {
+  expectTypeOf(splice([] as (number | string)[], 0, 0, [9])).toEqualTypeOf<
+    (number | string)[]
+  >();
+});
+
+describe("rejects invalid replacement", () => {
+  test("element type not in items' element union", () => {
+    // @ts-expect-error [ts2322] -- "a" not assignable to number
+    splice([] as number[], 0, 0, ["a"]);
   });
 
-  test("readonly array", () => {
-    expectTypeOf(splice([] as readonly number[], 0, 0, [9])).toEqualTypeOf<
-      number[]
-    >();
+  test("supertype replacement element", () => {
+    // @ts-expect-error [ts2322] -- string is wider than "a" | "b"
+    splice([] as ("a" | "b")[], 0, 0, ["c" as string]);
   });
 
-  test("regular array with union element type", () => {
-    expectTypeOf(
-      splice([] as (number | string)[], 0, 0, [9, "a"]),
-    ).toEqualTypeOf<(number | string)[]>();
+  test("literal outside const tuple's element union", () => {
+    // @ts-expect-error [ts2322] -- 4 not in 1 | "a" | true
+    splice([1, "a", true] as const, 0, 0, [4]);
   });
+});
 
-  test("empty replacement preserves element type", () => {
-    expectTypeOf(splice([] as number[], 0, 0, [])).toEqualTypeOf<number[]>();
-  });
-
-  test("prefix tuple", () => {
-    expectTypeOf(
-      splice([1] as [number, ...boolean[]], 0, 0, [true]),
-    ).toEqualTypeOf<(boolean | number)[]>();
-  });
-
-  test("suffix tuple", () => {
-    expectTypeOf(
-      splice([1] as [...boolean[], number], 0, 0, [true]),
-    ).toEqualTypeOf<(boolean | number)[]>();
-  });
-
-  test("prefix + suffix tuple", () => {
-    expectTypeOf(
-      splice([1, "a"] as [number, ...boolean[], string], 0, 0, [true]),
-    ).toEqualTypeOf<(boolean | number | string)[]>();
-  });
-
-  test("const tuple", () => {
-    expectTypeOf(splice([1, "a", true] as const, 0, 0, [1])).toEqualTypeOf<
-      ("a" | 1 | true)[]
-    >();
-  });
-
-  test("union of arrays", () => {
-    expectTypeOf(
-      splice([] as boolean[] | string[], 0, 0, [true]),
-    ).toEqualTypeOf<(boolean | string)[]>();
-  });
-
-  test("accepts replacement element subtype", () => {
-    expectTypeOf(splice([] as (number | string)[], 0, 0, [9])).toEqualTypeOf<
-      (number | string)[]
-    >();
-  });
-
-  describe("rejects invalid replacement", () => {
-    test("element type not in items' element union", () => {
-      // @ts-expect-error [ts2322] -- "a" not assignable to number
-      splice([] as number[], 0, 0, ["a"]);
-    });
-
-    test("supertype replacement element", () => {
-      // @ts-expect-error [ts2322] -- string is wider than "a" | "b"
-      splice([] as ("a" | "b")[], 0, 0, ["c" as string]);
-    });
-
-    test("literal outside const tuple's element union", () => {
-      // @ts-expect-error [ts2322] -- 4 not in 1 | "a" | true
-      splice([1, "a", true] as const, 0, 0, [4]);
-    });
-  });
-
-  test("replacement is optional", () => {
-    expectTypeOf(splice([] as number[], 0, 0)).toEqualTypeOf<number[]>();
-  });
+test("replacement is optional", () => {
+  expectTypeOf(splice([] as number[], 0, 0)).toEqualTypeOf<number[]>();
 });
 
 describe("data-last", () => {
@@ -138,19 +136,25 @@ describe("data-last", () => {
 
   describe("rejects invalid replacement", () => {
     test("element type not in items' element union", () => {
-      // @ts-expect-error [ts2322] -- "a" not assignable to number
+      // @ts-expect-error [ts2769] -- "a" not assignable to number
       pipe([] as number[], splice(0, 0, ["a"]));
     });
 
     test("supertype replacement element", () => {
-      // @ts-expect-error [ts2322] -- string is wider than "a" | "b"
+      // @ts-expect-error [ts2769] -- string is wider than "a" | "b"
       pipe([] as ("a" | "b")[], splice(0, 0, ["c" as string]));
     });
 
     test("literal outside const tuple's element union", () => {
-      // @ts-expect-error [ts2322] -- 4 not in 1 | "a" | true
+      // @ts-expect-error [ts2769] -- 4 not in 1 | "a" | true
       pipe([1, "a", true] as const, splice(0, 0, [4]));
     });
+  });
+
+  test("accepts replacement element subtype", () => {
+    expectTypeOf(
+      pipe([] as (number | string)[], splice(0, 0, [9])),
+    ).toEqualTypeOf<(number | string)[]>();
   });
 
   test("doesn't infer `never` from an empty `replacement` literal (#1359)", () => {

--- a/packages/remeda/src/splice.test.ts
+++ b/packages/remeda/src/splice.test.ts
@@ -108,7 +108,9 @@ describe("regression tests", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([], 0, -1, [3])).toStrictEqual([3]);
+        expect(splice([1, 2, 3, 4, 5], 0, -1, [3])).toStrictEqual([
+          3, 1, 2, 3, 4, 5,
+        ]);
       });
     });
   });
@@ -196,7 +198,9 @@ describe("overflow indices", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([], -1, -1, [3])).toStrictEqual([3]);
+        expect(splice([1, 2, 3, 4, 5], -1, -1, [3])).toStrictEqual([
+          1, 2, 3, 4, 3, 5,
+        ]);
       });
     });
 
@@ -206,7 +210,9 @@ describe("overflow indices", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([], 1, -1, [3])).toStrictEqual([3]);
+        expect(splice([1, 2, 3, 4, 5], 1, -1, [3])).toStrictEqual([
+          1, 3, 2, 3, 4, 5,
+        ]);
       });
     });
   });
@@ -216,4 +222,14 @@ test("a purried data-last implementation", () => {
   expect(pipe([1, 2, 3, 4, 5, 6, 7, 8], splice(2, 3, [9, 10]))).toStrictEqual([
     1, 2, 9, 10, 6, 7, 8,
   ]);
+});
+
+describe("replacement is optional", () => {
+  test("data-first omits replacement", () => {
+    expect(splice([1, 2, 3, 4, 5], 1, 2)).toStrictEqual([1, 4, 5]);
+  });
+
+  test("data-last omits replacement", () => {
+    expect(pipe([1, 2, 3, 4, 5], splice(1, 2))).toStrictEqual([1, 4, 5]);
+  });
 });

--- a/packages/remeda/src/splice.test.ts
+++ b/packages/remeda/src/splice.test.ts
@@ -108,9 +108,7 @@ describe("regression tests", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([1, 2, 3, 4, 5], 0, -1, [3])).toStrictEqual([
-          3, 1, 2, 3, 4, 5,
-        ]);
+        expect(splice([] as number[], 0, -1, [3])).toStrictEqual([3]);
       });
     });
   });
@@ -198,9 +196,7 @@ describe("overflow indices", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([1, 2, 3, 4, 5], -1, -1, [3])).toStrictEqual([
-          1, 2, 3, 4, 3, 5,
-        ]);
+        expect(splice([] as number[], -1, -1, [3])).toStrictEqual([3]);
       });
     });
 
@@ -210,9 +206,7 @@ describe("overflow indices", () => {
       });
 
       test("with replacement", () => {
-        expect(splice([1, 2, 3, 4, 5], 1, -1, [3])).toStrictEqual([
-          1, 3, 2, 3, 4, 5,
-        ]);
+        expect(splice([] as number[], 1, -1, [3])).toStrictEqual([3]);
       });
     });
   });

--- a/packages/remeda/src/splice.test.ts
+++ b/packages/remeda/src/splice.test.ts
@@ -218,12 +218,16 @@ test("a purried data-last implementation", () => {
   ]);
 });
 
-describe("replacement is optional", () => {
-  test("data-first omits replacement", () => {
-    expect(splice([1, 2, 3, 4, 5], 1, 2)).toStrictEqual([1, 4, 5]);
+describe("replacement defaults to an empty array", () => {
+  test("data-first", () => {
+    expect(splice([1, 2, 3, 4, 5], 1, 2)).toStrictEqual(
+      splice([1, 2, 3, 4, 5], 1, 2, []),
+    );
   });
 
-  test("data-last omits replacement", () => {
-    expect(pipe([1, 2, 3, 4, 5], splice(1, 2))).toStrictEqual([1, 4, 5]);
+  test("data-last", () => {
+    expect(pipe([1, 2, 3, 4, 5], splice(1, 2))).toStrictEqual(
+      pipe([1, 2, 3, 4, 5], splice(1, 2, [])),
+    );
   });
 });

--- a/packages/remeda/src/splice.ts
+++ b/packages/remeda/src/splice.ts
@@ -1,57 +1,77 @@
-import { purry } from "./purry";
+import { purryOn } from "./internal/purryOn";
+import type { IterableContainer } from "./internal/types/IterableContainer";
+import { isNumber } from "./isNumber";
 
 /**
- * Removes elements from an array and, inserts new elements in their place.
+ * Removes elements from an array and, optionally, inserts new elements in
+ * their place.
  *
- * @param items - The array to splice.
+ * Related operations:
+ * - `drop` - to skip past the first `n` elements.
+ * - `dropLast` - to skip past the last `n` elements.
+ * - `filter` - to shape the array by *value* rather than by *position*.
+ * - `swapIndices` - to swap two elements by their indices.
+ * - `take` - to keep only the first `n` elements.
+ * - `takeLast` - to keep only the last `n` elements.
+ *
+ * @param data - The array to splice.
  * @param start - The index from which to start removing elements.
  * @param deleteCount - The number of elements to remove.
- * @param replacement - The elements to insert into the array in place of the deleted elements.
+ * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
  * @signature
- *    splice(items, start, deleteCount, replacement)
+ *    splice(items, start, deleteCount, replacement?)
  * @example
- *    splice([1,2,3,4,5,6,7,8], 2, 3, []); //=> [1,2,6,7,8]
+ *    splice([1,2,3,4,5,6,7,8], 2, 3); //=> [1,2,6,7,8]
  *    splice([1,2,3,4,5,6,7,8], 2, 3, [9, 10]); //=> [1,2,9,10,6,7,8]
  * @dataFirst
  * @category Array
  */
-export function splice<T>(
-  items: readonly T[],
+export function splice<T extends IterableContainer>(
+  data: T,
   start: number,
   deleteCount: number,
-  replacement: readonly T[],
-): T[];
+  replacement?: readonly T[number][],
+): T[number][];
 
 /**
- * Removes elements from an array and, inserts new elements in their place.
+ * Removes elements from an array and, optionally, inserts new elements in
+ * their place.
+ *
+ * Related operations:
+ * - `drop` - to skip past the first `n` elements.
+ * - `dropLast` - to skip past the last `n` elements.
+ * - `filter` - to shape the array by *value* rather than by *position*.
+ * - `swapIndices` - to swap two elements by their indices.
+ * - `take` - to keep only the first `n` elements.
+ * - `takeLast` - to keep only the last `n` elements.
  *
  * @param start - The index from which to start removing elements.
  * @param deleteCount - The number of elements to remove.
- * @param replacement - The elements to insert into the array in place of the deleted elements.
+ * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
  * @signature
- *    splice(start, deleteCount, replacement)(items)
+ *    splice(start, deleteCount, replacement?)(items)
  * @example
- *    pipe([1,2,3,4,5,6,7,8], splice(2, 3, [])) // => [1,2,6,7,8]
+ *    pipe([1,2,3,4,5,6,7,8], splice(2, 3)) // => [1,2,6,7,8]
  *    pipe([1,2,3,4,5,6,7,8], splice(2, 3, [9, 10])) // => [1,2,9,10,6,7,8]
  * @dataLast
  * @category Array
  */
-export function splice<T>(
+export function splice<T extends IterableContainer>(
   start: number,
   deleteCount: number,
-  replacement: readonly T[],
-): (items: readonly T[]) => T[];
+  replacement?: readonly NoInfer<T>[number][],
+): (data: T) => T[number][];
 
 export function splice(...args: readonly unknown[]): unknown {
-  return purry(spliceImplementation, args);
+  return purryOn(isNumber, spliceImplementation, args);
 }
 
-function spliceImplementation<T>(
-  items: readonly T[],
+function spliceImplementation<T extends IterableContainer>(
+  items: T,
   start: number,
   deleteCount: number,
-  replacement: readonly T[],
-): T[] {
+  replacement: readonly T[number][] = [],
+): T[number][] {
   // TODO [>2]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.toSpliced` here.
   const result = [...items];
   result.splice(start, deleteCount, ...replacement);

--- a/packages/remeda/src/splice.ts
+++ b/packages/remeda/src/splice.ts
@@ -1,6 +1,5 @@
 import { purryOn } from "./internal/purryOn";
 import type { IterableContainer } from "./internal/types/IterableContainer";
-import { isNumber } from "./isNumber";
 
 /**
  * Removes elements from an array and, optionally, inserts new elements in
@@ -19,7 +18,8 @@ import { isNumber } from "./isNumber";
  * @param deleteCount - The number of elements to remove.
  * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
  * @signature
- *    splice(items, start, deleteCount, replacement?)
+ *    splice(data, start, deleteCount);
+ *    splice(data, start, deleteCount, replacement);
  * @example
  *    splice([1,2,3,4,5,6,7,8], 2, 3); //=> [1,2,6,7,8]
  *    splice([1,2,3,4,5,6,7,8], 2, 3, [9, 10]); //=> [1,2,9,10,6,7,8]
@@ -49,7 +49,8 @@ export function splice<T extends IterableContainer>(
  * @param deleteCount - The number of elements to remove.
  * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
  * @signature
- *    splice(start, deleteCount, replacement?)(items)
+ *    splice(start, deleteCount)(data);
+ *    splice(start, deleteCount, replacement)(data);
  * @example
  *    pipe([1,2,3,4,5,6,7,8], splice(2, 3)) // => [1,2,6,7,8]
  *    pipe([1,2,3,4,5,6,7,8], splice(2, 3, [9, 10])) // => [1,2,9,10,6,7,8]
@@ -59,21 +60,25 @@ export function splice<T extends IterableContainer>(
 export function splice<T extends IterableContainer>(
   start: number,
   deleteCount: number,
+  // We use NoInfer to prevent TypeScript from inferring T over-eagerly when the
+  // value of replacement is ambiguous which then prevents the type coming from
+  // the type to override it. We need `data` to be the inference source for T.
+  //  @see https://github.com/remeda/remeda/pull/1358
   replacement?: readonly NoInfer<T>[number][],
 ): (data: T) => T[number][];
 
 export function splice(...args: readonly unknown[]): unknown {
-  return purryOn(isNumber, spliceImplementation, args);
+  return purryOn(($) => typeof $ === "number", spliceImplementation, args);
 }
 
 function spliceImplementation<T extends IterableContainer>(
-  items: T,
+  data: T,
   start: number,
   deleteCount: number,
   replacement: readonly T[number][] = [],
 ): T[number][] {
   // TODO [>2]: When node 18 reaches end-of-life bump target lib to ES2023+ and use `Array.prototype.toSpliced` here.
-  const result = [...items];
+  const result = [...data];
   result.splice(start, deleteCount, ...replacement);
   return result;
 }

--- a/packages/remeda/src/splice.ts
+++ b/packages/remeda/src/splice.ts
@@ -16,7 +16,7 @@ import type { IterableContainer } from "./internal/types/IterableContainer";
  * @param data - The array to splice.
  * @param start - The index from which to start removing elements.
  * @param deleteCount - The number of elements to remove.
- * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
+ * @param replacement - Elements to insert at the cutoff point.
  * @signature
  *    splice(data, start, deleteCount);
  *    splice(data, start, deleteCount, replacement);
@@ -47,7 +47,7 @@ export function splice<T extends IterableContainer>(
  *
  * @param start - The index from which to start removing elements.
  * @param deleteCount - The number of elements to remove.
- * @param replacement - Optional elements to insert into the array in place of the deleted elements. Defaults to no elements.
+ * @param replacement - Elements to insert at the cutoff point.
  * @signature
  *    splice(start, deleteCount)(data);
  *    splice(start, deleteCount, replacement)(data);

--- a/packages/remeda/src/splice.ts
+++ b/packages/remeda/src/splice.ts
@@ -60,11 +60,7 @@ export function splice<T extends IterableContainer>(
 export function splice<T extends IterableContainer>(
   start: number,
   deleteCount: number,
-  // We use NoInfer to prevent TypeScript from inferring T over-eagerly when the
-  // value of replacement is ambiguous which then prevents the type coming from
-  // the type to override it. We need `data` to be the inference source for T.
-  //  @see https://github.com/remeda/remeda/pull/1358
-  replacement?: readonly NoInfer<T>[number][],
+  replacement?: readonly T[number][],
 ): (data: T) => T[number][];
 
 export function splice(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/swapIndices.ts
+++ b/packages/remeda/src/swapIndices.ts
@@ -92,6 +92,9 @@ type SwappedIndices<
  *
  * If either index is out of bounds the result would be a shallow copy of the input, as-is.
  *
+ * Related operations:
+ * - `splice` - for more general positional edits (remove a slice, insert at an index).
+ *
  * @param data - The item to be manipulated. This can be an array, or a string.
  * @param index1 - The first index.
  * @param index2 - The second index.
@@ -117,6 +120,9 @@ export function swapIndices<
  * Negative indices are supported and would be treated as an offset from the end of the array. The resulting type thought would be less strict than when using positive indices.
  *
  * If either index is out of bounds the result would be a shallow copy of the input, as-is.
+ *
+ * Related operations:
+ * - `splice` - for more general positional edits (remove a slice, insert at an index).
  *
  * @param index1 - The first index.
  * @param index2 - The second index.

--- a/packages/remeda/src/take.ts
+++ b/packages/remeda/src/take.ts
@@ -6,6 +6,11 @@ import { purry } from "./purry";
 /**
  * Returns the first `n` elements of `array`.
  *
+ * Related operations:
+ * - `drop` - to skip past the first `n` instead.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `takeLast` - same, but from the end of the array.
+ *
  * @param array - The array.
  * @param n - The number of elements to take.
  * @signature
@@ -23,6 +28,11 @@ export function take<T extends IterableContainer>(
 
 /**
  * Returns the first `n` elements of `array`.
+ *
+ * Related operations:
+ * - `drop` - to skip past the first `n` instead.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `takeLast` - same, but from the end of the array.
  *
  * @param n - The number of elements to take.
  * @signature

--- a/packages/remeda/src/takeLast.ts
+++ b/packages/remeda/src/takeLast.ts
@@ -4,6 +4,11 @@ import { purry } from "./purry";
 /**
  * Takes the last `n` elements from the `array`.
  *
+ * Related operations:
+ * - `dropLast` - to skip past the last `n` instead.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `take` - same, but from the start of the array.
+ *
  * @param array - The target array.
  * @param n - The number of elements to take.
  * @signature
@@ -20,6 +25,11 @@ export function takeLast<T extends IterableContainer>(
 
 /**
  * Take the last `n` elements from the `array`.
+ *
+ * Related operations:
+ * - `dropLast` - to skip past the last `n` instead.
+ * - `splice` - to remove or insert at an arbitrary index.
+ * - `take` - same, but from the start of the array.
  *
  * @param n - The number of elements to take.
  * @signature


### PR DESCRIPTION
Under the current implementation TypeScript eagerly infers the type of T the moment it sees the optional `replacement` array. When this array is an empty constant (`[]`) it would infer to `never[]` which would then be used as the type of T, breaking the function in pipes.

This PR redesigns the type of `splice` to work around this by using `NoInfer`. It also refactors the typing and implementation to allow droping the `replacement` array when it isn't needed (similar to how the built-in splice allows for not providing a replacement). Finally, we also added cross-references in the JSDoc of `splice` and other utilities for better discoverability.

P.S. `purryOn` typing was fixed to allow using it for `splice` and other functions that take an optional param.
