### PR TITLE
fix(filter, groupByProp): support type predicates that aren't subtypes of the item type

### DIFF
--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -257,6 +257,12 @@ describe("data last", () => {
 
     expectTypeOf(result).toEqualTypeOf<[1, 2, 3]>();
   });
+
+  test("predicate wider than the item", () => {
+    expectTypeOf(
+      pipe([] as (string | null)[], filter(isNullish)),
+    ).toEqualTypeOf<null[]>();
+  });
 });
 
 describe("union of array types", () => {

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -309,13 +309,71 @@ describe("condition isn't a subtype of the item", () => {
     expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
   });
 
-  test("supertype", () => {
-    expectTypeOf(filter([] as Dog[], isAnimal)).toEqualTypeOf<Dog[]>();
-  });
+  describe("supertype", () => {
+    test("empty tuple", () => {
+      expectTypeOf(filter($typed<[]>(), isAnimal)).toEqualTypeOf<[]>();
+    });
 
-  test("supertype, fixed tuple", () => {
-    expectTypeOf(filter($typed<[Dog, Dog]>(), isAnimal)).toEqualTypeOf<
-      [Dog, Dog]
-    >();
+    test("fixed tuple", () => {
+      expectTypeOf(filter($typed<[Dog, Dog]>(), isAnimal)).toEqualTypeOf<
+        [Dog, Dog]
+      >();
+    });
+
+    test("readonly fixed tuple", () => {
+      expectTypeOf(
+        filter($typed<readonly [Dog, Dog]>(), isAnimal),
+      ).toEqualTypeOf<[Dog, Dog]>();
+    });
+
+    test("optional tuple", () => {
+      expectTypeOf(filter($typed<[Dog?]>(), isAnimal)).toEqualTypeOf<[Dog?]>();
+    });
+
+    test("mixed tuple", () => {
+      expectTypeOf(filter($typed<[Dog, Dog?]>(), isAnimal)).toEqualTypeOf<
+        [Dog, Dog?]
+      >();
+    });
+
+    test("array", () => {
+      expectTypeOf(filter([] as Dog[], isAnimal)).toEqualTypeOf<Dog[]>();
+    });
+
+    test("fixed-prefix array", () => {
+      expectTypeOf(filter($typed<[Dog, ...Dog[]]>(), isAnimal)).toEqualTypeOf<
+        [Dog, ...Dog[]]
+      >();
+    });
+
+    test("optional-prefix array", () => {
+      expectTypeOf(filter($typed<[Dog?, ...Dog[]]>(), isAnimal)).toEqualTypeOf<
+        [Dog?, ...Dog[]]
+      >();
+    });
+
+    test("mixed-prefix array", () => {
+      expectTypeOf(
+        filter($typed<[Dog, Dog?, ...Dog[]]>(), isAnimal),
+      ).toEqualTypeOf<[Dog, Dog?, ...Dog[]]>();
+    });
+
+    test("fixed-suffix array", () => {
+      expectTypeOf(filter($typed<[...Dog[], Dog]>(), isAnimal)).toEqualTypeOf<
+        [...Dog[], Dog]
+      >();
+    });
+
+    test("fixed-elements array", () => {
+      expectTypeOf(
+        filter($typed<[Dog, ...Dog[], Dog]>(), isAnimal),
+      ).toEqualTypeOf<[Dog, ...Dog[], Dog]>();
+    });
+
+    test("union of arrays", () => {
+      expectTypeOf(filter($typed<Dog[] | string[]>(), isAnimal)).toEqualTypeOf<
+        [] | Dog[]
+      >();
+    });
   });
 });

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -284,18 +284,10 @@ describe("union of array types", () => {
   });
 });
 
