### PR TITLE
fix(pipe): allow early returns to short-circuit the pipe, remove shared objects between pipes

### DIFF
--- a/packages/remeda/src/internal/types/LazyDefinition.ts
+++ b/packages/remeda/src/internal/types/LazyDefinition.ts
@@ -1,16 +1,10 @@
-import type { LazyResult } from "./LazyResult";
+import type { LazyEvaluator } from "./LazyEvaluator";
 
 export type LazyDefinition = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This allows typescript the most flexibility in inferring function types, `unknown` doesn't always work!
-  readonly lazy: LazyMeta & ((...args: any) => LazyFn);
+  readonly lazy: LazyMeta & ((...args: any) => LazyEvaluator);
   readonly lazyArgs: readonly unknown[];
 };
-
-type LazyFn = (
-  value: unknown,
-  index: number,
-  items: readonly unknown[],
-) => LazyResult<unknown>;
 
 type LazyMeta = {
   readonly single?: boolean;

--- a/packages/remeda/src/internal/types/LazyResult.ts
+++ b/packages/remeda/src/internal/types/LazyResult.ts
@@ -1,4 +1,4 @@
-export type LazyResult<T> = LazyEmpty | LazyMany<T> | LazyNext<T>;
+export type LazyResult<T = unknown> = LazyEmpty | LazyMany<T> | LazyNext<T>;
 
 type LazyEmpty = {
   done: boolean;

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -4,7 +4,6 @@ import { flat } from "./flat";
 import { identity } from "./identity";
 import { purryFromLazy } from "./internal/purryFromLazy";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
@@ -172,29 +171,20 @@ describe("lazy", () => {
   test("early exit when done with many next values", () => {
     const mockMapper = vi.fn<(x: number) => number>(identity());
 
-    expect(
-      pipe([1, 2, 3, 4, 5], map(mockMapper), duplicateFirst()),
-    ).toStrictEqual([1, 1]);
+    expect(pipe([1, 2, 3, 4, 5], map(mockMapper), firstTwice())).toStrictEqual([
+      1, 1,
+    ]);
     expect(mockMapper).toHaveBeenCalledTimes(1);
-  });
-
-  test("doesn't mutate shared singleton evaluators", () => {
-    pipe([1, 2, 3], take(0));
-
-    // `take(0)` returns the module-level `lazyEmptyEvaluator` shared by every
-    // pipe in the process, so per-pipe state must not be stamped onto it.
-    expect(lazyEmptyEvaluator).not.toHaveProperty("items");
   });
 });
 
-// A dummy utility that returns the first value twice using a lazy evaluator
-// that returns `done`, `hasNext`, and `hasMany` all true. We don't have a real
-//  utility that does this and still want to check how `pipe` handles it.
-const duplicateFirst: () => (data: readonly number[]) => number[] = () =>
+// We want to test a a lazy evaluator that returns both `done === true` and
+// `hasMany === true` at the same time but don't have any utility that does it.
+const firstTwice: () => (data: readonly number[]) => number[] = () =>
   // @ts-expect-error [ts2322] -- Our purry functions don't infer the correct return type, we explicit casting to force it.
-  purryFromLazy(() => duplicateFirstEvaluator, []);
+  purryFromLazy(() => firstTwiceEvaluator, []);
 
-const duplicateFirstEvaluator: LazyEvaluator = (value) => ({
+const firstTwiceEvaluator: LazyEvaluator = (value) => ({
   done: true,
   hasNext: true,
   hasMany: true,

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { flat } from "./flat";
 import { identity } from "./identity";
+import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
+import { purry } from "./purry";
 import { take } from "./take";
 
 test("should pass through data with 0 functions", () => {
@@ -143,7 +146,27 @@ describe("lazy", () => {
       take(0),
     );
 
+    // An element must be pulled before `take(0)` can report `done`, so the
+    // callback runs exactly once even though the result is empty.
     expect(count).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([]);
+  });
+
+  test("early exit when done without a next value mid-pipe", () => {
+    const count = vi.fn<() => void>();
+    const downstream = vi.fn<(x: number) => number>();
+    const result = pipe(
+      [1, 2, 3],
+      map((x) => {
+        count();
+        return x * 10;
+      }),
+      take(0),
+      map(downstream),
+    );
+
+    expect(count).toHaveBeenCalledTimes(1);
+    expect(downstream).not.toHaveBeenCalled();
     expect(result).toStrictEqual([]);
   });
 
@@ -160,4 +183,45 @@ describe("lazy", () => {
 
     expect(result).toStrictEqual([1, 2]);
   });
+
+  test("early exit when done with many next values", () => {
+    // No built-in function emits `hasMany` results together with `done`; the
+    // combination is only reachable via custom `purry` lazy implementations,
+    // but it is part of the lazy protocol and must stop the input iteration.
+    const duplicateFirst = purry(
+      /* v8 ignore next 2 -- `pipe` only ever runs the lazy implementation. */
+      (data: readonly number[]) =>
+        data.slice(0, 1).flatMap((value) => [value, value]),
+      [],
+      () => duplicateFirstEvaluator,
+    ) as (data: readonly number[]) => number[];
+
+    const count = vi.fn<() => void>();
+    const result = pipe(
+      [1, 2, 3],
+      map((x) => {
+        count();
+        return x * 10;
+      }),
+      duplicateFirst,
+    );
+
+    expect(count).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([10, 10]);
+  });
+
+  test("doesn't mutate shared singleton evaluators", () => {
+    pipe([1, 2, 3], take(0));
+
+    // `take(0)` returns the module-level `lazyEmptyEvaluator` shared by every
+    // pipe in the process, so per-pipe state must not be stamped onto it.
+    expect(lazyEmptyEvaluator).not.toHaveProperty("items");
+  });
+});
+
+const duplicateFirstEvaluator: LazyEvaluator = (value) => ({
+  done: true,
+  hasNext: true,
+  hasMany: true,
+  next: [value, value],
 });

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -178,7 +178,7 @@ describe("lazy", () => {
   });
 });
 
-// We want to test a a lazy evaluator that returns both `done === true` and
+// We want to test a lazy evaluator that returns both `done === true` and
 // `hasMany === true` at the same time but don't have any utility that does it.
 const firstTwice: () => (data: readonly number[]) => number[] = () =>
   // @ts-expect-error [ts2322] -- Our purry functions don't infer the correct return type, we explicit casting to force it.

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -132,6 +132,21 @@ describe("lazy", () => {
     expect(result).toStrictEqual([100, 200]);
   });
 
+  test("early exit when done without a next value", () => {
+    const count = vi.fn<() => void>();
+    const result = pipe(
+      [1, 2, 3, 4, 5],
+      map((x) => {
+        count();
+        return x * 10;
+      }),
+      take(0),
+    );
+
+    expect(count).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([]);
+  });
+
   test("lazy early exit with hasMany", () => {
     const result = pipe(
       [

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import { filter } from "./filter";
 import { flat } from "./flat";
 import { identity } from "./identity";
+import { purryFromLazy } from "./internal/purryFromLazy";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import { map } from "./map";
 import { pipe } from "./pipe";
 import { prop } from "./prop";
-import { purry } from "./purry";
 import { take } from "./take";
 
 test("should pass through data with 0 functions", () => {
@@ -136,38 +136,23 @@ describe("lazy", () => {
   });
 
   test("early exit when done without a next value", () => {
-    const count = vi.fn<() => void>();
-    const result = pipe(
-      [1, 2, 3, 4, 5],
-      map((x) => {
-        count();
-        return x * 10;
-      }),
-      take(0),
-    );
+    const mockMapper = vi.fn<(x: number) => number>();
 
+    expect(pipe([1, 2, 3, 4, 5], map(mockMapper), take(0))).toStrictEqual([]);
     // An element must be pulled before `take(0)` can report `done`, so the
     // callback runs exactly once even though the result is empty.
-    expect(count).toHaveBeenCalledTimes(1);
-    expect(result).toStrictEqual([]);
+    expect(mockMapper).toHaveBeenCalledTimes(1);
   });
 
   test("early exit when done without a next value mid-pipe", () => {
-    const count = vi.fn<() => void>();
+    const mockMapper = vi.fn<(x: number) => number>();
     const downstream = vi.fn<(x: number) => number>();
-    const result = pipe(
-      [1, 2, 3],
-      map((x) => {
-        count();
-        return x * 10;
-      }),
-      take(0),
-      map(downstream),
-    );
 
-    expect(count).toHaveBeenCalledTimes(1);
+    expect(
+      pipe([1, 2, 3, 4, 5], map(mockMapper), take(0), map(downstream)),
+    ).toStrictEqual([]);
+    expect(mockMapper).toHaveBeenCalledTimes(1);
     expect(downstream).not.toHaveBeenCalled();
-    expect(result).toStrictEqual([]);
   });
 
   test("lazy early exit with hasMany", () => {
@@ -185,29 +170,12 @@ describe("lazy", () => {
   });
 
   test("early exit when done with many next values", () => {
-    // No built-in function emits `hasMany` results together with `done`; the
-    // combination is only reachable via custom `purry` lazy implementations,
-    // but it is part of the lazy protocol and must stop the input iteration.
-    const duplicateFirst = purry(
-      /* v8 ignore next 2 -- `pipe` only ever runs the lazy implementation. */
-      (data: readonly number[]) =>
-        data.slice(0, 1).flatMap((value) => [value, value]),
-      [],
-      () => duplicateFirstEvaluator,
-    ) as (data: readonly number[]) => number[];
+    const mockMapper = vi.fn<(x: number) => number>(identity());
 
-    const count = vi.fn<() => void>();
-    const result = pipe(
-      [1, 2, 3],
-      map((x) => {
-        count();
-        return x * 10;
-      }),
-      duplicateFirst,
-    );
-
-    expect(count).toHaveBeenCalledTimes(1);
-    expect(result).toStrictEqual([10, 10]);
+    expect(
+      pipe([1, 2, 3, 4, 5], map(mockMapper), duplicateFirst()),
+    ).toStrictEqual([1, 1]);
+    expect(mockMapper).toHaveBeenCalledTimes(1);
   });
 
   test("doesn't mutate shared singleton evaluators", () => {
@@ -218,6 +186,13 @@ describe("lazy", () => {
     expect(lazyEmptyEvaluator).not.toHaveProperty("items");
   });
 });
+
+// A dummy utility that returns the first value twice using a lazy evaluator
+// that returns `done`, `hasNext`, and `hasMany` all true. We don't have a real
+//  utility that does this and still want to check how `pipe` handles it.
+const duplicateFirst: () => (data: readonly number[]) => number[] = () =>
+  // @ts-expect-error [ts2322] -- Our purry functions don't infer the correct return type, we explicit casting to force it.
+  purryFromLazy(() => duplicateFirstEvaluator, []);
 
 const duplicateFirstEvaluator: LazyEvaluator = (value) => ({
   done: true,

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -7,8 +7,8 @@ import type { LazyResult } from "./internal/types/LazyResult";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 
 type PreparedLazyFunction = {
-  readonly fn: LazyEvaluator;
-  readonly isSingle: boolean | undefined;
+  readonly lazyEvaluator: LazyEvaluator;
+  readonly isSingle: boolean;
 
   // These are intentionally mutable, they maintain the lazy piped state.
   index: number;
@@ -305,7 +305,7 @@ export function pipe(
     const lazySequence = extractLazySequence(lazyFunctions, functionIndex);
     const accumulator = processIterable(output, lazySequence);
 
-    const { isSingle = false } = lazySequence.at(-1)!;
+    const { isSingle } = lazySequence.at(-1)!;
     output = isSingle ? accumulator[0] : accumulator;
     functionIndex += lazySequence.length;
   }
@@ -326,7 +326,7 @@ function extractLazySequence(
     }
 
     lazySequence.push(lazyFunction);
-    if (lazyFunction.isSingle ?? false) {
+    if (lazyFunction.isSingle) {
       break;
     }
   }
@@ -370,7 +370,7 @@ function processItem(
   for (const [functionsIndex, lazyFn] of lazySequence.entries()) {
     const { index, items } = lazyFn;
     items.push(currentItem);
-    lazyResult = lazyFn.fn(currentItem, index, items);
+    lazyResult = lazyFn.lazyEvaluator(currentItem, index, items);
     lazyFn.index += 1;
 
     // Process remaining functions in the pipe but don't process remaining
@@ -409,8 +409,8 @@ const prepareLazyFunction = ({
   lazy,
   lazyArgs,
 }: LazyFunction): PreparedLazyFunction => ({
-  fn: lazy(...lazyArgs),
-  isSingle: lazy.single,
+  lazyEvaluator: lazy(...lazyArgs),
+  isSingle: lazy.single ?? false,
   index: 0,
   items: [],
 });

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -1,5 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable jsdoc/check-param-names -- we don't document the op params, it'd be redundant */
+/* eslint-disable jsdoc/check-param-names --
+ * We document pipe's function params as a single parameter entry in the docs.
+ */
 
 import type { LazyDefinition } from "./internal/types/LazyDefinition";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
@@ -9,10 +10,9 @@ import { SKIP_ITEM } from "./internal/utilityEvaluators";
 type LazyStep = {
   readonly lazyEvaluator: LazyEvaluator;
   readonly isSingle: boolean;
-
-  // These are intentionally mutable, they maintain the lazy piped state.
-  index: number;
-  items: unknown[];
+  // Notice the array is mutable, we will be adding items as the pipe is
+  // evaluating them.
+  readonly items: unknown[];
 };
 
 type LazyFunction = LazyDefinition & ((input: unknown) => unknown);
@@ -284,8 +284,8 @@ export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
 
 export function pipe(
   input: unknown,
-  ...functions: readonly (LazyFunction | ((value: any) => unknown))[]
-): any {
+  ...functions: readonly (LazyFunction | ((value: unknown) => unknown))[]
+): unknown {
   let output = input;
 
   const lazySteps = functions.map((op) =>
@@ -320,7 +320,7 @@ export function pipe(
 }
 
 function extractLazySequence(
-  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The lazy functions are stateful and contain the state needed to compute the next value lazily.
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The items array is mutable for efficiency.
   lazySteps: readonly (LazyStep | undefined)[],
   startIndex: number,
 ): readonly LazyStep[] {
@@ -343,7 +343,7 @@ function extractLazySequence(
 
 function processIterable(
   iterable: Iterable<unknown>,
-  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The lazy sequence is stateful and contains the state needed to compute the next value lazily.
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The items array is mutable for efficiency.
   lazySequence: readonly LazyStep[],
 ): unknown[] {
   const accumulator: unknown[] = [];
@@ -362,7 +362,7 @@ function processItem(
   item: unknown,
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- Intentionally mutable, we use the accumulator directly to accumulate the results.
   accumulator: unknown[],
-  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- Intentionally mutable, the lazy sequence is stateful and contains the state needed to compute the next value lazily.
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The items array is mutable for efficiency.
   lazySequence: readonly LazyStep[],
 ): boolean {
   if (lazySequence.length === 0) {
@@ -372,17 +372,15 @@ function processItem(
 
   let currentItem = item;
 
-  let lazyResult: LazyResult<any> = SKIP_ITEM;
+  let lazyResult: LazyResult<unknown> = SKIP_ITEM;
   let isDone = false;
-  for (const [functionsIndex, lazyFn] of lazySequence.entries()) {
-    const { index, items } = lazyFn;
+  for (const [
+    functionsIndex,
+    { items, lazyEvaluator },
+  ] of lazySequence.entries()) {
     items.push(currentItem);
-    lazyResult = lazyFn.lazyEvaluator(currentItem, index, items);
-    lazyFn.index += 1;
+    lazyResult = lazyEvaluator(currentItem, items.length - 1, items);
 
-    // Process remaining functions in the pipe but don't process remaining
-    // elements in the input array. This must be checked before `hasNext`
-    // because results without a value also stop the iteration.
     if (lazyResult.done) {
       isDone = true;
     }

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -301,8 +301,8 @@ export function pipe(
 
   let functionIndex = 0;
   while (functionIndex < functions.length) {
-    const lazyFunction = lazySteps[functionIndex];
-    if (lazyFunction === undefined || !isIterable(output)) {
+    const lazyStep = lazySteps[functionIndex];
+    if (lazyStep === undefined || !isIterable(output)) {
       const func = functions[functionIndex]!;
       output = func(output);
       functionIndex += 1;

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -372,7 +372,7 @@ function processItem(
 
   let currentItem = item;
 
-  let lazyResult: LazyResult<unknown> = SKIP_ITEM;
+  let lazyResult: LazyResult = SKIP_ITEM;
   let isDone = false;
   for (const [
     functionsIndex,

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -6,8 +6,9 @@ import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { LazyResult } from "./internal/types/LazyResult";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 
-type PreparedLazyFunction = LazyEvaluator & {
-  readonly isSingle: boolean;
+type PreparedLazyFunction = {
+  readonly fn: LazyEvaluator;
+  readonly isSingle: boolean | undefined;
 
   // These are intentionally mutable, they maintain the lazy piped state.
   index: number;
@@ -304,7 +305,7 @@ export function pipe(
     const lazySequence = extractLazySequence(lazyFunctions, functionIndex);
     const accumulator = processIterable(output, lazySequence);
 
-    const { isSingle } = lazySequence.at(-1)!;
+    const { isSingle = false } = lazySequence.at(-1)!;
     output = isSingle ? accumulator[0] : accumulator;
     functionIndex += lazySequence.length;
   }
@@ -325,7 +326,7 @@ function extractLazySequence(
     }
 
     lazySequence.push(lazyFunction);
-    if (lazyFunction.isSingle) {
+    if (lazyFunction.isSingle ?? false) {
       break;
     }
   }
@@ -369,8 +370,16 @@ function processItem(
   for (const [functionsIndex, lazyFn] of lazySequence.entries()) {
     const { index, items } = lazyFn;
     items.push(currentItem);
-    lazyResult = lazyFn(currentItem, index, items);
+    lazyResult = lazyFn.fn(currentItem, index, items);
     lazyFn.index += 1;
+
+    // Process remaining functions in the pipe but don't process remaining
+    // elements in the input array. This must be checked before `hasNext`
+    // because results without a value also stop the iteration.
+    if (lazyResult.done) {
+      isDone = true;
+    }
+
     if (lazyResult.hasNext) {
       if (lazyResult.hasMany ?? false) {
         for (const subItem of lazyResult.next as readonly unknown[]) {
@@ -389,11 +398,6 @@ function processItem(
     } else {
       break;
     }
-    // process remaining functions in the pipe
-    // but don't process remaining elements in the input array
-    if (lazyResult.done) {
-      isDone = true;
-    }
   }
   if (lazyResult.hasNext) {
     accumulator.push(currentItem);
@@ -401,15 +405,15 @@ function processItem(
   return isDone;
 }
 
-function prepareLazyFunction(func: LazyFunction): PreparedLazyFunction {
-  const { lazy, lazyArgs } = func;
-  const fn = lazy(...lazyArgs);
-  return Object.assign(fn, {
-    isSingle: lazy.single ?? false,
-    index: 0,
-    items: [] as unknown[],
-  });
-}
+const prepareLazyFunction = ({
+  lazy,
+  lazyArgs,
+}: LazyFunction): PreparedLazyFunction => ({
+  fn: lazy(...lazyArgs),
+  isSingle: lazy.single,
+  index: 0,
+  items: [],
+});
 
 function isIterable(something: unknown): something is Iterable<unknown> {
   // Check for null and undefined to avoid errors when accessing Symbol.iterator

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -404,9 +404,11 @@ function processItem(
       break;
     }
   }
+
   if (lazyResult.hasNext) {
     accumulator.push(currentItem);
   }
+
   return isDone;
 }
 

--- a/packages/remeda/src/pipe.ts
+++ b/packages/remeda/src/pipe.ts
@@ -6,7 +6,7 @@ import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { LazyResult } from "./internal/types/LazyResult";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 
-type PreparedLazyFunction = {
+type LazyStep = {
   readonly lazyEvaluator: LazyEvaluator;
   readonly isSingle: boolean;
 
@@ -288,13 +288,20 @@ export function pipe(
 ): any {
   let output = input;
 
-  const lazyFunctions = functions.map((op) =>
-    "lazy" in op ? prepareLazyFunction(op) : undefined,
+  const lazySteps = functions.map((op) =>
+    "lazy" in op
+      ? {
+          lazyEvaluator: op.lazy(...op.lazyArgs),
+          isSingle: op.lazy.single ?? false,
+          index: 0,
+          items: [],
+        }
+      : undefined,
   );
 
   let functionIndex = 0;
   while (functionIndex < functions.length) {
-    const lazyFunction = lazyFunctions[functionIndex];
+    const lazyFunction = lazySteps[functionIndex];
     if (lazyFunction === undefined || !isIterable(output)) {
       const func = functions[functionIndex]!;
       output = func(output);
@@ -302,7 +309,7 @@ export function pipe(
       continue;
     }
 
-    const lazySequence = extractLazySequence(lazyFunctions, functionIndex);
+    const lazySequence = extractLazySequence(lazySteps, functionIndex);
     const accumulator = processIterable(output, lazySequence);
 
     const { isSingle } = lazySequence.at(-1)!;
@@ -314,19 +321,19 @@ export function pipe(
 
 function extractLazySequence(
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The lazy functions are stateful and contain the state needed to compute the next value lazily.
-  lazyFunctions: readonly (PreparedLazyFunction | undefined)[],
+  lazySteps: readonly (LazyStep | undefined)[],
   startIndex: number,
-): readonly PreparedLazyFunction[] {
-  const lazySequence: PreparedLazyFunction[] = [];
+): readonly LazyStep[] {
+  const lazySequence: LazyStep[] = [];
 
-  for (let index = startIndex; index < lazyFunctions.length; index++) {
-    const lazyFunction = lazyFunctions[index];
-    if (lazyFunction === undefined) {
+  for (let index = startIndex; index < lazySteps.length; index++) {
+    const lazyStep = lazySteps[index];
+    if (lazyStep === undefined) {
       break;
     }
 
-    lazySequence.push(lazyFunction);
-    if (lazyFunction.isSingle) {
+    lazySequence.push(lazyStep);
+    if (lazyStep.isSingle) {
       break;
     }
   }
@@ -337,7 +344,7 @@ function extractLazySequence(
 function processIterable(
   iterable: Iterable<unknown>,
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- The lazy sequence is stateful and contains the state needed to compute the next value lazily.
-  lazySequence: readonly PreparedLazyFunction[],
+  lazySequence: readonly LazyStep[],
 ): unknown[] {
   const accumulator: unknown[] = [];
 
@@ -356,7 +363,7 @@ function processItem(
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- Intentionally mutable, we use the accumulator directly to accumulate the results.
   accumulator: unknown[],
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- Intentionally mutable, the lazy sequence is stateful and contains the state needed to compute the next value lazily.
-  lazySequence: readonly PreparedLazyFunction[],
+  lazySequence: readonly LazyStep[],
 ): boolean {
   if (lazySequence.length === 0) {
     accumulator.push(item);
@@ -404,16 +411,6 @@ function processItem(
   }
   return isDone;
 }
-
-const prepareLazyFunction = ({
-  lazy,
-  lazyArgs,
-}: LazyFunction): PreparedLazyFunction => ({
-  lazyEvaluator: lazy(...lazyArgs),
-  isSingle: lazy.single ?? false,
-  index: 0,
-  items: [],
-});
 
 function isIterable(something: unknown): something is Iterable<unknown> {
   // Check for null and undefined to avoid errors when accessing Symbol.iterator


### PR DESCRIPTION
Two issues we had with pipe:
* When a lazy function returns "isDone" early we still ran the full pipe, albeit ignoring the items, before terminating. Now we allow the pipe itself to stop processing asap
* We added state on top of the lazy implementation to track the pipe, but that would mean that the state is shared between different pipes and different instances of the same piped functions, instead, now we have a self-contained object per pipe *run*.