### PR TITLE
fix(isNot): allow widening type predicates

### DIFF
--- a/packages/docs/src/content/mapping/lodash/negate.md
+++ b/packages/docs/src/content/mapping/lodash/negate.md
@@ -1,0 +1,59 @@
+---
+category: Function
+remeda: isNot
+---
+
+- Unlike Lodash's `negate`, `isNot` preserves type predicates: negating a
+  type-guard returns a type-guard which _excludes_ the guarded type, so the
+  result of [`filter`](/docs#filter) stays narrowed.
+- Lodash's `negate` forwards every argument it receives to the predicate, and
+  invokes it with the same `this`. `isNot` only takes a single-parameter
+  predicate and passes just the first argument through; wrap multi-parameter
+  functions with the native [logical NOT operator `!`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT)
+  instead.
+- Lodash's `negate` negates the _truthiness_ of any return value, whereas
+  `isNot` requires a predicate that returns a `boolean`. Compose with
+  [`isTruthy`](/docs#isTruthy) to get the Lodash semantics.
+
+#### Predicates
+
+```ts
+// Lodash
+_.negate(predicate);
+
+// Remeda
+isNot(predicate);
+```
+
+#### Filtering
+
+```ts
+// Lodash
+_.filter(DATA, _.negate(_.isString));
+
+// Remeda
+filter(DATA, isNot(isString));
+```
+
+#### Multiple parameters
+
+```ts
+// Lodash
+_.negate(isGreaterThan);
+
+// Native
+(a: number, b: number) => !isGreaterThan(a, b);
+```
+
+#### Non-boolean predicates
+
+```ts
+// Lodash
+_.negate(getLength);
+
+// Remeda
+isNot(piped(getLength, isTruthy));
+
+// Or directly via Native JS:
+(data: string) => !getLength(data);
+```

--- a/packages/docs/src/content/mapping/ramda/__MISSING.md
+++ b/packages/docs/src/content/mapping/ramda/__MISSING.md
@@ -92,7 +92,6 @@
 
 - and
 - both
-- complement
 - either
 - isNotEmpty
 - or

--- a/packages/docs/src/content/mapping/ramda/complement.md
+++ b/packages/docs/src/content/mapping/ramda/complement.md
@@ -1,0 +1,28 @@
+---
+category: Logic
+remeda: isNot
+---
+
+- Unlike Ramda's `complement`, `isNot` preserves type predicates: negating a
+  type-guard returns a type-guard which _excludes_ the guarded type, so the
+  result of [`filter`](/docs#filter) stays narrowed.
+
+#### Predicates
+
+```ts
+// Ramda
+complement(predicate);
+
+// Remeda
+isNot(predicate);
+```
+
+#### Filtering
+
+```ts
+// Ramda
+filter(complement(is(String)), DATA);
+
+// Remeda
+filter(DATA, isNot(isString));
+```

--- a/packages/docs/src/content/mapping/ramda/complement.md
+++ b/packages/docs/src/content/mapping/ramda/complement.md
@@ -6,6 +6,14 @@ remeda: isNot
 - Unlike Ramda's `complement`, `isNot` preserves type predicates: negating a
   type-guard returns a type-guard which _excludes_ the guarded type, so the
   result of [`filter`](/docs#filter) stays narrowed.
+- Ramda's `complement` preserves the arity of the function it wraps, and the
+  result stays curried. `isNot` only takes a single-parameter predicate and
+  passes just the first argument through; wrap multi-parameter functions with
+  the native [logical NOT operator `!`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT)
+  instead.
+- Ramda's `complement` negates the _truthiness_ of any return value, whereas
+  `isNot` requires a predicate that returns a `boolean`. Compose with
+  [`isTruthy`](/docs#isTruthy) to get the Ramda semantics.
 
 #### Predicates
 
@@ -25,4 +33,27 @@ filter(complement(is(String)), DATA);
 
 // Remeda
 filter(DATA, isNot(isString));
+```
+
+#### Multiple parameters
+
+```ts
+// Ramda
+complement(isGreaterThan);
+
+// Native
+(a: number, b: number) => !isGreaterThan(a, b);
+```
+
+#### Non-boolean predicates
+
+```ts
+// Ramda
+complement(getLength);
+
+// Remeda
+isNot(piped(getLength, isTruthy));
+
+// Or directly via Native JS:
+(data: string) => !getLength(data);
 ```

--- a/packages/docs/src/content/mapping/ramda/not.md
+++ b/packages/docs/src/content/mapping/ramda/not.md
@@ -1,27 +1,29 @@
 ---
 category: Logic
-remeda: isNot
 ---
 
-The function only accepts boolean values, to support arbitrary values compose
-it with [`isTruthy`](/docs#isTruthy).
+_Not provided by Remeda._
 
-#### Booleans
+- Use the native [logical NOT operator `!`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT).
+- Ramda's `not` is a function, so it can be passed around point-free. The native
+  operator can't; wrap it in an arrow function.
+
+#### Values
 
 ```ts
 // Ramda
-not(val);
+not(value);
 
-// Remeda
-isNot(val);
+// Native
+!value;
 ```
 
-#### Arbitrary
+#### Point-free
 
 ```ts
 // Ramda
-not(val);
+map(not, DATA);
 
 // Remeda
-isNot(isTruthy(val));
+map(DATA, (value) => !value);
 ```

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -9,6 +9,7 @@ import {
 import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
+import { $typed } from "../test/$typed";
 
 test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
@@ -61,4 +62,12 @@ test("should work as type guard in filter", () => {
       | undefined
     )[]
   >();
+});
+
+test("negates a predicate wider than the data", () => {
+  expectTypeOf(
+    $typed<(string | null)[]>().filter(
+      isNot((x: unknown) => x === null || x === undefined),
+    ),
+  ).items.toEqualTypeOf<string>();
 });

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -83,7 +83,7 @@ test("type predicates that take a type parameter", () => {
 });
 
 test("type predicates which are too narrow for the wrapper", () => {
-  // eslint-disable-next-line unicorn/no-unused-array-method-return
+  // eslint-disable-next-line unicorn/no-unused-array-method-return -- We use `filter` as a canonical usage of `isNot`, we need it so that we have a wrapper around `isNot` which defines the type for the items being checked.
   $typed<(string | undefined)[]>().filter(
     // @ts-expect-error [ts2769] -- Intentional! This is what we want to test
     // here. The `undefined` in the data type cannot be processed by the type

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from "vitest";
+import { $typed } from "../test/$typed";
 import {
   ALL_TYPES_DATA_PROVIDER,
   TYPES_DATA_PROVIDER,
@@ -9,7 +10,6 @@ import {
 import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
-import { $typed } from "../test/$typed";
 
 test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -8,6 +8,7 @@ import {
   type TypedArray,
 } from "../test/typesDataProvider";
 import { isNot } from "./isNot";
+import { isNullish } from "./isNullish";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
 import { isTruthy } from "./isTruthy";
@@ -90,4 +91,16 @@ test("type predicates which are too narrow for the wrapper", () => {
     // predicate.
     isNot(startsWith("hello")),
   );
+});
+
+test("negates a generic guard", () => {
+  expectTypeOf(
+    $typed<(string | null)[]>().filter(isNot(isNullish)),
+  ).items.toEqualTypeOf<string>();
+});
+
+test("non-narrowing predicates stay non-narrowing", () => {
+  expectTypeOf(
+    $typed<string[]>().filter(isNot((data: string) => data.length > 3)),
+  ).items.toEqualTypeOf<string>();
 });

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -79,15 +79,25 @@ test("negates a predicate wider than the data", () => {
 
 test("type predicates that take a type parameter", () => {
   expectTypeOf(
-    $typed<(true | false)[]>().filter(isNot(isTruthy)),
+    $typed<boolean[]>().filter(isNot(isTruthy)),
   ).items.toEqualTypeOf<false>();
 });
 
 test("type predicates which are too narrow for the wrapper", () => {
   // eslint-disable-next-line unicorn/no-unused-array-method-return -- We use `filter` as a canonical usage of `isNot`, we need it so that we have a wrapper around `isNot` which defines the type for the items being checked.
-  $typed<(string | undefined)[]>().filter(
+  $typed<(string | number)[]>().filter(
     // @ts-expect-error [ts2769] -- Intentional! This is what we want to test
-    // here. The `undefined` in the data type cannot be processed by the type
+    // here. The `number` in the data type cannot be processed by the type
+    // predicate.
+    isNot(startsWith("hello")),
+  );
+});
+
+test("type predicates which are disjoint for the wrapper", () => {
+  // eslint-disable-next-line unicorn/no-unused-array-method-return -- We use `filter` as a canonical usage of `isNot`, we need it so that we have a wrapper around `isNot` which defines the type for the items being checked.
+  $typed<number[]>().filter(
+    // @ts-expect-error [ts2769] -- Intentional! This is what we want to test
+    // here. The `number` in the data type cannot be processed by the type
     // predicate.
     isNot(startsWith("hello")),
   );

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -10,6 +10,8 @@ import {
 import { isNot } from "./isNot";
 import { isPromise } from "./isPromise";
 import { isString } from "./isString";
+import { isTruthy } from "./isTruthy";
+import { startsWith } from "./startsWith";
 
 test("should work as type guard", () => {
   const data = TYPES_DATA_PROVIDER.promise as AllTypesDataProviderTypes;
@@ -70,4 +72,20 @@ test("negates a predicate wider than the data", () => {
       isNot((x: unknown) => x === null || x === undefined),
     ),
   ).items.toEqualTypeOf<string>();
+});
+
+test("type predicates that take a type parameter", () => {
+  expectTypeOf(
+    $typed<(true | false)[]>().filter(isNot(isTruthy)),
+  ).items.toEqualTypeOf<false>();
+});
+
+test("type predicates which are too narrow for the wrapper", () => {
+  // eslint-disable-next-line unicorn/no-unused-array-method-return
+  $typed<(string | undefined)[]>().filter(
+    // @ts-expect-error [ts2769] -- Intentional! This is what we want to test
+    // here. The `undefined` in the data type cannot be processed by the type
+    // predicate.
+    isNot(startsWith("hello")),
+  );
 });

--- a/packages/remeda/src/isNot.test-d.ts
+++ b/packages/remeda/src/isNot.test-d.ts
@@ -69,7 +69,9 @@ test("should work as type guard in filter", () => {
 test("negates a predicate wider than the data", () => {
   expectTypeOf(
     $typed<(string | null)[]>().filter(
-      isNot((x: unknown) => x === null || x === undefined),
+      isNot(
+        (x: unknown): x is null | undefined => x === null || x === undefined,
+      ),
     ),
   ).items.toEqualTypeOf<string>();
 });

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -1,3 +1,5 @@
+type Predicate<T> = (data: T) => boolean;
+
 /**
  * A function that takes a guard function as predicate and returns a guard that negates it.
  *
@@ -11,11 +13,12 @@
  * @dataLast
  * @category Guard
  */
-export function isNot<T, S extends T>(
-  predicate: (data: T) => data is S,
-): (data: T) => data is Exclude<T, S>;
-export function isNot<T>(predicate: (data: T) => boolean): (data: T) => boolean;
+export function isNot<T, Narrow extends T>(
+  predicate: (data: T) => data is Narrow,
+): <Wide extends T>(data: Wide) => data is Exclude<Wide, Narrow>;
 
-export function isNot<T>(predicate: (data: T) => boolean) {
-  return (data: T): boolean => !predicate(data);
+export function isNot<T>(predicate: Predicate<T>): Predicate<T>;
+
+export function isNot<T>(predicate: Predicate<T>): Predicate<T> {
+  return (data) => !predicate(data);
 }

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -1,4 +1,6 @@
-type Predicate<T> = (data: T) => boolean;
+import type { IsUnknown } from "type-fest";
+import type { GuardType } from "./internal/types/GuardType";
+import type { IterableContainer } from "./internal/types/IterableContainer";
 
 /**
  * A function that takes a guard function as predicate and returns a guard that negates it.
@@ -13,12 +15,27 @@ type Predicate<T> = (data: T) => boolean;
  * @dataLast
  * @category Guard
  */
-export function isNot<T, Narrow extends T>(
-  predicate: (data: T) => data is Narrow,
-): <Wide extends T>(data: Wide) => data is Exclude<Wide, Narrow>;
+export function isNot<
+  T extends (data: unknown, ...args: never) => data is unknown,
+>(
+  predicate: IsUnknown<GuardType<T>> extends true ? never : T,
+): <Wide extends Parameters<T>[0]>(
+  data: Wide,
+) => data is Exclude<Wide, GuardType<T>>;
 
-export function isNot<T>(predicate: Predicate<T>): Predicate<T>;
+// Fallback for type-predicates which take a type parameter and resolve eagerly
+// to undefined.
+export function isNot<T, Rest extends IterableContainer, Narrow extends T>(
+  predicate: (data: T, ...rest: Rest) => data is Narrow,
+): (data: T, ...rest: Rest) => data is Exclude<T, Narrow>;
 
-export function isNot<T>(predicate: Predicate<T>): Predicate<T> {
-  return (data) => !predicate(data);
+// Fallback for trivial (non-narrowing) boolean predicates.
+export function isNot<T, Rest extends IterableContainer>(
+  predicate: (data: T, ...rest: Rest) => boolean,
+): (data: T, ...rest: Rest) => boolean;
+
+export function isNot<T, Rest extends IterableContainer>(
+  predicate: (data: T, ...rest: Rest) => boolean,
+): (data: T, ...rest: Rest) => boolean {
+  return (data, ...rest) => !predicate(data, ...rest);
 }

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -25,9 +25,7 @@ export function isNot<T extends (data: unknown) => data is unknown>(
   predicate: IsUnknown<GuardType<T>> extends true
     ? (data: Parameters<T>[0]) => data is never
     : T,
-): <Wide extends Parameters<T>[0]>(
-  data: Wide,
-) => data is Exclude<Wide, GuardType<T>>;
+): <Wide>(data: Wide) => data is Exclude<Wide, GuardType<T>>;
 
 // Fallback for guards the signature above rejects: those whose guarded type is
 // `unknown` (e.g. `isTruthy`), and those whose parameter is narrower than

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -15,6 +15,7 @@ import type { GuardType } from "./internal/types/GuardType";
  * @category Guard
  */
 export function isNot<T extends (data: unknown) => data is unknown>(
+  // Prevent guards which would result in narrowing to `never` from using this signature; allowing the next signature to handle them.
   predicate: IsUnknown<GuardType<T>> extends true ? never : T,
 ): <Wide extends Parameters<T>[0]>(
   data: Wide,

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -15,14 +15,23 @@ import type { GuardType } from "./internal/types/GuardType";
  * @category Guard
  */
 export function isNot<T extends (data: unknown) => data is unknown>(
-  // Prevent guards which would result in narrowing to `never` from using this signature; allowing the next signature to handle them.
-  predicate: IsUnknown<GuardType<T>> extends true ? never : T,
+  // Guards whose guarded type is `unknown` would make the `Exclude` below
+  // collapse to `never`, so they are rejected here and handled by the next
+  // signature instead. The rejection is spelled as a guard narrowing to `never`
+  // (rather than as a bare `never`) so that this position stays function-shaped
+  // and keeps mentioning `T`: against a bare `never` no candidate is inferred
+  // for `T`, so every generic guard (`isString`, `isNullish`, ...) falls back
+  // to the constraint, whose guarded type is `unknown`, and gets rejected too.
+  predicate: IsUnknown<GuardType<T>> extends true
+    ? (data: Parameters<T>[0]) => data is never
+    : T,
 ): <Wide extends Parameters<T>[0]>(
   data: Wide,
 ) => data is Exclude<Wide, GuardType<T>>;
 
-// Fallback for type-predicates which take a type parameter and resolve eagerly
-// to `unknown`.
+// Fallback for guards the signature above rejects: those whose guarded type is
+// `unknown` (e.g. `isTruthy`), and those whose parameter is narrower than
+// `unknown` (e.g. `startsWith`), which the constraint above can't accept.
 export function isNot<T, Narrow extends T>(
   predicate: (data: T) => data is Narrow,
 ): (data: T) => data is Exclude<T, Narrow>;

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -20,7 +20,7 @@ export function isNot<T extends (data: unknown) => data is unknown>(
   data: Wide,
 ) => data is Exclude<Wide, GuardType<T>>;
 
-// Fallback for type-predicates which take a type parameter and resolves eagerly
+// Fallback for type-predicates which take a type parameter and resolve eagerly
 // to `unknown`.
 export function isNot<T, Narrow extends T>(
   predicate: (data: T) => data is Narrow,

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -5,7 +5,6 @@ import type { GuardType } from "./internal/types/GuardType";
  * A function that takes a guard function as predicate and returns a guard that negates it.
  *
  * @param predicate - The guard function to negate.
- * @returns Function A guard function.
  * @signature
  *    isNot(isTruthy)(data)
  * @example
@@ -23,7 +22,7 @@ export function isNot<T extends (data: unknown) => data is unknown>(
   // for `T`, so every generic guard (`isString`, `isNullish`, ...) falls back
   // to the constraint, whose guarded type is `unknown`, and gets rejected too.
   predicate: IsUnknown<GuardType<T>> extends true
-    ? (data: Parameters<T>[0]) => data is never
+    ? (data: unknown) => data is never
     : T,
 ): <Wide>(data: Wide) => data is Exclude<Wide, GuardType<T>>;
 

--- a/packages/remeda/src/isNot.ts
+++ b/packages/remeda/src/isNot.ts
@@ -1,6 +1,5 @@
 import type { IsUnknown } from "type-fest";
 import type { GuardType } from "./internal/types/GuardType";
-import type { IterableContainer } from "./internal/types/IterableContainer";
 
 /**
  * A function that takes a guard function as predicate and returns a guard that negates it.
@@ -15,27 +14,23 @@ import type { IterableContainer } from "./internal/types/IterableContainer";
  * @dataLast
  * @category Guard
  */
-export function isNot<
-  T extends (data: unknown, ...args: never) => data is unknown,
->(
+export function isNot<T extends (data: unknown) => data is unknown>(
   predicate: IsUnknown<GuardType<T>> extends true ? never : T,
 ): <Wide extends Parameters<T>[0]>(
   data: Wide,
 ) => data is Exclude<Wide, GuardType<T>>;
 
-// Fallback for type-predicates which take a type parameter and resolve eagerly
-// to undefined.
-export function isNot<T, Rest extends IterableContainer, Narrow extends T>(
-  predicate: (data: T, ...rest: Rest) => data is Narrow,
-): (data: T, ...rest: Rest) => data is Exclude<T, Narrow>;
+// Fallback for type-predicates which take a type parameter and resolves eagerly
+// to `unknown`.
+export function isNot<T, Narrow extends T>(
+  predicate: (data: T) => data is Narrow,
+): (data: T) => data is Exclude<T, Narrow>;
 
 // Fallback for trivial (non-narrowing) boolean predicates.
-export function isNot<T, Rest extends IterableContainer>(
-  predicate: (data: T, ...rest: Rest) => boolean,
-): (data: T, ...rest: Rest) => boolean;
+export function isNot<T>(predicate: (data: T) => boolean): (data: T) => boolean;
 
-export function isNot<T, Rest extends IterableContainer>(
-  predicate: (data: T, ...rest: Rest) => boolean,
-): (data: T, ...rest: Rest) => boolean {
-  return (data, ...rest) => !predicate(data, ...rest);
+export function isNot<T>(
+  predicate: (data: T) => boolean,
+): (data: T) => boolean {
+  return (data) => !predicate(data);
 }


### PR DESCRIPTION
The current implementation only works if the type-predicate used narrows to a strict subtype of the external type, and it doesn't let the type flow through when inferring the output.