### PR TITLE
fix(map, mapWithFeedback): Correct types through `NoInfer`

### DIFF
--- a/packages/remeda/src/internal/types/Mapped.ts
+++ b/packages/remeda/src/internal/types/Mapped.ts
@@ -1,5 +1,12 @@
 import type { IterableContainer } from "./IterableContainer";
 
-export type Mapped<T extends IterableContainer, K> = {
-  -readonly [P in keyof T]: K;
-};
+export type Mapped<T extends IterableContainer, K> = T[number][] extends T
+  ? // In rare cases TypeScript can't infer the exact shape of the array but can
+    // still infer it's a simple array. For those cases TypeScript would fail to
+    // remap the array, resulting in a broken type. To circumvent this we can
+    // fallback to a simpler type if we know that TypeScript would treat it as
+    // such anyway. (https://github.com/remeda/remeda/issues/1364)
+    K[]
+  : // Otherwise we use a mapped type to preserve the original shape of the
+    // input.
+    { -readonly [P in keyof T]: K };

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -84,7 +84,7 @@ test("empty tuple", () => {
 });
 
 test("all-optional tuple", () => {
-  expectTypeOf(map([1] as [a?: number, b?: number], identity())).toEqualTypeOf<
+  expectTypeOf(map([] as [a?: number, b?: number], identity())).toEqualTypeOf<
     [a?: number, b?: number]
   >();
 });

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -1,7 +1,10 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { add } from "./add";
 import { constant } from "./constant";
+import { identity } from "./identity";
 import { map } from "./map";
+import { pipe } from "./pipe";
+import { sortBy } from "./sortBy";
 
 test("number array", () => {
   const result = map([1, 2, 3] as number[], add(1));
@@ -74,6 +77,16 @@ test("nonempty readonly (head) number array", () => {
   const result = map([1, 2, 3] as readonly [...number[], number], add(1));
 
   expectTypeOf(result).toEqualTypeOf<[...number[], number]>();
+});
+
+test("empty tuple", () => {
+  expectTypeOf(map([], add(1))).toEqualTypeOf<[]>();
+});
+
+test("all-optional tuple", () => {
+  expectTypeOf(map([1] as [a?: number, b?: number], identity())).toEqualTypeOf<
+    [a?: number, b?: number]
+  >();
 });
 
 describe("indexed", () => {
@@ -172,5 +185,30 @@ describe("indexed", () => {
     );
 
     expectTypeOf(result).toEqualTypeOf<[...number[], number]>();
+  });
+});
+
+// @see https://github.com/remeda/remeda/issues/1364.
+describe("limited type inference through `NoInfer` (#1364)", () => {
+  test("data-first returns a plain array", () => {
+    expectTypeOf(map([] as NoInfer<{ a: number }[]>, identity())).toEqualTypeOf<
+      { a: number }[]
+    >();
+  });
+
+  test("result flows into a downstream IterableContainer constraint", () => {
+    const mapped = map([] as NoInfer<{ a: number }[]>, identity());
+
+    expectTypeOf(sortBy(mapped, ({ a }) => a)).toEqualTypeOf<{ a: number }[]>();
+  });
+
+  test("data-last in a pipe flows into sortBy", () => {
+    expectTypeOf(
+      pipe(
+        [] as NoInfer<{ a: number }[]>,
+        map(identity()),
+        sortBy(({ a }) => a),
+      ),
+    ).toEqualTypeOf<{ a: number }[]>();
   });
 });

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -188,27 +188,29 @@ describe("indexed", () => {
   });
 });
 
-// @see https://github.com/remeda/remeda/issues/1364.
+// @see https://github.com/remeda/remeda/issues/1364
 describe("limited type inference through `NoInfer` (#1364)", () => {
   test("data-first returns a plain array", () => {
-    expectTypeOf(map([] as NoInfer<{ a: number }[]>, identity())).toEqualTypeOf<
-      { a: number }[]
+    expectTypeOf(map([] as NoInfer<number[]>, identity())).toEqualTypeOf<
+      number[]
     >();
   });
 
-  test("result flows into a downstream IterableContainer constraint", () => {
-    const mapped = map([] as NoInfer<{ a: number }[]>, identity());
+  test("works with readonly arrays", () => {
+    expectTypeOf(
+      map([] as NoInfer<readonly number[]>, identity()),
+    ).toEqualTypeOf<number[]>();
+  });
 
-    expectTypeOf(sortBy(mapped, ({ a }) => a)).toEqualTypeOf<{ a: number }[]>();
+  test("result flows into a downstream IterableContainer constraint", () => {
+    const mapped = map([] as NoInfer<number[]>, identity());
+
+    expectTypeOf(sortBy(mapped, identity())).toEqualTypeOf<number[]>();
   });
 
   test("data-last in a pipe flows into sortBy", () => {
     expectTypeOf(
-      pipe(
-        [] as NoInfer<{ a: number }[]>,
-        map(identity()),
-        sortBy(({ a }) => a),
-      ),
-    ).toEqualTypeOf<{ a: number }[]>();
+      pipe([] as NoInfer<number[]>, map(identity()), sortBy(identity())),
+    ).toEqualTypeOf<number[]>();
   });
 });


### PR DESCRIPTION
Fixes: #1364

When an array is typed through a NoInfer (as in the attached issue) it fails to map properly via mapped types (while still being inferred as an array). To work around this we short-circuit our mapped type for simple arrays.