### PR TITLE
fix(zip,zipWith): handle data-last with empty param

### DIFF
--- a/packages/remeda/src/zip.test.ts
+++ b/packages/remeda/src/zip.test.ts
@@ -51,6 +51,14 @@ describe("dataLast", () => {
     ]);
   });
 
+  test("should return empty when second is empty", () => {
+    expect(pipe([1, 2], zip([]))).toStrictEqual([]);
+  });
+
+  test("should return empty when first is empty", () => {
+    expect(pipe([], zip(["a", "b"]))).toStrictEqual([]);
+  });
+
   test("evaluates lazily", () => {
     const mockFn = vi.fn<(x: number) => number>();
     pipe([1, 2, 3], map(mockFn), zip([4, 5, 6]), first());

--- a/packages/remeda/src/zip.ts
+++ b/packages/remeda/src/zip.ts
@@ -1,5 +1,6 @@
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
 
 type Zipped<Left extends IterableContainer, Right extends IterableContainer> =
@@ -75,12 +76,16 @@ const zipImplementation = <
     ? first.map((item, index) => [item, second[index]])
     : second.map((item, index) => [first[index], item])) as Zipped<F, S>;
 
-const lazyImplementation =
-  <F extends IterableContainer, S extends IterableContainer>(
-    second: S,
-  ): LazyEvaluator<F[number], [F[number], S[number]]> =>
-  (value, index) => ({
-    hasNext: true,
-    next: [value, second[index]],
-    done: index >= second.length - 1,
-  });
+const lazyImplementation = <
+  F extends IterableContainer,
+  S extends IterableContainer,
+>(
+  second: S,
+): LazyEvaluator<F[number], [F[number], S[number]]> =>
+  second.length === 0
+    ? lazyEmptyEvaluator
+    : (value, index) => ({
+        hasNext: true,
+        next: [value, second[index]],
+        done: index >= second.length - 1,
+      });

--- a/packages/remeda/src/zipWith.test.ts
+++ b/packages/remeda/src/zipWith.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { pipe } from "./pipe";
 import { zipWith } from "./zipWith";
 
@@ -77,5 +77,21 @@ describe("data second with initial arg", () => {
         zipWith(["a", "b", "c"], (a, b) => `${a}${b}`),
       ),
     ).toStrictEqual(["1a", "2b"]);
+  });
+
+  test("should return empty when second is empty", () => {
+    const mockFn = vi.fn<(a: string, b: string) => string>();
+
+    expect(pipe(["1", "2"], zipWith([], mockFn))).toStrictEqual([]);
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  test("should return empty when first is empty", () => {
+    expect(
+      pipe(
+        [],
+        zipWith(["a", "b"], (a, b) => `${a}${b}`),
+      ),
+    ).toStrictEqual([]);
   });
 });

--- a/packages/remeda/src/zipWith.ts
+++ b/packages/remeda/src/zipWith.ts
@@ -1,4 +1,5 @@
 import { lazyDataLastImpl } from "./internal/lazyDataLastImpl";
+import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 
@@ -107,13 +108,14 @@ function zipWithImplementation<
     : second.map((item, index) => fn(first[index], item, index, datum));
 }
 
-const lazyImplementation =
-  <T1, T2 extends IterableContainer, Value>(
-    second: T2,
-    fn: ZippingFunction<readonly T1[], T2, Value>,
-  ): LazyEvaluator<T1, Value> =>
-  (value, index, data) => ({
-    next: fn(value, second[index], index, [data, second]),
-    hasNext: true,
-    done: index >= second.length - 1,
-  });
+const lazyImplementation = <T1, T2 extends IterableContainer, Value>(
+  second: T2,
+  fn: ZippingFunction<readonly T1[], T2, Value>,
+): LazyEvaluator<T1, Value> =>
+  second.length === 0
+    ? lazyEmptyEvaluator
+    : (value, index, data) => ({
+        next: fn(value, second[index], index, [data, second]),
+        hasNext: true,
+        done: index >= second.length - 1,
+      });


### PR DESCRIPTION
There is currently a bug where when the second param is empty and the function is invoked data-last (like in a pipe) it would still generate a single pair with undefined values.