### PR TITLE
fix(prop): Handle index signatures correctly

### DIFF
--- a/.agents/skills/remeda-utility/reference/testing-types.md
+++ b/.agents/skills/remeda-utility/reference/testing-types.md
@@ -1,5 +1,5 @@
 - Use `expectTypeOf(...).toEqualTypeOf<...>()` (not `assertType`)
-- When a call's inferred return type is a deferred union of a non-primitive type and `undefined`, assign the result to a `const` explicitly; when inferred implicitly inline the unresolved type makes the assertion fail even when the types match (suspected expect-type limitation).
+- When a call's inferred return type is a deferred union of a non-primitive type and `undefined`, assign the result to a `const` first; asserting inline on the unresolved type makes the assertion fail even when the types match (suspected expect-type limitation).
 - Before writing, open a similar function's `.test-d.ts` to see which variation axes were covered (literal vs primitive, single vs union vs template-literal, exact-position vs spread vs optional tuple slots, bounded vs unbounded record, readonly vs mutable). The relevant subset varies per function.
 - `interface` tests are NOT redundant with `type` tests of the same shape — they exercise different TS-level paths through `Record`-extending constraints.
 - Cast empty arrays for type data: `[] as Array<{ name: string }>`

--- a/.agents/skills/remeda-utility/reference/testing-types.md
+++ b/.agents/skills/remeda-utility/reference/testing-types.md
@@ -1,4 +1,5 @@
 - Use `expectTypeOf(...).toEqualTypeOf<...>()` (not `assertType`)
+- When a call's inferred return type is a deferred union of a non-primitive type and `undefined`, assign the result to a `const` explicitly; when inferred implicitly inline the unresolved type makes the assertion fail even when the types match (suspected expect-type limitation).
 - Before writing, open a similar function's `.test-d.ts` to see which variation axes were covered (literal vs primitive, single vs union vs template-literal, exact-position vs spread vs optional tuple slots, bounded vs unbounded record, readonly vs mutable). The relevant subset varies per function.
 - `interface` tests are NOT redundant with `type` tests of the same shape — they exercise different TS-level paths through `Record`-extending constraints.
 - Cast empty arrays for type data: `[] as Array<{ name: string }>`

--- a/packages/remeda/src/internal/types/Resolved.ts
+++ b/packages/remeda/src/internal/types/Resolved.ts
@@ -1,0 +1,6 @@
+// Acts as a "inference" point that forces TypeScript to resolve during a deep
+// recursive type instead of accumulating more complexity through the tree.
+// This can be used to avoid `Type instantiation is excessively deep and
+// possibly infinite (ts2589)` errors by wrapping the (recursive) computed
+// return types of overloaded signatures with this.
+export type Resolved<T> = T extends infer U ? U : never;

--- a/packages/remeda/src/prop.test-d.ts
+++ b/packages/remeda/src/prop.test-d.ts
@@ -471,6 +471,20 @@ describe("unbounded records (issue #1274)", () => {
     expectTypeOf(prop(data, "b")).toEqualTypeOf<number | undefined>();
   });
 
