### PR TITLE
docs(funnel,debounce): Improve reference implementation documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,13 +122,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "2.0.239",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.239.tgz",
-      "integrity": "sha512-AndJQ331q4lw07AV46wR3RWhw49XDxe5DnXFUv4bKsayykTW1eQK55Rjddqn78ETxRCmIa1v6JQdO2cJGr2hQg==",
+      "version": "2.0.240",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.240.tgz",
+      "integrity": "sha512-jUrJECM6+PAiWsBqYeTfMr4mk82ms+5jH6o+j5NkCvrk1+dyTG2SMQVCJ3ICglfKZqgTEGnMU8dVIP7qHy6nhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider-utils": "3.0.32",
-        "ai": "5.0.236",
+        "ai": "5.0.237",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
-      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "dev": true,
       "funding": [
         {
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
-      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
       "dev": true,
       "funding": [
         {
@@ -2101,7 +2101,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/color-helpers": "^6.1.1",
         "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
-      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
       "dev": true,
       "funding": [
         {
@@ -8688,9 +8688,9 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.236",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.236.tgz",
-      "integrity": "sha512-Lni0elREeqnHJ8P0Sg2b6JEPz4/J3/yXkMbnBdQjhhLzrzIm/I2ifwzHmMbc0C3sH6QGazljYaWdkwKeVKvM9g==",
+      "version": "5.0.237",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.237.tgz",
+      "integrity": "sha512-vhUJTINUVbmXA4djxDPeYXSmAkzF/dkixHzdCvaCyD+mDsWLemvokt+KWmfkdDwv4Htt2iCScFuB23lP30XALg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/gateway": "2.0.134",
@@ -11281,9 +11281,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11613,9 +11613,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.406",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
-      "integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
+      "version": "1.5.408",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.408.tgz",
+      "integrity": "sha512-SLoprcYpJ/OH2v2ps0+N5biv9H4/KBT3+YmmDew64TwK5y9j2wv7pMOFY7IorVkyMtEyLSCRlXKLsNlakeAlPw==",
       "license": "ISC"
     },
     "node_modules/emmet": {
@@ -11995,9 +11995,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -12295,9 +12295,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "64.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.1.0.tgz",
-      "integrity": "sha512-UyAR/zVWn1jgIM/7eDMeLHuqLVtqKtamNVE0M7mdcZtFkWdYlNvDVDzyCCcURmLe66JpTZkMM3ZM3zjiVvIByA==",
+      "version": "64.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.2.0.tgz",
+      "integrity": "sha512-z3zGmJoPhOdKnxzQ3R+8MZeJjW8vrRW8r7sYp/ErBp8K9+05RIa6vWXtbEGr7D1obBHk64LdKyLHoMLSzHFINA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15298,9 +15298,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -15461,9 +15461,9 @@
       "license": "MIT"
     },
     "node_modules/json-with-bigint": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.11.tgz",
-      "integrity": "sha512-WvkM9Hfb9kqzCcbsvpwfWDvdfGZDhYuCoaCwHRe5q3LtULKkbrI/L6JYcN8owflgA3di5dP2yVAV2NVCXkgtkA==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.12.tgz",
+      "integrity": "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -19741,9 +19741,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -24841,6 +24841,57 @@
         }
       }
     },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
@@ -26365,291 +26416,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "packages/remeda/node_modules/lightningcss": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.33.0",
-        "lightningcss-darwin-arm64": "1.33.0",
-        "lightningcss-darwin-x64": "1.33.0",
-        "lightningcss-freebsd-x64": "1.33.0",
-        "lightningcss-linux-arm-gnueabihf": "1.33.0",
-        "lightningcss-linux-arm64-gnu": "1.33.0",
-        "lightningcss-linux-arm64-musl": "1.33.0",
-        "lightningcss-linux-x64-gnu": "1.33.0",
-        "lightningcss-linux-x64-musl": "1.33.0",
-        "lightningcss-win32-arm64-msvc": "1.33.0",
-        "lightningcss-win32-x64-msvc": "1.33.0"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "packages/remeda/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "packages/remeda/node_modules/tsdown": {
       "version": "0.22.14",
       "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.14.tgz",
@@ -26761,122 +26527,6 @@
           "optional": true
         },
         "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "packages/remeda/node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lightningcss": "^1.33.0",
-        "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
-        "tinyglobby": "^0.2.17"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "packages/remeda/node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
-    "packages/remeda/node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13698,6 +13698,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -26332,6 +26339,7 @@
         "type-fest": "5.8.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.67.0",
+        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -26355,6 +26363,291 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "packages/remeda/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "packages/remeda/node_modules/tsdown": {
@@ -26468,6 +26761,122 @@
           "optional": true
         },
         "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "packages/remeda/node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "packages/remeda/node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "packages/remeda/node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       "eslint": "~10.8.1"
     },
     "vite": "~8.2.1",
