### PR TITLE
chore(canary): allow breaking unrelated peer dependencies

### DIFF
--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -129,8 +129,9 @@ jobs:
       - name: 📥 Download dependencies
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1.12.1
 
-      # See the note on the same step in test-source above.
       - name: 📘 Install TypeScript
+        # legacy-peer-deps allows us to avoid peer dependency conflicts for
+        # packages which are not relevant for this check anyway.
         run: npm --workspace=remeda install -D --legacy-peer-deps typescript@${{ matrix.typescript-version }}
 
       - name: 🚚 Restore distributable

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -40,7 +40,9 @@ jobs:
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1.12.1
 
       - name: 📘 Install TypeScript
-        run: npm --workspace=remeda install -D typescript@${{ matrix.typescript-version }}
+        # legacy-peer-deps allows us to avoid peer dependency conflicts for
+        # packages which are not relevant for this check anyway.
+        run: npm --workspace=remeda install -D --legacy-peer-deps typescript@${{ matrix.typescript-version }}
 
       - name: 🎯 Concrete version
         run: npx --workspace=remeda tsc --version | tee -a $GITHUB_STEP_SUMMARY
@@ -127,8 +129,9 @@ jobs:
       - name: 📥 Download dependencies
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1.12.1
 
+      # See the note on the same step in test-source above.
       - name: 📘 Install TypeScript
-        run: npm --workspace=remeda install -D typescript@${{ matrix.typescript-version }}
+        run: npm --workspace=remeda install -D --legacy-peer-deps typescript@${{ matrix.typescript-version }}
 
       - name: 🚚 Restore distributable
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
These are not useful for the canary and cause breakages