+  test("declared props alongside a template-literal index signature", () => {
+    const data = {} as { [key: `data-${string}`]: number; a: 1 };
+
+    expectTypeOf(prop(data, "a")).toEqualTypeOf<1>();
+    expectTypeOf(prop(data, "data-foo")).toEqualTypeOf<number | undefined>();
+  });
+
+  test("record intersected with declared props", () => {
+    const data = {} as Record<string, number> & { a: boolean };
+
+    expectTypeOf(prop(data, "a")).toEqualTypeOf<boolean>();
+    expectTypeOf(prop(data, "b")).toEqualTypeOf<number | undefined>();
+  });
+
   test("interface with an index signature", () => {
     const data = {} as InterfaceWithIndexSignature;
 
@@ -509,6 +523,9 @@ describe("unbounded records (issue #1274)", () => {
   });
 
   test("data-last", () => {
+    expectTypeOf(pipe({} as Record<string, number>, prop("x"))).toEqualTypeOf<
+      number | undefined
+    >();
     expectTypeOf(
       pipe({} as { a: Record<string, number> }, prop("a", "x")),
     ).toEqualTypeOf<number | undefined>();

--- a/packages/remeda/src/prop.test-d.ts
+++ b/packages/remeda/src/prop.test-d.ts
@@ -7,6 +7,11 @@ import { stringToPath } from "./stringToPath";
 
 declare const SYMBOL: unique symbol;
 
+interface InterfaceWithIndexSignature {
+  [key: string]: number;
+  a: 1;
+}
+
 describe("data-last", () => {
   test("inferred directly", () => {
     expectTypeOf(sortBy([{ a: 1 }] as const, prop("a"))).toEqualTypeOf<
@@ -418,6 +423,95 @@ describe("optional props", () => {
         "content",
       ),
     ).toEqualTypeOf<string | undefined>();
+  });
+});
+
+// @see https://github.com/remeda/remeda/issues/1274
+describe("unbounded records (issue #1274)", () => {
+  test("unbounded string record", () => {
+    expectTypeOf(prop({} as Record<string, number>, "x")).toEqualTypeOf<
+      number | undefined
+    >();
+  });
+
+  test("unbounded number record", () => {
+    expectTypeOf(prop({} as Record<number, boolean>, 123)).toEqualTypeOf<
+      boolean | undefined
+    >();
+  });
+
+  test("unbounded symbol record", () => {
+    const result = prop({} as Record<symbol, Date>, SYMBOL);
+
+    expectTypeOf(result).toEqualTypeOf<Date | undefined>();
+  });
+
+  test("template-literal record", () => {
+    expectTypeOf(
+      prop({} as Record<`data-${string}`, number>, "data-foo"),
+    ).toEqualTypeOf<number | undefined>();
+  });
+
+  test("bounded record", () => {
+    expectTypeOf(
+      prop({} as Record<"a" | "b", number>, "a"),
+    ).toEqualTypeOf<number>();
+  });
+
+  test("partial bounded record", () => {
+    expectTypeOf(
+      prop({} as Partial<Record<"a" | "b", number>>, "a"),
+    ).toEqualTypeOf<number | undefined>();
+  });
+
+  test("declared props alongside an index signature", () => {
+    const data = {} as { [key: string]: number; a: 1 };
+
+    expectTypeOf(prop(data, "a")).toEqualTypeOf<1>();
+    expectTypeOf(prop(data, "b")).toEqualTypeOf<number | undefined>();
+  });
+
+  test("interface with an index signature", () => {
+    const data = {} as InterfaceWithIndexSignature;
+
+    expectTypeOf(prop(data, "a")).toEqualTypeOf<1>();
+    expectTypeOf(prop(data, "b")).toEqualTypeOf<number | undefined>();
+  });
+
+  test("union of records", () => {
+    expectTypeOf(
+      prop({} as Record<string, number> | Record<string, boolean>, "x"),
+    ).toEqualTypeOf<number | boolean | undefined>();
+  });
+
+  test("record in a deep path", () => {
+    const data = {} as {
+      a: Record<string, { b: { c: "hello"; d: boolean; e: string } }>;
+    };
+    const recordEntry = prop(data, "a", "x");
+    const insideRecordEntry = prop(data, "a", "x", "b");
+
+    expectTypeOf(prop(data, "a")).toEqualTypeOf<
+      Record<string, { b: { c: "hello"; d: boolean; e: string } }>
+    >();
+    expectTypeOf(recordEntry).toEqualTypeOf<
+      { b: { c: "hello"; d: boolean; e: string } } | undefined
+    >();
+    expectTypeOf(insideRecordEntry).toEqualTypeOf<
+      { c: "hello"; d: boolean; e: string } | undefined
+    >();
+    expectTypeOf(prop(data, "a", "x", "b", "c")).toEqualTypeOf<
+      "hello" | undefined
+    >();
+    expectTypeOf(prop(data, "a", "x", "b", "d")).toEqualTypeOf<
+      boolean | undefined
+    >();
+  });
+
+  test("data-last", () => {
+    expectTypeOf(
+      pipe({} as { a: Record<string, number> }, prop("a", "x")),
+    ).toEqualTypeOf<number | undefined>();
   });
 });
 

--- a/packages/remeda/src/prop.ts
+++ b/packages/remeda/src/prop.ts
@@ -1,5 +1,6 @@
 import type { KeysOfUnion, OmitIndexSignature } from "type-fest";
 import type { ArrayAt } from "./internal/types/ArrayAt";
+import type { Resolved } from "./internal/types/Resolved";
 
 // Computes all possible keys of `T` at `Path` spread over unions, allowing
 // keys from any of the results, not just those **shared** by all of them.
@@ -70,12 +71,12 @@ type NonPropertyKey = object | null | undefined;
 export function prop<T extends NonPropertyKey, Key extends KeysDeep<T, []>>(
   data: T,
   key: Key,
-): NoInfer<Prop<T, Key>>;
+): Resolved<Prop<T, Key>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
   Key1 extends KeysDeep<T, [Key0]>,
->(data: T, key0: Key0, key1: Key1): NoInfer<PropDeep<T, [Key0, Key1]>>;
+>(data: T, key0: Key0, key1: Key1): Resolved<PropDeep<T, [Key0, Key1]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -86,7 +87,7 @@ export function prop<
   key0: Key0,
   key1: Key1,
   key2: Key2,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -99,7 +100,7 @@ export function prop<
   key1: Key1,
   key2: Key2,
   key3: Key3,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2, Key3]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -114,7 +115,7 @@ export function prop<
   key2: Key2,
   key3: Key3,
   key4: Key4,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -131,7 +132,7 @@ export function prop<
   key3: Key3,
   key4: Key4,
   key5: Key5,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -150,7 +151,7 @@ export function prop<
   key4: Key4,
   key5: Key5,
   key6: Key6,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -171,7 +172,7 @@ export function prop<
   key5: Key5,
   key6: Key6,
   key7: Key7,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7]>>;
+): Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -194,7 +195,9 @@ export function prop<
   key6: Key6,
   key7: Key7,
   key8: Key8,
-): NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7, Key8]>>;
+): Resolved<
+  PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7, Key8]>
+>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -224,7 +227,7 @@ export function prop<
   key8: Key8,
   key9: Key9,
   ...additionalKeys: AdditionalKeys
-): NoInfer<
+): Resolved<
   PropDeep<
     T,
     [
@@ -267,12 +270,12 @@ export function prop<
  */
 export function prop<T extends NonPropertyKey, Key extends KeysOfUnion<T>>(
   key: Key,
-): (data: T) => NoInfer<Prop<T, Key>>;
+): (data: T) => Resolved<Prop<T, Key>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
   Key1 extends KeysDeep<T, [Key0]>,
->(key0: Key0, key1: Key1): (data: T) => NoInfer<PropDeep<T, [Key0, Key1]>>;
+>(key0: Key0, key1: Key1): (data: T) => Resolved<PropDeep<T, [Key0, Key1]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -282,7 +285,7 @@ export function prop<
   key0: Key0,
   key1: Key1,
   key2: Key2,
-): (data: T) => NoInfer<PropDeep<T, [Key0, Key1, Key2]>>;
+): (data: T) => Resolved<PropDeep<T, [Key0, Key1, Key2]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -294,7 +297,7 @@ export function prop<
   key1: Key1,
   key2: Key2,
   key3: Key3,
-): (data: T) => NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3]>>;
+): (data: T) => Resolved<PropDeep<T, [Key0, Key1, Key2, Key3]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -308,7 +311,7 @@ export function prop<
   key2: Key2,
   key3: Key3,
   key4: Key4,
-): (data: T) => NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4]>>;
+): (data: T) => Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -324,7 +327,7 @@ export function prop<
   key3: Key3,
   key4: Key4,
   key5: Key5,
-): (data: T) => NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5]>>;
+): (data: T) => Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -344,7 +347,7 @@ export function prop<
   key6: Key6,
 ): (
   data: T,
-) => NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6]>>;
+) => Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -366,7 +369,7 @@ export function prop<
   key7: Key7,
 ): (
   data: T,
-) => NoInfer<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7]>>;
+) => Resolved<PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7]>>;
 export function prop<
   T extends NonPropertyKey,
   Key0 extends KeysDeep<T, []>,
@@ -390,7 +393,7 @@ export function prop<
   key8: Key8,
 ): (
   data: T,
-) => NoInfer<
+) => Resolved<
   PropDeep<T, [Key0, Key1, Key2, Key3, Key4, Key5, Key6, Key7, Key8]>
 >;
 export function prop<
