### PR TITLE
fix(setPath): build missing path segments instead of throwing

### DIFF
--- a/packages/remeda/src/setPath.test.ts
+++ b/packages/remeda/src/setPath.test.ts
@@ -53,6 +53,22 @@ describe("data first", () => {
       a: { ...TEST_OBJECT.a, b: { c: 2 } },
     });
   });
+
+  test("should build missing segments instead of throwing (issue #554)", () => {
+    expect(
+      setPath({} as Record<string, { b: number }>, ["a", "b"], 123),
+    ).toStrictEqual({ a: { b: 123 } });
+  });
+
+  test("should build deeply nested missing segments", () => {
+    expect(
+      setPath(
+        {} as Record<string, Record<string, { c: number }>>,
+        ["a", "b", "c"],
+        123,
+      ),
+    ).toStrictEqual({ a: { b: { c: 123 } } });
+  });
 });
 
 describe("data last", () => {

--- a/packages/remeda/src/setPath.ts
+++ b/packages/remeda/src/setPath.ts
@@ -105,7 +105,11 @@ function setPathImplementation(
     return copy;
   }
 
-  const { [pivot]: currentValue, ...remaining } = data as Record<
+  // When the path descends into a property that doesn't exist on `data` (e.g.
+  // a missing key of a `Record`, or a missing optional property) the value
+  // here would be nullish. The path is still valid type-wise, so instead of
+  // throwing when trying to destructure it we build the missing object.
+  const { [pivot]: currentValue, ...remaining } = (data ?? {}) as Record<
     PropertyKey,
     unknown
   >;


### PR DESCRIPTION
## Problem

`setPath` throws a runtime `TypeError` when the path descends into a property that doesn't exist on the data — for example a missing key of a `Record`, or a missing optional property:

```ts
setPath({} as Record<string, { b: number }>, ["a", "b"], 123);
// TypeError: Cannot destructure 'data' as it is undefined.
```

The path `["a", "b"]` is valid at the type level (`Paths<Record<string, { b: number }>>` accepts it and types the value as `number`), so the runtime promises something it then fails to deliver. This was confirmed as a bug in the issue thread.

## Cause

In `setPathImplementation`, the intermediate value becomes nullish when the key is absent, and the object destructuring `const { [pivot]: currentValue, ...remaining } = data` throws on `null`/`undefined`.

## Fix

When the intermediate value is nullish, build the missing object instead of throwing — `(data ?? {})` — which honors the (already valid) type contract and follows the library's *prefer not throwing* philosophy. Existing siblings are preserved and array handling is unchanged.

```ts
setPath({} as Record<string, { b: number }>, ["a", "b"], 123);
// => { a: { b: 123 } }
```

## Tests

Added two data-first regression tests in `setPath.test.ts` covering a single missing segment and deeply nested missing segments. Full suite passes (`test:runtime`, `test:types`, `test:prop`), `check` and `lint` are clean.

Closes #554