-describe("predicate wider than the item", () => {
-  test("data-first", () => {
-    expectTypeOf(filter([] as (string | null)[], isNullish)).toEqualTypeOf<
-      null[]
-    >();
-  });
-
-  test("data-last", () => {
-    expectTypeOf(
-      pipe([] as (string | null)[], filter(isNullish)),
-    ).toEqualTypeOf<null[]>();
-  });
+test("predicate wider than the item", () => {
+  expectTypeOf(filter([] as (string | null)[], isNullish)).toEqualTypeOf<
+    null[]
+  >();
 });
 
 test("predicate disjoint from the item", () => {

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -5,6 +5,7 @@ import { filter } from "./filter";
 import { isDefined } from "./isDefined";
 import { isNonNull } from "./isNonNull";
 import { isNonNullish } from "./isNonNullish";
+import { isNullish } from "./isNullish";
 import { isStrictEqual } from "./isStrictEqual";
 import { pipe } from "./pipe";
 
@@ -300,6 +301,3 @@ describe("predicate wider than the item", () => {
 test("predicate disjoint from the item", () => {
   expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
 });
-
-const isNullish = (value: unknown): value is null | undefined =>
-  value === null || value === undefined;

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -11,6 +11,16 @@ import { isStrictEqual } from "./isStrictEqual";
 import { isString } from "./isString";
 import { pipe } from "./pipe";
 
+interface Animal {
+  readonly name: string;
+}
+
+interface Dog extends Animal {
+  readonly bark: () => void;
+}
+
+declare function isAnimal(x: unknown): x is Animal;
+
 describe("primitives arrays", () => {
   test("predicate", () => {
     expectTypeOf(filter([] as string[], constant(true))).toEqualTypeOf<
@@ -297,5 +307,15 @@ describe("condition isn't a subtype of the item", () => {
 
   test("disjoint", () => {
     expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
+  });
+
+  test("supertype", () => {
+    expectTypeOf(filter([] as Dog[], isAnimal)).toEqualTypeOf<Dog[]>();
+  });
+
+  test("supertype, fixed tuple", () => {
+    expectTypeOf(filter($typed<[Dog, Dog]>(), isAnimal)).toEqualTypeOf<
+      [Dog, Dog]
+    >();
   });
 });

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -6,12 +6,10 @@ import { isDefined } from "./isDefined";
 import { isNonNull } from "./isNonNull";
 import { isNonNullish } from "./isNonNullish";
 import { isNullish } from "./isNullish";
+import { isNumber } from "./isNumber";
 import { isStrictEqual } from "./isStrictEqual";
+import { isString } from "./isString";
 import { pipe } from "./pipe";
-
-// TODO [>2]: Our type-narrowing utilities aren't narrowing our types correctly in these tests due to them inferring the types "too soon" (because they are invoked "headless"ly). This is also a problem with TypeScript before version 5.5 because we can't use a simple arrow function too without being explicit about it's return type, which makes the whole code messy. In Remeda v3 we plan to bump the minimum TypeScript version so this wouldn't be an issue any way, but we also plan to deprecate headless type predicates.
-declare function isNumber<T>(x: T): x is Extract<T, number>;
-declare function isString<T>(x: T): x is Extract<T, string>;
 
 describe("primitives arrays", () => {
   test("predicate", () => {

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -258,7 +258,7 @@ describe("data last", () => {
     expectTypeOf(result).toEqualTypeOf<[1, 2, 3]>();
   });
 
-  test("predicate wider than the item", () => {
+  test("partially overlapping", () => {
     expectTypeOf(
       pipe([] as (string | null)[], filter(isNullish)),
     ).toEqualTypeOf<null[]>();
@@ -288,12 +288,14 @@ describe("union of array types", () => {
   });
 });
 
-test("predicate wider than the item", () => {
-  expectTypeOf(filter([] as (string | null)[], isNullish)).toEqualTypeOf<
-    null[]
-  >();
-});
+describe("condition isn't a subtype of the item", () => {
+  test("partially overlapping", () => {
+    expectTypeOf(filter([] as (string | null)[], isNullish)).toEqualTypeOf<
+      null[]
+    >();
+  });
 
-test("predicate disjoint from the item", () => {
-  expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
+  test("disjoint", () => {
+    expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
+  });
 });

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -172,8 +172,7 @@ describe("special tuple shapes", () => {
 
 test("discriminated union filtering", () => {
   const data = [] as (
-    | { type: "cat"; hates: string }
-    | { type: "dog"; numFriends: number }
+    { type: "cat"; hates: string } | { type: "dog"; numFriends: number }
   )[];
 
   expectTypeOf(
@@ -283,3 +282,24 @@ describe("union of array types", () => {
     ).toEqualTypeOf<[0] | [1, 2, 3, 4]>();
   });
 });
+
+describe("predicate wider than the item", () => {
+  test("data-first", () => {
+    expectTypeOf(filter([] as (string | null)[], isNullish)).toEqualTypeOf<
+      null[]
+    >();
+  });
+
+  test("data-last", () => {
+    expectTypeOf(
+      pipe([] as (string | null)[], filter(isNullish)),
+    ).toEqualTypeOf<null[]>();
+  });
+});
+
+test("predicate disjoint from the item", () => {
+  expectTypeOf(filter([] as string[], isNullish)).toEqualTypeOf<[]>();
+});
+
+const isNullish = (value: unknown): value is null | undefined =>
+  value === null || value === undefined;

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -48,10 +48,7 @@ type NonRefinedFilteredArray<
  * @lazy
  * @category Array
  */
-export function filter<
-  T extends IterableContainer,
-  Condition extends T[number],
->(
+export function filter<T extends IterableContainer, Condition>(
   data: T,
   predicate: (value: T[number], index: number, data: T) => value is Condition,
 ): FilteredArray<T, Condition>;
@@ -84,10 +81,7 @@ export function filter<
  * @lazy
  * @category Array
  */
-export function filter<
-  T extends IterableContainer,
-  Condition extends T[number],
->(
+export function filter<T extends IterableContainer, Condition>(
   predicate: (value: T[number], index: number, data: T) => value is Condition,
 ): (data: T) => FilteredArray<T, Condition>;
 export function filter<

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -70,7 +70,7 @@ export function filter<
  *
  * @param predicate - A function to execute for each element in the array. It
  * should return `true` to keep the element in the resulting array, and `false`
- * otherwise.
+ * otherwise. A type-predicate can also be used to narrow the result.
  * @returns A shallow copy of the given array containing just the elements that
  * pass the test. If no elements pass the test, an empty array is returned.
  * @signature

--- a/packages/remeda/src/groupByProp.test-d.ts
+++ b/packages/remeda/src/groupByProp.test-d.ts
@@ -161,6 +161,23 @@ test("all values are undefined", () => {
   ).toEqualTypeOf<EmptyObject>();
 });
 
+test("tuple, grouping on a prop with literal union values", () => {
+  expectTypeOf(
+    groupByProp(
+      [
+        { a: "cat", b: 1 },
+        { a: "cat", c: 2 },
+      ] as [{ a: "cat" | "dog"; b: 1 }, { a: "cat"; c: 2 }],
+      "a",
+    ),
+  ).toEqualTypeOf<{
+    cat:
+      | [{ a: "cat"; c: 2 }]
+      | [{ a: "cat" | "dog"; b: 1 } & Record<"a", "cat">, { a: "cat"; c: 2 }];
+    dog?: [{ a: "cat" | "dog"; b: 1 } & Record<"a", "dog">];
+  }>();
+});
+
 // @see https://github.com/remeda/remeda/issues/1231
 test("grouping on a prop with literal union values (issue #1231)", () => {
   expectTypeOf(

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -948,3 +948,20 @@ describe("item and condition aren't type literals", () => {
     ).toEqualTypeOf<(ItemClass & ConditionClass)[]>();
   });
 });
+
+describe("arrays and non-array objects never share a refinement", () => {
+  test("array item, object condition", () => {
+    expectTypeOf(
+      filteredArray($typed<[string[]]>(), $typed<{ length: 3 }>()),
+    ).toEqualTypeOf<[]>();
+  });
+
+  test("object item, array condition", () => {
+    expectTypeOf(
+      filteredArray(
+        $typed<[{ length: number; foo: string }]>(),
+        $typed<["a"]>(),
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+});

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -346,10 +346,21 @@ describe("condition is a complex object", () => {
         $typed<{ a: "hello"; b: "world" }>(),
       ),
     ).toEqualTypeOf<
-      [
-        { readonly a: "hello"; readonly b: "world" },
-        { readonly a: "hello"; readonly b: "world"; readonly c: 1234 },
-      ]
+      | [
+          { readonly a: "hello"; readonly b: "world" },
+          { readonly a: "hello"; readonly b: "world"; readonly c: 1234 },
+        ]
+      | [
+          { a: "hello"; b: "world" },
+          { readonly a: "hello"; readonly b: "world" },
+          { readonly a: "hello"; readonly b: "world"; readonly c: 1234 },
+        ]
+      | [
+          { a: "hello"; b: "world" },
+          { a: "hello"; b: "world" },
+          { readonly a: "hello"; readonly b: "world" },
+          { readonly a: "hello"; readonly b: "world"; readonly c: 1234 },
+        ]
     >();
   });
 
@@ -486,7 +497,7 @@ describe("condition is an array of literals", () => {
         [[], []] as [readonly "hello"[], readonly "world"[]],
         [] as "hello"[],
       ),
-    ).toEqualTypeOf<[]>();
+    ).toEqualTypeOf<[] | ["hello"[]]>();
 
     expectTypeOf(
       filteredArray(
@@ -556,7 +567,7 @@ describe("condition is a tuple", () => {
         ] as [readonly [string, number], readonly [number, string]],
         ["", 0] as [string, number],
       ),
-    ).toEqualTypeOf<[]>();
+    ).toEqualTypeOf<[] | [[string, number]]>();
 
     expectTypeOf(
       filteredArray(
@@ -842,4 +853,20 @@ test("prop with literal union value filtered by disjoint value", () => {
       a: "bird" as const,
     }),
   ).toEqualTypeOf<[]>();
+});
+
+describe("condition is never", () => {
+  test("array", () => {
+    expectTypeOf(filteredArray([] as string[], $typed())).toEqualTypeOf<[]>();
+  });
+
+  test("fixed tuple", () => {
+    expectTypeOf(filteredArray([""] as [string], $typed())).toEqualTypeOf<[]>();
+  });
+
+  test("tuple with a rest element", () => {
+    expectTypeOf(
+      filteredArray([""] as [string, ...number[]], $typed()),
+    ).toEqualTypeOf<[]>();
+  });
 });

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -776,6 +776,37 @@ describe("complex nested union conditions", () => {
       ),
     ).toEqualTypeOf<[[string, number], [boolean, string]]>();
   });
+
+  describe("union of object and a primitive", () => {
+    test("array", () => {
+      expectTypeOf(
+        filteredArray(
+          [] as { a: "cat" | "dog"; b: number }[],
+          $typed<string | { a: "cat" }>(),
+        ),
+      ).toEqualTypeOf<({ a: "cat" | "dog"; b: number } & { a: "cat" })[]>();
+    });
+
+    test("fixed tuple", () => {
+      expectTypeOf(
+        filteredArray(
+          [{ a: "cat", b: 1 }] as [{ a: "cat" | "dog"; b: number }],
+          $typed<string | { a: "cat" }>(),
+        ),
+      ).toEqualTypeOf<[] | [{ a: "cat" | "dog"; b: number } & { a: "cat" }]>();
+    });
+
+    test("tuple with an optional element", () => {
+      expectTypeOf(
+        filteredArray(
+          [] as [{ a: "cat" | "dog"; b: number }?],
+          $typed<string | { a: "cat" }>(),
+        ),
+      ).toEqualTypeOf<
+        [] | [({ a: "cat" | "dog"; b: number } & { a: "cat" })?]
+      >();
+    });
+  });
 });
 
 describe("tuples with optional elements", () => {
@@ -821,13 +852,7 @@ describe("tuples with optional elements", () => {
     expectTypeOf(
       filteredArray([] as [string?, string?], $typed<"hello" | "foo">()),
     ).toEqualTypeOf<
-      | ["hello"?, "foo"?]
-      | []
-      | ["hello"?]
-      | ["foo"?]
-      | ["hello"?, "hello"?]
-      | ["foo"?, "hello"?]
-      | ["foo"?, "foo"?]
+      [] | [("hello" | "foo")?] | [("hello" | "foo")?, ("hello" | "foo")?]
     >();
   });
 });

--- a/packages/remeda/src/internal/types/FilteredArray.test-d.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.test-d.ts
@@ -3,6 +3,26 @@ import { $typed } from "../../../test/$typed";
 import type { FilteredArray } from "./FilteredArray";
 import type { IterableContainer } from "./IterableContainer";
 
+interface ItemInterface {
+  readonly type: "cat" | "dog";
+  readonly legs: number;
+}
+
+interface ConditionInterface {
+  readonly type: "cat";
+  readonly name: string;
+}
+
+class ItemClass {
+  declare public readonly type: "cat" | "dog";
+  declare public readonly legs: number;
+}
+
+class ConditionClass {
+  declare public readonly type: "cat";
+  declare public readonly name: string;
+}
+
 declare function filteredArray<T extends IterableContainer, C>(
   data: T,
   condition: C,
@@ -893,5 +913,38 @@ describe("condition is never", () => {
     expectTypeOf(
       filteredArray([""] as [string, ...number[]], $typed()),
     ).toEqualTypeOf<[]>();
+  });
+
+  test("tuple with an `any` item", () => {
+    expectTypeOf(
+      filteredArray(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentional...
+        $typed<[any]>(),
+        $typed(),
+      ),
+    ).toEqualTypeOf<[]>();
+  });
+});
+
+describe("item and condition aren't type literals", () => {
+  test("interface", () => {
+    expectTypeOf(
+      filteredArray([] as ItemInterface[], $typed<ConditionInterface>()),
+    ).toEqualTypeOf<(ItemInterface & ConditionInterface)[]>();
+  });
+
+  test("interface in a fixed tuple", () => {
+    expectTypeOf(
+      filteredArray(
+        [{ type: "cat", legs: 4 }] as [ItemInterface],
+        $typed<ConditionInterface>(),
+      ),
+    ).toEqualTypeOf<[] | [ItemInterface & ConditionInterface]>();
+  });
+
+  test("class", () => {
+    expectTypeOf(
+      filteredArray([] as ItemClass[], $typed<ConditionClass>()),
+    ).toEqualTypeOf<(ItemClass & ConditionClass)[]>();
   });
 });

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -5,43 +5,51 @@ import type { PartialArray } from "./PartialArray";
 import type { TupleParts } from "./TupleParts";
 
 export type FilteredArray<T extends IterableContainer, Condition> =
-  // We distribute the array type to support unions of arrays/tuples.
-  T extends unknown
-    ? // Reconstruct the array from its parts, but with each part being
-      // filtered on the condition.
-      [
-        ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
-        ...PartialArray<
-          FilteredFixedTuple<TupleParts<T>["optional"], Condition>
-        >,
-        ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
-        ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
-      ]
-    : never;
+  IsNever<Condition> extends true
+    ? // Nothing can satisfy a condition of `never`.
+      []
+    : // We distribute the array type to support unions of arrays/tuples.
+      T extends unknown
+      ? // Reconstruct the array from its parts, but with each part being
+        // filtered on the condition.
+        [
+          ...FilteredFixedTuple<TupleParts<T>["required"], Condition>,
+          ...PartialArray<
+            FilteredFixedTuple<TupleParts<T>["optional"], Condition>
+          >,
+          ...CoercedArray<SymmetricRefine<TupleParts<T>["item"], Condition>>,
+          ...FilteredFixedTuple<TupleParts<T>["suffix"], Condition>,
+        ]
+      : never;
 
 /**
  * The real logic for filtering an array is done on fixed tuples (as those make
  * up the required prefix, the optional prefix, and the suffix of the array).
  */
-type FilteredFixedTuple<T, Condition, Output extends unknown[] = []> =
-  IsNever<Condition> extends true
-    ? // A condition of `never` can never be satisfied so nothing is kept.
-      []
-    : T extends readonly [infer Head, ...infer Rest]
-      ? FilteredFixedTuple<
-          Rest,
-          Condition,
-          Head extends Condition
-            ? // If the item in the array already satisfies the condition we
-              // pass it through to the output.
-              [...Output, Head]
-            : // Otherwise, the item _might_ satisfy the condition in certain
-              // cases (e.g., an item of `string` against a condition of
-              // `"hello"`), and in other cases it might not, so we build the
-              // output once without the item, and once with it appended.
-              Output | Push<Output, SymmetricRefine<Head, Condition>>
-        >
-      : Output;
+type FilteredFixedTuple<T, Condition> = T extends readonly [
+  infer Head,
+  ...infer Rest,
+]
+  ? Head extends Condition
+    ? // If the item in the array already satisfies the condition we pass it
+      // through to the output.
+      [Head, ...FilteredFixedTuple<Rest, Condition>]
+    : // The item doesn't satisfy the condition, but it might share a refined
+      // type with it, so it would still show up in the output; to accommodate
+      // for this we consider both cases for the output.
+      | FilteredFixedTuple<Rest, Condition>
+      | (IsNever<SymmetricRefine<Head, Condition>> extends true
+          ? // The item is entirely disjoint from the condition, it would never
+            // match.
+            never
+          : [
+              // Instead of adding the item as-is, we add the common refined
+              // base type.
+              SymmetricRefine<Head, Condition>,
+              ...FilteredFixedTuple<Rest, Condition>,
+            ])
+  : // Our inputs are fixed-tuples so we reach here only when T is exactly `[]`.
+    [];
 
 /**
  * This type is similar to the built-in `Extract` type, but allows us to have
@@ -61,23 +69,22 @@ type SymmetricRefine<Item, Condition> = Item extends Condition
  * allowing more value types than the other (e.g.,
  * `{ a: "cat" | "dog", b: number }` and `{ a: "cat" }`).
  */
-type RefineIncomparable<Item, Condition> = Item extends object
-  ? Item extends readonly unknown[]
-    ? never
-    : Condition extends object
-      ? Condition extends readonly unknown[]
+type RefineIncomparable<Item, Condition> =
+  IsRealObject<Item> extends true
+    ? IsRealObject<Condition> extends true
+      ? // We take the (symmetric) intersection of the two objects; but only
+        // when we know it isn't empty. This would only happen if they share at
+        // least one key.
+        IsNever<Extract<keyof Item, keyof Condition>> extends true
         ? never
-        : // We take the (symmetric) intersection of the two objects;
-          // but only when we know it isn't empty. This would only happen if
-          // they share at least one key.
-          IsNever<Extract<keyof Item, keyof Condition>> extends true
-          ? never
-          : Item & Condition
+        : Item & Condition
       : never
-  : never;
+    : never;
 
-/**
- * Add an item to a tuple, skipping `never` values...
- */
-type Push<Output extends unknown[], Refined> =
-  IsNever<Refined> extends true ? never : [...Output, Refined];
+// Arrays are objects but they don't behave like ones because they have
+// different `extend` and `keyof` semantics.
+type IsRealObject<T> = T extends object
+  ? T extends readonly unknown[]
+    ? false
+    : true
+  : false;

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -23,42 +23,41 @@ export type FilteredArray<T extends IterableContainer, Condition> =
  * The real logic for filtering an array is done on fixed tuples (as those make
  * up the required prefix, the optional prefix, and the suffix of the array).
  */
-type FilteredFixedTuple<
-  T,
-  Condition,
-  Output extends unknown[] = [],
-> = T extends readonly [infer Head, ...infer Rest]
-  ? FilteredFixedTuple<
-      Rest,
-      Condition,
-      Head extends Condition
-        ? // If the item in the array already satisfies the condition we pass
-          // it through to the output.
-          [...Output, Head]
-        : Head | Condition extends object
-          ? // TypeScript defines "extends" for objects differently than it
-            // does for primitives, e.g. `{ a: string, b: number }` extends
-            // `{ a: string }` because any function that would accept the latter
-            // would be able to accept the former (by ignoring the extra props)
-            // because TypeScript is structurally typed; but for filtering we
-            // want the opposite semantics, and at this point we already know
-            // that that is false, so we can safely say this item doesn't meet
-            // the condition and skip it.
-            Output
-          : Condition extends Head
-            ? // But for any other type (mostly primitives), if the condition
-                // extends the item it means that there are situations where the
-                // item could satisfy the condition and cases where it won't
-                // (e.g. if the item type is `string` and the condition type is
-                // `"hello"`, then item could be `"hello"` or it could be any
-                // other string, e.g. `"world"`). In this case we need to take
-                // both into consideration in the output type.
-                Output | [...Output, Condition]
-            : // But if the item and condition are disjoint then we simply skip
-              // it as it would never satisfy the condition.
-              Output
-    >
-  : Output;
+type FilteredFixedTuple<T, Condition, Output extends unknown[] = []> =
+  IsNever<Condition> extends true
+    ? // A condition of `never` can never be satisfied so nothing is kept.
+      []
+    : T extends readonly [infer Head, ...infer Rest]
+      ? FilteredFixedTuple<
+          Rest,
+          Condition,
+          Head extends Condition
+            ? // If the item in the array already satisfies the condition we
+              // pass it through to the output.
+              [...Output, Head]
+            : // For items that don't satisfy the condition they still _might_
+              // satisfy it in certain situations, so we construct the type
+              // assuming both
+              | Output
+              | (Head | Condition extends object
+                  ? // If both item and condition are objects...
+                    IsNever<SymmetricRefine<Head, Condition>> extends true
+                    ? // If the item is entirely disjoint we skip it.
+                      never
+                    : // Otherwise we add the more specific type to the output.
+                      [...Output, SymmetricRefine<Head, Condition>]
+                  : Condition extends Head
+                    ? // But for any other type (mostly primitives), if the
+                      // condition extends the item it means that there are
+                      // situations where the item could satisfy the condition
+                      // (e.g., if the item type is `string` and the condition
+                      // type is `"hello"`, then item could be `"hello"` or it
+                      // could be any other string, e.g. `"world"`).
+                      [...Output, Condition]
+                    : // If the item is entirely disjoint we skip it.
+                      never)
+        >
+      : Output;
 
 /**
  * This type is similar to the built-in `Extract` type, but allows us to have
@@ -78,14 +77,17 @@ type SymmetricRefine<Item, Condition> = Item extends Condition
  * allowing more value types than the other (e.g.,
  * `{ a: "cat" | "dog", b: number }` and `{ a: "cat" }`).
  */
-type RefineIncomparable<Item, Condition> =
-  Item extends Record<PropertyKey, unknown>
-    ? Condition extends Record<PropertyKey, unknown>
-      ? // We take the (symmetric) intersection of the two objects;
-        // but only when we know it isn't empty. This would only happen if they
-        // share a least one key.
-        IsNever<Extract<keyof Item, keyof Condition>> extends true
+type RefineIncomparable<Item, Condition> = Item extends object
+  ? Item extends readonly unknown[]
+    ? never
+    : Condition extends object
+      ? Condition extends readonly unknown[]
         ? never
-        : Item & Condition
+        : // We take the (symmetric) intersection of the two objects;
+          // but only when we know it isn't empty. This would only happen if
+          // they share a least one key.
+          IsNever<Extract<keyof Item, keyof Condition>> extends true
+          ? never
+          : Item & Condition
       : never
-    : never;
+  : never;

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -85,7 +85,7 @@ type RefineIncomparable<Item, Condition> = Item extends object
         ? never
         : // We take the (symmetric) intersection of the two objects;
           // but only when we know it isn't empty. This would only happen if
-          // they share a least one key.
+          // they share at least one key.
           IsNever<Extract<keyof Item, keyof Condition>> extends true
           ? never
           : Item & Condition

--- a/packages/remeda/src/internal/types/FilteredArray.ts
+++ b/packages/remeda/src/internal/types/FilteredArray.ts
@@ -35,27 +35,11 @@ type FilteredFixedTuple<T, Condition, Output extends unknown[] = []> =
             ? // If the item in the array already satisfies the condition we
               // pass it through to the output.
               [...Output, Head]
-            : // For items that don't satisfy the condition they still _might_
-              // satisfy it in certain situations, so we construct the type
-              // assuming both
-              | Output
-              | (Head | Condition extends object
-                  ? // If both item and condition are objects...
-                    IsNever<SymmetricRefine<Head, Condition>> extends true
-                    ? // If the item is entirely disjoint we skip it.
-                      never
-                    : // Otherwise we add the more specific type to the output.
-                      [...Output, SymmetricRefine<Head, Condition>]
-                  : Condition extends Head
-                    ? // But for any other type (mostly primitives), if the
-                      // condition extends the item it means that there are
-                      // situations where the item could satisfy the condition
-                      // (e.g., if the item type is `string` and the condition
-                      // type is `"hello"`, then item could be `"hello"` or it
-                      // could be any other string, e.g. `"world"`).
-                      [...Output, Condition]
-                    : // If the item is entirely disjoint we skip it.
-                      never)
+            : // Otherwise, the item _might_ satisfy the condition in certain
+              // cases (e.g., an item of `string` against a condition of
+              // `"hello"`), and in other cases it might not, so we build the
+              // output once without the item, and once with it appended.
+              Output | Push<Output, SymmetricRefine<Head, Condition>>
         >
       : Output;
 
@@ -91,3 +75,9 @@ type RefineIncomparable<Item, Condition> = Item extends object
           : Item & Condition
       : never
   : never;
+
+/**
+ * Add an item to a tuple, skipping `never` values...
+ */
+type Push<Output extends unknown[], Refined> =
+  IsNever<Refined> extends true ? never : [...Output, Refined];


### PR DESCRIPTION
The narrowing of the filter condition type in the function definition is not required for the typing to work, and actually limits what the better type narrowing signature is used for, causing some cases to fall through to the trivial non-narrowing signature.

Additionally, the type that drives type-narrowing filters has been refactored and expanded with more edge-cases in mind.

This also fixed an existing bug in `groupByProp` which uses this type too.

NOTE: for complex long **const** tuples these fixes might regress on typescript performance. This would show up as slowness in the IDE when hovering over types downstream to when running type checking on the project. Comment here or in a new issue if you experience any problems, and in the meantime, cast your type to a simpler shape (e.g. as `readonly MyType[]`) to avoid these problems.