+    "vite-tsconfig-paths": {
+      "vite": "~7.3.1"
+    },
     "vitest": {
       "vite": "~7.3.1"
     }

--- a/packages/docs/src/content/mapping/lodash/debounce.md
+++ b/packages/docs/src/content/mapping/lodash/debounce.md
@@ -13,8 +13,9 @@ remeda: funnel
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By
   inlining only the parts you need you can take advantage of capabilities not
-  available in Lodash. In the test files, copy everything between the
-  `REFERENCE START` and `REFERENCE END` markers.
+  available in Lodash. To copy the expanded versions from the test files
+  instead, take everything between the `REFERENCE START` and `REFERENCE END`
+  markers.
 
 #### Reference
 

--- a/packages/docs/src/content/mapping/lodash/debounce.md
+++ b/packages/docs/src/content/mapping/lodash/debounce.md
@@ -13,11 +13,14 @@ remeda: funnel
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By
   inlining only the parts you need you can take advantage of capabilities not
-  available in Lodash.
+  available in Lodash. In the test files, copy everything between the
+  `REFERENCE START` and `REFERENCE END` markers.
 
 #### Reference
 
 ```ts
+import { funnel } from "remeda";
+
 function debounce<F extends (...args: any) => void>(
   func: F,
   wait = 0,
@@ -44,7 +47,11 @@ function debounce<F extends (...args: any) => void>(
     {
       minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      triggerAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
   return Object.assign(call, rest);
@@ -54,6 +61,8 @@ function debounce<F extends (...args: any) => void>(
 #### With call arguments
 
 ```ts
