### PR TITLE
chore(tsgo): Stop canaries from failing on the beta channel

### DIFF
--- a/.github/workflows/canaries-tsgo.yml
+++ b/.github/workflows/canaries-tsgo.yml
@@ -24,6 +24,10 @@ jobs:
   test-source:
     name: 📒 Test source [tsgo ${{ matrix.native-preview-version }}]
     runs-on: ubuntu-latest
+    # We test beta so we have the data, but because `beta` doesn't change,
+    # failing on it would simply fail our canary even when bugs are detected
+    # and fixed.
+    continue-on-error: ${{ matrix.native-preview-version == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +113,8 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    # See rationale above...
+    continue-on-error: ${{ matrix.native-preview-version == 'beta' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Beta is a fixed version and does not get updated with bugfixes. This means that anything in beta which is broken for us would stay broken.

This makes our canary uneffecitve at surfacing *new* breakages.