### PR TITLE
fix(swapIndices): treat an index equal to the array length as out of bounds

### DIFF
--- a/packages/remeda/src/swapIndices.test.ts
+++ b/packages/remeda/src/swapIndices.test.ts
@@ -21,6 +21,16 @@ describe("data_first", () => {
     expect(swapIndices("apple", 1, 100)).toBe("apple");
     expect(swapIndices("apple", 200, 300)).toBe("apple");
   });
+
+  test("fails gracefully when an index equals the length", () => {
+    // The largest valid index is `length - 1`, so an index equal to `length`
+    // is out of bounds and should return the input as-is (and not grow it).
+    expect(swapIndices([1, 2, 3], 3, 0)).toStrictEqual([1, 2, 3]);
+    expect(swapIndices([1, 2, 3], 0, 3)).toStrictEqual([1, 2, 3]);
+    expect(swapIndices([1, 2, 3], 3, 3)).toStrictEqual([1, 2, 3]);
+    expect(swapIndices("apple", 5, 0)).toBe("apple");
+    expect(swapIndices("apple", 0, 5)).toBe("apple");
+  });
 });
 
 describe("data_last", () => {

--- a/packages/remeda/src/swapIndices.ts
+++ b/packages/remeda/src/swapIndices.ts
@@ -172,11 +172,11 @@ function swapArray(
   const positiveIndexA = index1 < 0 ? data.length + index1 : index1;
   const positiveIndexB = index2 < 0 ? data.length + index2 : index2;
 
-  if (positiveIndexA < 0 || positiveIndexA > data.length) {
+  if (positiveIndexA < 0 || positiveIndexA >= data.length) {
     return result;
   }
 
-  if (positiveIndexB < 0 || positiveIndexB > data.length) {
+  if (positiveIndexB < 0 || positiveIndexB >= data.length) {
     return result;
   }
 


### PR DESCRIPTION
`swapIndices` is documented to return a shallow copy of the input as-is when an index is out of bounds. But the bounds check used `> data.length`, while the largest valid index is `data.length - 1`. An index exactly equal to the length slipped through and corrupted the result — it grew the array by one element and wrote an `undefined`/hole:

```ts
swapIndices([1, 2, 3], 3, 0); // => [undefined, 2, 3, 1]  (expected [1, 2, 3])
swapIndices([1, 2, 3], 0, 3); // => [undefined, 2, 3, 1]
swapIndices("apple", 5, 0);   // => corrupted (expected "apple")
```

This also contradicts the static type, which already treats an index equal to the length as out of bounds (`isLessThan<K, T["length"]>` ⇒ returns `T` unchanged). The fix aligns the runtime with the type by using `>= data.length`. As a bonus this also fixes the empty-array case (`swapIndices([], 0, 0)`).

Added regression tests for the boundary (array + string); the existing far-overflow / negative / NaN cases are unaffected. Full runtime suite passes.

> Note: the `.github/workflows/canaries-tsgo.yml` change in this branch is only a rebase artifact (my fork token lacks the `workflow` scope, so it's pinned to the fork's revision). Happy to drop it — it's unrelated to the fix.