@@ -423,7 +426,7 @@ export function prop<
   ...additionalKeys: AdditionalKeys
 ): (
   data: T,
-) => NoInfer<
+) => Resolved<
   PropDeep<
     T,
     [

--- a/packages/remeda/src/prop.ts
+++ b/packages/remeda/src/prop.ts
@@ -29,8 +29,7 @@ type Prop<T, Key> =
         ? ArrayAt<T, Key>
         : | T[Key]
           // Keys that are only matched by an index signature (and not declared
-          // explicitly) might be missing at runtime; mirroring
-          // `noUncheckedIndexedAccess`.
+          // explicitly) are not guaranteed to exist and need to be widened.
           | (Key extends keyof OmitIndexSignature<T> ? never : undefined)
       : undefined
     : never;

--- a/packages/remeda/src/prop.ts
+++ b/packages/remeda/src/prop.ts
@@ -1,4 +1,4 @@
-import type { KeysOfUnion } from "type-fest";
+import type { KeysOfUnion, OmitIndexSignature } from "type-fest";
 import type { ArrayAt } from "./internal/types/ArrayAt";
 
 // Computes all possible keys of `T` at `Path` spread over unions, allowing
@@ -27,7 +27,11 @@ type Prop<T, Key> =
       Key extends keyof T
       ? T extends readonly unknown[]
         ? ArrayAt<T, Key>
-        : T[Key]
+        : | T[Key]
+          // Keys that are only matched by an index signature (and not declared
+          // explicitly) might be missing at runtime; mirroring
+          // `noUncheckedIndexedAccess`.
+          | (Key extends keyof OmitIndexSignature<T> ? never : undefined)
       : undefined
     : never;
 
@@ -45,10 +49,11 @@ type NonPropertyKey = object | null | undefined;
  * Gets the value of the given property from an object. Nested properties can
  * be accessed by providing a variadic array of keys that define the path from
  * the root to the desired property. Arrays can be accessed by using numeric
- * keys. Unions and optional properties are handled gracefully by returning
- * `undefined` early for any non-existing property on the path. Paths are
- * validated against the object type to provide stronger type safety, better
- * compile-time errors, and to enable autocompletion in IDEs.
+ * keys. Unions, optional properties, and index signatures are handled
+ * gracefully by returning `undefined` early for any non-existing property on
+ * the path. Paths are validated against the object type to provide stronger
+ * type safety, better compile-time errors, and to enable autocompletion in
+ * IDEs.
  *
  * To check whether a key exists on the object, use `hasProp`.
  *
@@ -243,10 +248,11 @@ export function prop<
  * Gets the value of the given property from an object. Nested properties can
  * be accessed by providing a variadic array of keys that define the path from
  * the root to the desired property. Arrays can be accessed by using numeric
- * keys. Unions and optional properties are handled gracefully by returning
- * `undefined` early for any non-existing property on the path. Paths are
- * validated against the object type to provide stronger type safety, better
- * compile-time errors, and to enable autocompletion in IDEs.
+ * keys. Unions, optional properties, and index signatures are handled
+ * gracefully by returning `undefined` early for any non-existing property on
+ * the path. Paths are validated against the object type to provide stronger
+ * type safety, better compile-time errors, and to enable autocompletion in
+ * IDEs.
  *
  * To check whether a key exists on the object, use `hasProp`.
  *

--- a/packages/remeda/src/tap.ts
+++ b/packages/remeda/src/tap.ts
@@ -40,7 +40,7 @@ export function tap<T>(value: T, fn: (value: T) => void): T;
  */
 export function tap<
   T,
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- TODO: This is solvable by inlining F and wrapping the T parameter with `NoInfer` (e.g. `(value: NoInfer<T>) => unknown`); to prevent typescript from inferring it as `unknown`. This is only available in TS 5.4, which is above what we currently support (5.1).
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- TODO [>2]: This is solvable by inlining F and wrapping the T parameter with `NoInfer` (e.g. `(value: NoInfer<T>) => unknown`); to prevent typescript from inferring it as `unknown`. This is only available in TS 5.4, which is above what we currently support (5.1).
   F extends (value: T) => unknown,
 >(fn: F): (value: T) => T;
 


### PR DESCRIPTION
Fixes: #1274

We didn't take index signatures into consideration when we built the type for prop, making trivial objects like `Record<string, string>` behave incorrectly; they were missing the `| undefined` widening that is required when the key isn't guaranteed to exist.