+import { funnel } from "remeda";
+
 function debounce<F extends (...args: any) => void>(
   func: F,
   wait = 0,
@@ -81,7 +90,11 @@ function debounce<F extends (...args: any) => void>(
       reducer: (_, ...args: Parameters<F>) => args,
       minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      triggerAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
   return Object.assign(call, rest);
@@ -91,6 +104,8 @@ function debounce<F extends (...args: any) => void>(
 #### With cached value
 
 ```ts
+import { funnel } from "remeda";
+
 function debounce<F extends (...args: any) => any>(
   func: F,
   wait = 0,
@@ -116,7 +131,11 @@ function debounce<F extends (...args: any) => any>(
       reducer: (_, ...args: Parameters<F>) => args,
       minQuietPeriodMs: wait,
       ...(maxWait !== undefined && { maxBurstDurationMs: maxWait }),
-      triggerAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
   return Object.assign(

--- a/packages/docs/src/content/mapping/lodash/throttle.md
+++ b/packages/docs/src/content/mapping/lodash/throttle.md
@@ -13,8 +13,9 @@ remeda: funnel
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By
   inlining only the parts you need you can take advantage of capabilities not
-  available in Lodash. In the test files, copy everything between the
-  `REFERENCE START` and `REFERENCE END` markers.
+  available in Lodash. To copy the expanded versions from the test files
+  instead, take everything between the `REFERENCE START` and `REFERENCE END`
+  markers.
 
 #### Reference
 

--- a/packages/docs/src/content/mapping/lodash/throttle.md
+++ b/packages/docs/src/content/mapping/lodash/throttle.md
@@ -13,11 +13,14 @@ remeda: funnel
 - These implementations can be copied as-is into your project, but might contain
   redundant parts which are not relevant for your specific use cases. By
   inlining only the parts you need you can take advantage of capabilities not
-  available in Lodash.
+  available in Lodash. In the test files, copy everything between the
+  `REFERENCE START` and `REFERENCE END` markers.
 
 #### Reference
 
 ```ts
+import { funnel } from "remeda";
+
 function throttle<F extends (...args: any) => void>(
   func: F,
   wait = 0,
@@ -37,9 +40,13 @@ function throttle<F extends (...args: any) => void>(
       }
     },
     {
-      burstCoolDownMs: wait,
+      minQuietPeriodMs: wait,
       maxBurstDurationMs: wait,
-      invokedAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
   return Object.assign(call, rest);
@@ -49,6 +56,8 @@ function throttle<F extends (...args: any) => void>(
 #### With call arguments
 
 ```ts
+import { funnel } from "remeda";
+
 function throttle<F extends (...args: any) => void>(
   func: F,
   wait = 0,
@@ -71,7 +80,11 @@ function throttle<F extends (...args: any) => void>(
       reducer: (_, ...args: Parameters<F>) => args,
       minQuietPeriodMs: wait,
       maxBurstDurationMs: wait,
-      triggerAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
   return Object.assign(call, rest);
@@ -81,6 +94,8 @@ function throttle<F extends (...args: any) => void>(
 #### With cached value
 
 ```ts
+import { funnel } from "remeda";
+
 function throttle<F extends (...args: any) => any>(
   func: F,
   wait = 0,
@@ -101,7 +116,11 @@ function throttle<F extends (...args: any) => any>(
       reducer: (_, ...args: Parameters<F>) => args,
       minQuietPeriodMs: wait,
       maxBurstDurationMs: wait,
-      triggerAt: trailing ? (leading ? "both" : "end") : "start",
+      ...(trailing
+        ? leading
+          ? { triggerAt: "both" }
+          : { triggerAt: "end" }
+        : { triggerAt: "start" }),
     },
   );
 

--- a/packages/remeda/package.json
+++ b/packages/remeda/package.json
@@ -87,6 +87,7 @@
     "type-fest": "5.8.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.67.0",
+    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.10"
   },
   "sideEffects": false

--- a/packages/remeda/src/debounce.ts
+++ b/packages/remeda/src/debounce.ts
@@ -51,7 +51,7 @@ type DebounceOptions = {
  * It stores the value returned by `func` whenever its invoked. This value is returned on every call, and is accessible via the `cachedValue` property of the debouncer. Its important to note that the value might be different from the value that would be returned from running `func` with the current arguments as it is a cached value from a previous invocation.
  * **Important**: The cool-down period defines the minimum between two invocations, and not the maximum. The period will be **extended** each time a call is made until a full cool-down period has elapsed without any additional calls.
  *
- *! **DEPRECATED**: This implementation of debounce is known to have issues and might not behave as expected. It should be replaced with the `funnel` utility instead. The test file [funnel.remeda-debounce.test.ts](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts) offers a reference implementation that replicates `debounce` via `funnel`!
+ *! **DEPRECATED**: This implementation of debounce is known to have issues and might not behave as expected. It should be replaced with the `funnel` utility instead. The test file [funnel.remeda-debounce.test.ts](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts) offers a drop-in replacement implemented via `funnel`: copy everything between its REFERENCE START and REFERENCE END markers into your project!
  *
  * @param func - The function to debounce, the returned `call` function will have
  * the exact same signature.
@@ -94,8 +94,9 @@ type DebounceOptions = {
  * @category Function
  * @deprecated This implementation of debounce is known to have issues and might
  * not behave as expected. It should be replaced with the `funnel` utility
- * instead. The test file `funnel.remeda-debounce.test.ts` offers a reference
- * implementation that replicates `debounce` via `funnel`.
+ * instead. The test file [funnel.remeda-debounce.test.ts](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts)
+ * offers a drop-in replacement implemented via `funnel`: copy everything
+ * between its REFERENCE START and REFERENCE END markers into your project.
  * @see https://css-tricks.com/debouncing-throttling-explained-examples/
  */
 export function debounce<F extends StrictFunction>(

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -52,8 +52,8 @@ function debounceWithCachedValue<F extends StrictFunction>(
       if (!leading && !trailing) {
         // In Lodash you can disable both the trailing and leading edges of the
         // debounce window, effectively causing the function to never be
-        // invoked. Remeda uses the invokedAt enum exactly to prevent such a
-        // situation; so to simulate Lodash we need to only pass the callback
+        // invoked. Remeda's `triggerAt` option exists exactly to prevent such
+        // a situation; so to simulate Lodash we need to only pass the callback
         // when at least one of them is enabled.
         return;
       }

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -5,36 +5,31 @@
 import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
-import { funnel } from "./funnel";
 import { identity } from "./identity";
-import type { StrictFunction } from "./internal/types/StrictFunction";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
+
+// `never` is intentional; function params are contravariant.
+type StrictFunction = (...args: never) => unknown;
 
 /**
- * A reference implementation of the Lodash `debounce` function using the
- * Remeda `funnel` function. While migrating from Lodash you can copy this
- * function as-is into your codebase and use it as a drop-in replacement; but
- * we recommend eventually inlining the call to `funnel` so you can adjust the
- * function to your specific needs.
+ * A drop-in replacement for the Lodash `debounce` function, implemented on
+ * top of Remeda's `funnel`. This is a more complex implementation which
+ * respects Lodash's capability to track the return value of the callback
+ * function; in most cases you are more likely to prefer the simpler variant
+ * available in the migration docs. Whenever Lodash offered a concrete spec
+ * this implementation respects it, but there might be untested use-cases that
+ * would have differing runtime behaviors.
  *
- * This is a more complex implementation which respects Lodash capability to
- * track the return value of the callback function. In most cases you are more
- * likely to prefer the simpler reference implementation `debounce` which can
- * be found in the other test file.
+ * We recommend eventually inlining the call to `funnel` and adjusting the
+ * implementation to your specific needs.
  *
- * The following tests in this file are based on the Lodash tests for debounce.
- * They have been adapted to work with our testing framework, have been fixed
- * or expanded slightly were it felt necessary, and have been modernized for
- * better readability. The names of the test cases have been preserved to ease
- * comparing them to the original tests. Tests that are unrelated to the cache
- * capability have been removed to avoid duplication with the other test file.
- *
- * Note that this means that whenever Lodash offered a concrete spec, we made
- * sure our reference implementation respects it, but there might be untested
- * use-cases that would have differing runtime behaviors.
- *
+ * @see https://remedajs.com/migrate/lodash#debounce
  * @see Lodash Documentation: https://lodash.com/docs/4.17.15#debounce
  * @see Lodash Implementation: https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10372
- * @see Lodash Tests: https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187
  * @see Lodash Typing: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/common/function.d.ts#L374
  */
 function debounceWithCachedValue<F extends StrictFunction>(
@@ -105,6 +100,15 @@ function debounceWithCachedValue<F extends StrictFunction>(
     },
   );
 }
+// --- REFERENCE END ---------------------------------------------------------
+
+// The following tests are based on the Lodash tests for debounce
+// (https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L4187). They
+// have been adapted to work with our testing framework, have been fixed or
+// expanded slightly where it felt necessary, and have been modernized for
+// better readability. The names of the test cases have been preserved to ease
+// comparing them to the original tests. Tests that are unrelated to the cache
+// capability have been removed to avoid duplication with the other test file.
 
 // We need some non-trivial duration to use in all our tests, to abstract the
 // actual chosen value we use this UnitOfTime (UT) constant. As long as it is a

--- a/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce-with-cached-value.test.ts
@@ -12,7 +12,7 @@ import { identity } from "./identity";
 // --- REFERENCE START -------------------------------------------------------
 import { funnel } from "remeda";
 
-// `never` is intentional; function params are contravariant.
+// Using `never` as the type for args allows this to extend *any* function.
 type StrictFunction = (...args: never) => unknown;
 
 /**

--- a/packages/remeda/src/funnel.lodash-debounce.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce.test.ts
@@ -4,31 +4,26 @@
 
 import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
-import { funnel } from "./funnel";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
 
 /**
- * A reference implementation of the Lodash `debounce` function using the
- * Remeda `funnel` function. While migrating from Lodash you can copy this
- * function as-is into your code base and use it as a drop-in replacement; but
- * we recommend eventually inlining the call to `funnel` so you can adjust the
- * function to your specific needs.
+ * A drop-in replacement for the Lodash `debounce` function, implemented on
+ * top of Remeda's `funnel`. This is a simplified implementation which ignores
+ * the Lodash capability to track the return value of the callback function,
+ * but it is most likely the more common use-case; a more complete (and more
+ * complex) variant that also handles that requirement is available in the
+ * migration docs. Whenever Lodash offered a concrete spec this implementation
+ * respects it, but there might be untested use-cases that would have
+ * differing runtime behaviors.
  *
- * This is a simplified implementation which ignores the Lodash capability to
- * track the return value of the callback function, but it is most likely the
- * more common use-case. For a more complete (and more complex) implementation
- * that also handles that requirement see the reference implementation for
- * `debounceWithCachedValue` in the other test file.
+ * We recommend eventually inlining the call to `funnel` and adjusting the
+ * implementation to your specific needs.
  *
- * The following tests in this file are based on the Lodash tests for debounce.
- * They have been adapted to work with our testing framework, have been fixed
- * or expanded slightly were it felt necessary, and have been modernized for
- * better readability. The names of the test cases have been preserved to ease
- * comparing them to the original tests.
- *
- * Note that this means that whenever Lodash offered a concrete spec, we made
- * sure our reference implementation respects it, but there might be untested
- * use-cases that would have differing runtime behaviors.
- *
+ * @see https://remedajs.com/migrate/lodash#debounce
  * @see Lodash Documentation: https://lodash.com/docs/4.17.15#debounce
  * @see Lodash Implementation: https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10372
  * @see Lodash Typing: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/common/function.d.ts#L374
@@ -88,6 +83,13 @@ function debounce<F extends (...args: any) => void>(
   // reconstruct the object to fit the Lodash API.
   return Object.assign(call, rest);
 }
+// --- REFERENCE END ---------------------------------------------------------
+
+// The following tests are based on the Lodash tests for debounce. They have
+// been adapted to work with our testing framework, have been fixed or
+// expanded slightly where it felt necessary, and have been modernized for
+// better readability. The names of the test cases have been preserved to ease
+// comparing them to the original tests.
 
 // We need some non-trivial duration to use in all our tests, to abstract the
 // actual chosen value we use this UnitOfTime (UT) constant. As long as it is a

--- a/packages/remeda/src/funnel.lodash-debounce.test.ts
+++ b/packages/remeda/src/funnel.lodash-debounce.test.ts
@@ -52,8 +52,8 @@ function debounce<F extends (...args: any) => void>(
       if (!trailing && !leading) {
         // In Lodash you can disable both the trailing and leading edges of the
         // debounce window, effectively causing the function to never be
-        // invoked. Remeda uses the invokedAt enum exactly to prevent such a
-        // situation; so to simulate Lodash we need to only pass the callback
+        // invoked. Remeda's `triggerAt` option exists exactly to prevent such
+        // a situation; so to simulate Lodash we need to only pass the callback
         // when at least one of them is enabled.
         return;
       }

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -5,36 +5,31 @@
 import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
-import { funnel } from "./funnel";
 import { identity } from "./identity";
-import type { StrictFunction } from "./internal/types/StrictFunction";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
+
+// `never` is intentional; function params are contravariant.
+type StrictFunction = (...args: never) => unknown;
 
 /**
- * A reference implementation of the Lodash `throttle` function using the
- * Remeda `funnel` function. While migrating from Lodash you can copy this
- * function as-is into your codebase and use it as a drop-in replacement; but
- * we recommend eventually inlining the call to `funnel` so you can adjust the
- * function to your specific needs.
+ * A drop-in replacement for the Lodash `throttle` function, implemented on
+ * top of Remeda's `funnel`. This is a more complex implementation which
+ * respects Lodash's capability to track the return value of the callback
+ * function; in most cases you are more likely to prefer the simpler variant
+ * available in the migration docs. Whenever Lodash offered a concrete spec
+ * this implementation respects it, but there might be untested use-cases that
+ * would have differing runtime behaviors.
  *
- * This is a more complex implementation which respects Lodash capability to
- * track the return value of the callback function. In most cases you are more
- * likely to prefer the simpler reference implementation `throttle` which can
- * be found in the other test file.
+ * We recommend eventually inlining the call to `funnel` and adjusting the
+ * implementation to your specific needs.
  *
- * The following tests in this file are based on the Lodash tests for throttle.
- * They have been adapted to work with our testing framework, have been fixed
- * or expanded slightly were it felt necessary, and have been modernized for
- * better readability. The names of the test cases have been preserved to ease
- * comparing them to the original tests. Tests that are unrelated to the cache
- * capability have been removed to avoid duplication with the other test file.
- *
- * Note that this means that whenever Lodash offered a concrete spec, we made
- * sure our reference implementation respects it, but there might be untested
- * use-cases that would have differing runtime behaviors.
- *
+ * @see https://remedajs.com/migrate/lodash#throttle
  * @see Lodash Documentation: https://lodash.com/docs/4.17.15#throttle
  * @see Lodash Implementation: https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10965
- * @see Lodash Tests: https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768
  * @see Lodash Typing: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/common/function.d.ts#L1347
  */
 function throttleWithCachedValue<F extends StrictFunction>(
@@ -100,6 +95,15 @@ function throttleWithCachedValue<F extends StrictFunction>(
     },
   );
 }
+// --- REFERENCE END ---------------------------------------------------------
+
+// The following tests are based on the Lodash tests for throttle
+// (https://github.com/lodash/lodash/blob/4.17.21/test/test.js#L22768). They
+// have been adapted to work with our testing framework, have been fixed or
+// expanded slightly where it felt necessary, and have been modernized for
+// better readability. The names of the test cases have been preserved to ease
+// comparing them to the original tests. Tests that are unrelated to the cache
+// capability have been removed to avoid duplication with the other test file.
 
 // We need some non-trivial duration to use in all our tests, to abstract the
 // actual chosen value we use this UnitOfTime (UT) constant. As long as it is a

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -47,8 +47,8 @@ function throttleWithCachedValue<F extends StrictFunction>(
       if (!leading && !trailing) {
         // In Lodash you can disable both the trailing and leading edges of the
         // throttle window, effectively causing the function to never be
-        // invoked. Remeda uses the invokedAt enum exactly to prevent such a
-        // situation; so to simulate Lodash we need to only pass the callback
+        // invoked. Remeda's `triggerAt` option exists exactly to prevent such
+        // a situation; so to simulate Lodash we need to only pass the callback
         // when at least one of them is enabled.
         return;
       }

--- a/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle-with-cached-value.test.ts
@@ -12,7 +12,7 @@ import { identity } from "./identity";
 // --- REFERENCE START -------------------------------------------------------
 import { funnel } from "remeda";
 
-// `never` is intentional; function params are contravariant.
+// Using `never` as the type for args allows this to extend *any* function.
 type StrictFunction = (...args: never) => unknown;
 
 /**

--- a/packages/remeda/src/funnel.lodash-throttle.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle.test.ts
@@ -4,31 +4,26 @@
 
 import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
-import { funnel } from "./funnel";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
 
 /**
- * A reference implementation of the Lodash `throttle` function using the
- * Remeda `funnel` function. While migrating from Lodash you can copy this
- * function as-is into your code base and use it as a drop-in replacement; but
- * we recommend eventually inlining the call to `funnel` so you can adjust the
- * function to your specific needs.
+ * A drop-in replacement for the Lodash `throttle` function, implemented on
+ * top of Remeda's `funnel`. This is a simplified implementation which ignores
+ * the Lodash capability to track the return value of the callback function,
+ * but it is most likely the more common use-case; a more complete (and more
+ * complex) variant that also handles that requirement is available in the
+ * migration docs. Whenever Lodash offered a concrete spec this implementation
+ * respects it, but there might be untested use-cases that would have
+ * differing runtime behaviors.
  *
- * This is a simplified implementation which ignores the Lodash capability to
- * track the return value of the callback function, but it is most likely the
- * more common use-case. For a more complete (and more complex) implementation
- * that also does that see the reference implementation for
- * `throttleWithCachedValue` in the other test file.
+ * We recommend eventually inlining the call to `funnel` and adjusting the
+ * implementation to your specific needs.
  *
- * The following tests in this file are based on the Lodash tests for throttle.
- * They have been adapted to work with our testing framework, have been fixed
- * or expanded slightly were it felt necessary, and have been modernized for
- * better readability. The names of the test cases have been preserved to ease
- * comparing them to the original tests.
- *
- * Note that this means that whenever Lodash offered a concrete spec, we made
- * sure our reference implementation respects it, but there might be untested
- * use-cases that would have differing runtime behaviors.
- *
+ * @see https://remedajs.com/migrate/lodash#throttle
  * @see Lodash Documentation: https://lodash.com/docs/4.17.15#throttle
  * @see Lodash Implementation: https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L10965
  * @see Lodash Typing: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/common/function.d.ts#L1347
@@ -82,6 +77,13 @@ function throttle<F extends (...args: any) => void>(
   // reconstruct the object to fit the Lodash API.
   return Object.assign(call, rest);
 }
+// --- REFERENCE END ---------------------------------------------------------
+
+// The following tests are based on the Lodash tests for throttle. They have
+// been adapted to work with our testing framework, have been fixed or
+// expanded slightly where it felt necessary, and have been modernized for
+// better readability. The names of the test cases have been preserved to ease
+// comparing them to the original tests.
 
 // We need some non-trivial duration to use in all our tests, to abstract the
 // actual chosen value we use this UnitOfTime (UT) constant. As long as it is a

--- a/packages/remeda/src/funnel.lodash-throttle.test.ts
+++ b/packages/remeda/src/funnel.lodash-throttle.test.ts
@@ -47,8 +47,8 @@ function throttle<F extends (...args: any) => void>(
       if (!leading && !trailing) {
         // In Lodash you can disable both the trailing and leading edges of the
         // throttle window, effectively causing the function to never be
-        // invoked. Remeda uses the invokedAt enum exactly to prevent such a
-        // situation; so to simulate Lodash we need to only pass the callback
+        // invoked. Remeda's `triggerAt` option exists exactly to prevent such
+        // a situation; so to simulate Lodash we need to only pass the callback
         // when at least one of them is enabled.
         return;
       }

--- a/packages/remeda/src/funnel.reference-batch.test.ts
+++ b/packages/remeda/src/funnel.reference-batch.test.ts
@@ -98,6 +98,12 @@ function batch<Params extends any[], BatchResponse, Result>(
   return {
     ...batchFunnel,
 
+    // The spread copies `isIdle`'s value at this point instead of its getter,
+    // so it needs to be redefined to keep it reflecting the funnel's state.
+    get isIdle() {
+      return batchFunnel.isIdle;
+    },
+
     call: async (...params: Params) =>
       new Promise<Result>((...promiseCallbacks) => {
         batchFunnel.call({ promiseCallbacks, params });

--- a/packages/remeda/src/funnel.reference-batch.test.ts
+++ b/packages/remeda/src/funnel.reference-batch.test.ts
@@ -5,7 +5,11 @@
 import { describe, expect, test, vi } from "vitest";
 import { doNothing } from "./doNothing";
 import { fromKeys } from "./fromKeys";
-import { funnel } from "./funnel";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
 
 type BatchRequest<Params extends any[], Result> = {
   readonly params: Params;
@@ -25,9 +29,8 @@ type BatchRequest<Params extends any[], Result> = {
  * This allows synchronizing multiple async calls while keeping each call site
  * isolated from the rest (for example, as react components).
  *
- * This reference implementation can be copied into your project as-is, or you
- * can use it as the basis for a more complex implementation with additional
- * features.
+ * You can use this implementation as-is, or as the basis for a more complex
+ * implementation with additional features.
  *
  * @param callback - The main function that takes a batch and returns an
  * aggregated response. The typing for the it's parameters will derive the
@@ -43,6 +46,7 @@ type BatchRequest<Params extends any[], Result> = {
  * default value.
  * @returns A Funnel object with the `call` method augmented to support async
  * response.
+ * @see https://remedajs.com/docs#funnel
  */
 function batch<Params extends any[], BatchResponse, Result>(
   callback: (requests: readonly Params[]) => Promise<BatchResponse>,
@@ -100,6 +104,7 @@ function batch<Params extends any[], BatchResponse, Result>(
       }),
   };
 }
+// --- REFERENCE END ---------------------------------------------------------
 
 describe("showcase", () => {
   test("results as object", async () => {

--- a/packages/remeda/src/funnel.reference-batch.test.ts
+++ b/packages/remeda/src/funnel.reference-batch.test.ts
@@ -98,8 +98,6 @@ function batch<Params extends any[], BatchResponse, Result>(
   return {
     ...batchFunnel,
 
-    // The spread copies `isIdle`'s value at this point instead of its getter,
-    // so it needs to be redefined to keep it reflecting the funnel's state.
     get isIdle() {
       return batchFunnel.isIdle;
     },

--- a/packages/remeda/src/funnel.remeda-debounce.test.ts
+++ b/packages/remeda/src/funnel.remeda-debounce.test.ts
@@ -113,6 +113,10 @@ function debounce<F extends StrictFunction>(
 }
 // --- REFERENCE END ---------------------------------------------------------
 
+// The following tests are the original tests for the deprecated `debounce`
+// function. The names of the test cases have been preserved to ease comparing
+// them to the original tests.
+
 describe("main functionality", () => {
   test("should debounce a function", async () => {
     const mockFn = vi.fn<(x: string) => string>(identity());

--- a/packages/remeda/src/funnel.remeda-debounce.test.ts
+++ b/packages/remeda/src/funnel.remeda-debounce.test.ts
@@ -5,9 +5,15 @@
 import { describe, expect, test, vi } from "vitest";
 import { sleep } from "../test/sleep";
 import { constant } from "./constant";
-import { funnel } from "./funnel";
 import { identity } from "./identity";
-import type { StrictFunction } from "./internal/types/StrictFunction";
+
+// Copy everything between the REFERENCE START and REFERENCE END markers into
+// your project.
+// --- REFERENCE START -------------------------------------------------------
+import { funnel } from "remeda";
+
+// Using `never` as the type for args allows this to extend *any* function.
+type StrictFunction = (...args: never) => unknown;
 
 type Debouncer<F extends StrictFunction, IsNullable extends boolean = true> = {
   readonly call: (
@@ -25,15 +31,11 @@ type DebounceOptions = {
 };
 
 /**
- * A reference implementation of the now deprecated `debounce` function using
- * the `funnel` function instead. While you update your codebase you can copy
- * this function as-is and use it as a drop-in replacement; but we recommend
- * eventually inlining the call to `funnel` so you can adjust the function to
- * your specific needs.
+ * A drop-in replacement for Remeda's deprecated `debounce` function,
+ * implemented on top of `funnel`. We recommend eventually inlining the call
+ * to `funnel` and adjusting the implementation to your specific needs.
  *
- * The following tests in this file are the original tests for debounce.
- *
- * @see debounce
+ * @see https://remedajs.com/docs#funnel
  */
 function debounce<F extends StrictFunction>(
   func: F,
@@ -109,6 +111,7 @@ function debounce<F extends StrictFunction>(
     },
   };
 }
+// --- REFERENCE END ---------------------------------------------------------
 
 describe("main functionality", () => {
   test("should debounce a function", async () => {

--- a/packages/remeda/src/funnel.ts
+++ b/packages/remeda/src/funnel.ts
@@ -88,9 +88,19 @@ type Funnel<Args extends RestArguments = []> = {
  * execute anything when called. The returned object should be used to execute
  * the funnel via the its `call` method.
  *
- * - Debouncing: use `minQuietPeriodMs` and any `triggerAt`.
+ * The type of the funnel object is not exported; when you need to reference
+ * it explicitly (e.g., a class property holding a funnel) use
+ * `ReturnType<typeof funnel>`, adding the `reducer`'s rest params as type
+ * arguments when one is used (e.g., `ReturnType<typeof funnel<[string]>>`).
+ *
+ * - Debouncing: use `minQuietPeriodMs` and any `triggerAt`. Copy-paste
+ * reference implementations are available for Remeda's deprecated `debounce`
+ * function in [`funnel.remeda-debounce.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts),
+ * and for the Lodash `debounce` function in the [Lodash migration docs](https://remedajs.com/migrate/lodash#debounce).
  * - Throttling: use `minGapMs` and `triggerAt: "start"` or `"both"`.
- * - Batching: See the reference implementation in [`funnel.reference-batch.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.reference-batch.test.ts).
+ * Copy-paste reference implementations for the Lodash `throttle` function are
+ * available in the [Lodash migration docs](https://remedajs.com/migrate/lodash#throttle).
+ * - Batching: a copy-paste reference implementation is available in [`funnel.reference-batch.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.reference-batch.test.ts).
  *
  * @param callback - The main function that would be invoked periodically based
  * on `options`. The function would take the latest result of the `reducer`; if

--- a/packages/remeda/src/funnel.ts
+++ b/packages/remeda/src/funnel.ts
@@ -90,16 +90,18 @@ type Funnel<Args extends RestArguments = []> = {
  *
  * The type of the funnel object is not exported; when you need to reference
  * it explicitly (e.g., a class property holding a funnel) use
- * `ReturnType<typeof funnel>`, adding the `reducer`'s rest params as type
- * arguments when one is used (e.g., `ReturnType<typeof funnel<[string]>>`).
+ * `ReturnType<typeof funnel<[]>>`, replacing `[]` with the `reducer`'s rest
+ * params when one is used (e.g., `ReturnType<typeof funnel<[string]>>`).
  *
  * - Debouncing: use `minQuietPeriodMs` and any `triggerAt`. Copy-paste
  * reference implementations are available for Remeda's deprecated `debounce`
  * function in [`funnel.remeda-debounce.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.remeda-debounce.test.ts),
  * and for the Lodash `debounce` function in the [Lodash migration docs](https://remedajs.com/migrate/lodash#debounce).
  * - Throttling: use `minGapMs` and `triggerAt: "start"` or `"both"`.
- * Copy-paste reference implementations for the Lodash `throttle` function are
- * available in the [Lodash migration docs](https://remedajs.com/migrate/lodash#throttle).
+ * Copy-paste reference implementations for the Lodash `throttle` function
+ * (which maps onto the burst options `minQuietPeriodMs` and
+ * `maxBurstDurationMs` instead of `minGapMs`) are available in the
+ * [Lodash migration docs](https://remedajs.com/migrate/lodash#throttle).
  * - Batching: a copy-paste reference implementation is available in [`funnel.reference-batch.test.ts`](https://github.com/remeda/remeda/blob/main/packages/remeda/src/funnel.reference-batch.test.ts).
  *
  * @param callback - The main function that would be invoked periodically based

--- a/packages/remeda/tsconfig.json
+++ b/packages/remeda/tsconfig.json
@@ -20,6 +20,11 @@
     // MODULES
     "module": "Preserve",
     "moduleResolution": "Bundler",
+    // Allow us to import utilities directly from "remeda" so we can write copy-
+    // pasteable reference implementations in our test files (e.g., like the
+    // ones for mimicking lodash-like `debounce` and `throttle` functions).
+    // @see https://github.com/remeda/remeda/pull/1419
+    "paths": { "remeda": ["./src/index.ts"] },
 
     // EMIT
     "noEmit": true,

--- a/packages/remeda/vitest.config.ts
+++ b/packages/remeda/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -13,6 +14,16 @@ export default defineConfig({
     },
     projects: [
       {
+        resolve: {
+          alias: {
+            // Allow us to import utilities directly from "remeda" so we can
+            // write copy-pasteable reference implementations in our test files
+            // (e.g., like the ones for mimicking lodash-like `debounce` and
+            // `throttle` functions).
+            // @see https://github.com/remeda/remeda/pull/1419
+            remeda: fileURLToPath(new URL("src/index.ts", import.meta.url)),
+          },
+        },
         test: {
           name: "runtime",
           include: ["src/**/*.test.ts"],

--- a/packages/remeda/vitest.config.ts
+++ b/packages/remeda/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
     },
     projects: [
       {
+        test: {
+          name: "runtime",
+          include: ["src/**/*.test.ts"],
+          isolate: false,
+        },
         resolve: {
           alias: {
             // Allow us to import utilities directly from "remeda" so we can
@@ -23,11 +28,6 @@ export default defineConfig({
             // @see https://github.com/remeda/remeda/pull/1419
             remeda: fileURLToPath(new URL("src/index.ts", import.meta.url)),
           },
-        },
-        test: {
-          name: "runtime",
-          include: ["src/**/*.test.ts"],
-          isolate: false,
         },
       },
       {

--- a/packages/remeda/vitest.config.ts
+++ b/packages/remeda/vitest.config.ts
@@ -1,7 +1,8 @@
-import { fileURLToPath } from "node:url";
+import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     coverage: {
       include: ["src/**"],
@@ -14,23 +15,15 @@ export default defineConfig({
     },
     projects: [
       {
+        extends: true,
         test: {
           name: "runtime",
           include: ["src/**/*.test.ts"],
           isolate: false,
         },
-        resolve: {
-          alias: {
-            // Allow us to import utilities directly from "remeda" so we can
-            // write copy-pasteable reference implementations in our test files
-            // (e.g., like the ones for mimicking lodash-like `debounce` and
-            // `throttle` functions).
-            // @see https://github.com/remeda/remeda/pull/1419
-            remeda: fileURLToPath(new URL("src/index.ts", import.meta.url)),
-          },
-        },
       },
       {
+        extends: true,
         test: {
           name: "types",
           include: ["src/**/*.test-d.ts"],
@@ -42,6 +35,7 @@ export default defineConfig({
         },
       },
       {
+        extends: true,
         test: {
           name: "prop",
           include: ["src/**/*.test-prop.ts"],


### PR DESCRIPTION
Closes: #1398

Our reference implementation wasn't easy enough to import directly into existing projects because it relied on non-exported types. The instructions themselves were also not written clearly enough. 

I revamped the whole mapping docs to hopefuly make it as easy as possible for people who need debounce.