### PR TITLE
fix(filter, find, flatMap, forEach, map, mapWithFeedback, uniqueBy, zipWith): narrow callback `data` param type for lazy evaluators

### DIFF
--- a/.agents/skills/remeda-utility/SKILL.md
+++ b/.agents/skills/remeda-utility/SKILL.md
@@ -33,6 +33,7 @@ Conventions that apply across all three kinds:
 - Test names do not need to read as prose!
 - Tests for a specific bug must reference the issue number, either in the test name or a comment so that the reporting issue can always be traced back.
 - Input data needs enough variation to produce distinct outputs — `[1, 1, 1]` hides bugs that `[1, 2, 3]` catches.
+- Known issues and limitations (an accepted wrong result, an upstream TypeScript bug, a case the types can't express) are pinned in a `describe("known issues!", ...)` block at the end of the file, in every test kind where the issue is observable. Each test asserts the **current** behavior so it turns red when the limitation lifts: assert the actual value, or put the desired assertion under `// @ts-expect-error [tsNNNN] -- <why, linking the upstream issue when one exists>` followed by an `// Actual` assertion. The test name states the limitation; why it exists goes in a comment inside the test body.
 
 # 3. JSDoc
 

--- a/.agents/skills/remeda-utility/reference/implementation.md
+++ b/.agents/skills/remeda-utility/reference/implementation.md
@@ -22,6 +22,29 @@ The lazy evaluator has the shape `(item, index, data) => LazyResult<T>`:
 
 Set `done: true` to short-circuit the pipe — no further items will be requested. For functions that return a single scalar (e.g., `first()`), wrap the evaluator with `toSingle(lazyImpl)` so `pipe` knows to stop after one result.
 
+### Typing the callback's `data` parameter
+
+Inside `pipe`, the lazy evaluator is invoked once per item with the accumulator of items processed so far as its `data` argument, not the complete input. Any user callback the evaluator forwards `data` to sees that same growing prefix, so its type has to say so. `NonEmptyPrefix<T>` (`src/internal/types/NonEmptyPrefix.ts`) computes that type from the input: the first element is required (the callback never runs on an empty accumulator), every later element is optional, and the tuple shape is preserved as far as TypeScript allows.
+
+Which overloads need it depends on the purrying helper:
+
+- `purry` with a lazy evaluator: the data-first overload runs the eager implementation and receives the complete input, so it keeps the standard `(value: T[number], index: number, data: T) => R` shape. Only the data-last overload is lazy.
+- `purryFromLazy`: both overloads route through `pipe`, so both use the lazy types.
+
+How to type a lazy overload:
+
+- Standard `(value, index, data)` callback: `LazyCallback<T, R>` (`src/internal/types/LazyCallback.ts`). For a type predicate use `LazyTypePredicate<T, S>`; TypeScript can't route `value is S` through a generic return type.
+- Any other shape (extra parameters like `mapWithFeedback`'s `previousValue`, or `data` nested inside a tuple like `zipWith`): declare a local alias next to the eager one and type the slot as `Readonly<NonEmptyPrefix<T>>`. Never drop the `Readonly`: `pipe` hands the same array to every invocation, so a callback that mutates it changes what later invocations see.
+- Only the array flowing through the pipe is a prefix. Arrays passed as arguments (`zipWith`'s `second`) are complete and keep their type.
+- If the implementation signature unions the eager and lazy callback types (as `zipWith` does), include the lazy alias in that union; without it the data-last overload fails with `ts2394`, because a callback accepting the full `T` is not assignable to one accepting only its prefix.
+
+Callbacks that never receive `data` (`uniqueWith`'s comparator, `differenceWith`'s `isEquals`) are unaffected.
+
+Known limitations:
+
+- On tuple inputs the prefix isn't assignable to a plain array (`sum(data)` fails on `[1, 2, 3] as const`) because TypeScript adds `undefined` to reads of optional tuple elements. Pinned in the known issues block of `NonEmptyPrefix.test-d.ts`.
+- A data-last call used as a callback outside `pipe` (`map(data, map(fn))`) runs eagerly and receives the complete array, yet is typed as a prefix. A single overload can't tell the two callers apart, so the type is pessimistic there by design.
+
 ## Handling `null`, `undefined`, and `NaN`
 
 These three "empty-ish" values are not interchangeable in Remeda:

--- a/.agents/skills/remeda-utility/reference/testing-runtime.md
+++ b/.agents/skills/remeda-utility/reference/testing-runtime.md
@@ -3,3 +3,4 @@
 - Keep tests simple and short — more tests are better than tests that do more
 - Tests must be self-contained — no shared utilities or helpers; inline everything
 - Use Remeda's own utilities in tests when applicable (`prop`, `constant`, etc.)
+- Lazy callbacks: verify the callback receives the items processed so far with a `vi.fn<LazyCallback<unknown[], unknown>>` mock that returns `[...data]`, asserted per call with `toHaveNthReturnedWith`. The spread is load-bearing: `pipe` reuses one accumulator array, so asserting on the reference after the pipe finishes compares the mutated, complete array and passes for the wrong reason. Template: `callbacks receive the items processed so far` in `pipe.test.ts`

--- a/.agents/skills/remeda-utility/reference/testing-types.md
+++ b/.agents/skills/remeda-utility/reference/testing-types.md
@@ -13,3 +13,4 @@
 - When `@typescript-eslint/no-unnecessary-type-assertion` flags an inference-controlling cast, replace `value as T` with `$typed<T>()` from `test/$typed` rather than autofixing
   - Safe when the rule's reason is "This assertion is unnecessary since the receiver accepts the original type of the expression"
   - Proceed cautiously for other reasons; for `interface` types, suppress per-site with a reason comment instead — see `$typed` JSDoc
+- Lazy callbacks (any overload typed with `LazyCallback`, `LazyTypePredicate`, or `NonEmptyPrefix`): assert the exact `data` type inside the callback body, on an `as const` tuple (`readonly [1, 2?, 3?]`) and on a plain array (`readonly [number, ...number[]]`). For `purry`-based functions also assert that the data-first overload still receives the complete input. Data-last assertions must run inside `pipe` to hit the lazy overload. Template: the `callback data param` block in `map.test-d.ts`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ We don't ship `reject` because it's `filter(isNot)`, and we don't ship `zipObjec
 
 - Add a JSDoc block with a description, parameters, signature, an example, and tags. This becomes the website docs.
 - Add runtime tests in `functionName.test.ts` and type tests in `functionName.test-d.ts`. Cover both data-first and data-last calling styles.
+- If the function supports lazy evaluation in `pipe` (tagged `@lazy`), type the lazy overload's callback with `LazyCallback` from [`packages/remeda/src/internal/types/`](packages/remeda/src/internal/types/): inside `pipe` the callback's `data` argument holds only the items processed so far, not the complete input.
 - Add an export to [`packages/remeda/src/index.ts`](packages/remeda/src/index.ts) (alphabetical).
 - If a Lodash, Ramda, or Just equivalent exists, add a mapping page under [`packages/docs/src/content/mapping/`](packages/docs/src/content/mapping/).
 

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -409,7 +409,7 @@ test("`unknown` data", () => {
   expectTypeOf(filter([] as unknown[], isString)).toEqualTypeOf<string[]>();
 });
 
-describe("data param", () => {
+describe("callback data param", () => {
   test("complete in data-first", () => {
     filter([1, 2, 3] as const, (_value, _index, data) => {
       expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -428,4 +428,15 @@ describe("data param", () => {
       }),
     );
   });
+
+  test("lazily reconstructed in data-last with a type predicate", () => {
+    pipe(
+      [1, 2, 3] as const,
+      filter((value, _index, data): value is 2 => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+        return value === 2;
+      }),
+    );
+  });
 });

--- a/packages/remeda/src/filter.test-d.ts
+++ b/packages/remeda/src/filter.test-d.ts
@@ -408,3 +408,24 @@ describe("condition isn't a subtype of the item", () => {
 test("`unknown` data", () => {
   expectTypeOf(filter([] as unknown[], isString)).toEqualTypeOf<string[]>();
 });
+
+describe("data param", () => {
+  test("complete in data-first", () => {
+    filter([1, 2, 3] as const, (_value, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+
+      return true;
+    });
+  });
+
+  test("lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3] as const,
+      filter((_value, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+        return true;
+      }),
+    );
+  });
+});

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -1,6 +1,10 @@
 import type { FilteredArray } from "./internal/types/FilteredArray";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type {
+  LazyCallback,
+  LazyTypePredicate,
+} from "./internal/types/NonEmptyPrefix";
 import type { NonRefinedFilteredArray } from "./internal/types/NonRefinedFilteredArray";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
@@ -31,6 +35,7 @@ export function filter<T extends IterableContainer, Condition>(
   data: T,
   predicate: (value: T[number], index: number, data: T) => value is Condition,
 ): FilteredArray<T, Condition>;
+
 export function filter<
   T extends IterableContainer,
   IsItemIncluded extends boolean,
@@ -61,13 +66,14 @@ export function filter<
  * @category Array
  */
 export function filter<T extends IterableContainer, Condition>(
-  predicate: (value: T[number], index: number, data: T) => value is Condition,
+  predicate: LazyTypePredicate<T, Condition>,
 ): (data: T) => FilteredArray<T, Condition>;
+
 export function filter<
   T extends IterableContainer,
   IsItemIncluded extends boolean,
 >(
-  predicate: (value: T[number], index: number, data: T) => IsItemIncluded,
+  predicate: LazyCallback<T, IsItemIncluded>,
 ): (data: T) => NonRefinedFilteredArray<T, IsItemIncluded>;
 
 export function filter(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/filter.ts
+++ b/packages/remeda/src/filter.ts
@@ -1,10 +1,10 @@
 import type { FilteredArray } from "./internal/types/FilteredArray";
 import type { IterableContainer } from "./internal/types/IterableContainer";
-import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type {
   LazyCallback,
   LazyTypePredicate,
-} from "./internal/types/NonEmptyPrefix";
+} from "./internal/types/LazyCallback";
+import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { NonRefinedFilteredArray } from "./internal/types/NonRefinedFilteredArray";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { purry } from "./purry";

--- a/packages/remeda/src/find.test-d.ts
+++ b/packages/remeda/src/find.test-d.ts
@@ -383,14 +383,6 @@ describe("data-last", () => {
 });
 
 describe("data param", () => {
-  test("complete in data-first", () => {
-    find([1, 2, 3] as const, (_value, _index, data) => {
-      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
-
-      return true;
-    });
-  });
-
   test("lazily reconstructed in data-last", () => {
     pipe(
       [1, 2, 3] as const,
@@ -398,6 +390,17 @@ describe("data param", () => {
         expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
 
         return true;
+      }),
+    );
+  });
+
+  test("lazily reconstructed in data-last with a type predicate", () => {
+    pipe(
+      [1, 2, 3] as const,
+      find((value, _index, data): value is 2 => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+        return value === 2;
       }),
     );
   });

--- a/packages/remeda/src/find.test-d.ts
+++ b/packages/remeda/src/find.test-d.ts
@@ -372,7 +372,30 @@ describe("data-last", () => {
       find((value, index, data) => {
         expectTypeOf(value).toEqualTypeOf<number | string>();
         expectTypeOf(index).toEqualTypeOf<number>();
-        expectTypeOf(data).toEqualTypeOf<(number | string)[]>();
+        expectTypeOf(data).toEqualTypeOf<
+          readonly [number | string, ...(number | string)[]]
+        >();
+
+        return true;
+      }),
+    );
+  });
+});
+
+describe("data param", () => {
+  test("complete in data-first", () => {
+    find([1, 2, 3] as const, (_value, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+
+      return true;
+    });
+  });
+
+  test("lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3] as const,
+      find((_value, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
 
         return true;
       }),

--- a/packages/remeda/src/find.test-d.ts
+++ b/packages/remeda/src/find.test-d.ts
@@ -382,7 +382,7 @@ describe("data-last", () => {
   });
 });
 
-describe("data param", () => {
+describe("callback data param", () => {
   test("lazily reconstructed in data-last", () => {
     pipe(
       [1, 2, 3] as const,

--- a/packages/remeda/src/find.ts
+++ b/packages/remeda/src/find.ts
@@ -4,6 +4,10 @@ import type { First } from "./internal/types/First";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { Narrowed } from "./internal/types/Narrowed";
+import type {
+  LazyCallback,
+  LazyTypePredicate,
+} from "./internal/types/NonEmptyPrefix";
 import type { TupleParts } from "./internal/types/TupleParts";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { purry } from "./purry";
@@ -139,14 +143,14 @@ export function find<
  * @category Array
  */
 export function find<T extends IterableContainer, Condition>(
-  predicate: (value: T[number], index: number, data: T) => value is Condition,
+  predicate: LazyTypePredicate<T, Condition>,
 ): (data: T) => Found<T, Condition>;
 
 export function find<
   T extends IterableContainer,
   IsItemIncluded extends boolean,
 >(
-  predicate: (value: T[number], index: number, data: T) => IsItemIncluded,
+  predicate: LazyCallback<T, IsItemIncluded>,
 ): (data: T) => FoundNonRefined<T, IsItemIncluded>;
 
 export function find(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/find.ts
+++ b/packages/remeda/src/find.ts
@@ -2,12 +2,12 @@ import { toSingle } from "./internal/toSingle";
 import type { Assignability } from "./internal/types/Assignability";
 import type { First } from "./internal/types/First";
 import type { IterableContainer } from "./internal/types/IterableContainer";
-import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import type { Narrowed } from "./internal/types/Narrowed";
 import type {
   LazyCallback,
   LazyTypePredicate,
-} from "./internal/types/NonEmptyPrefix";
+} from "./internal/types/LazyCallback";
+import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { Narrowed } from "./internal/types/Narrowed";
 import type { TupleParts } from "./internal/types/TupleParts";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 import { purry } from "./purry";

--- a/packages/remeda/src/flatMap.test-d.ts
+++ b/packages/remeda/src/flatMap.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import { flatMap } from "./flatMap";
 import { pipe } from "./pipe";
 
-describe("data param", () => {
+describe("callback data param", () => {
   test("complete in data-first", () => {
     flatMap([1, 2, 3], (_input, _index, data) => {
       expectTypeOf(data).toEqualTypeOf<readonly number[]>();

--- a/packages/remeda/src/flatMap.test-d.ts
+++ b/packages/remeda/src/flatMap.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { flatMap } from "./flatMap";
+import { pipe } from "./pipe";
+
+describe("data param", () => {
+  test("complete in data-first", () => {
+    flatMap([1, 2, 3], (_input, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly number[]>();
+
+      return [0];
+    });
+  });
+
+  test("lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3],
+      flatMap((_input, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<readonly [number, ...number[]]>();
+
+        return [0];
+      }),
+    );
+  });
+});

--- a/packages/remeda/src/flatMap.ts
+++ b/packages/remeda/src/flatMap.ts
@@ -1,5 +1,5 @@
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**
@@ -49,7 +49,7 @@ export function flatMap<T, U>(
  * @category Array
  */
 export function flatMap<T, U>(
-  callbackfn: LazyCallback<T[], readonly U[] | U>,
+  callbackfn: LazyCallback<readonly T[], readonly U[] | U>,
 ): (data: readonly T[]) => U[];
 
 export function flatMap(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/flatMap.ts
+++ b/packages/remeda/src/flatMap.ts
@@ -1,4 +1,5 @@
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**
@@ -48,7 +49,7 @@ export function flatMap<T, U>(
  * @category Array
  */
 export function flatMap<T, U>(
-  callbackfn: (input: T, index: number, data: readonly T[]) => readonly U[] | U,
+  callbackfn: LazyCallback<T[], readonly U[] | U>,
 ): (data: readonly T[]) => U[];
 
 export function flatMap(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/forEach.test-d.ts
+++ b/packages/remeda/src/forEach.test-d.ts
@@ -34,3 +34,18 @@ test("makes the result mutable", () => {
     expectTypeOf(x).toEqualTypeOf<number[]>();
   });
 });
+
+test("data param is complete in data-first", () => {
+  forEach([1, 2, 3] as const, (_value, _index, data) => {
+    expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+  });
+});
+
+test("data param is lazily reconstructed in data-last", () => {
+  pipe(
+    [1, 2, 3] as const,
+    forEach((_value, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+    }),
+  );
+});

--- a/packages/remeda/src/forEach.ts
+++ b/packages/remeda/src/forEach.ts
@@ -1,7 +1,7 @@
 import type { Writable } from "type-fest";
 import type { IterableContainer } from "./internal/types/IterableContainer";
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**

--- a/packages/remeda/src/forEach.ts
+++ b/packages/remeda/src/forEach.ts
@@ -1,6 +1,7 @@
 import type { Writable } from "type-fest";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**
@@ -53,7 +54,7 @@ export function forEach<T extends IterableContainer>(
  * @category Array
  */
 export function forEach<T extends IterableContainer>(
-  callbackfn: (value: T[number], index: number, data: T) => void,
+  callbackfn: LazyCallback<T, void>,
 ): (data: T) => Writable<T>;
 
 export function forEach(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/internal/types/LazyCallback.ts
+++ b/packages/remeda/src/internal/types/LazyCallback.ts
@@ -1,0 +1,25 @@
+import type { IterableContainer } from "./IterableContainer";
+import type { NonEmptyPrefix } from "./NonEmptyPrefix";
+
+/**
+ * Helper type for lazy data-last callbacks.
+ *
+ * @see NonEmptyPrefix
+ */
+export type LazyCallback<T extends IterableContainer, R> = (
+  value: T[number],
+  index: number,
+  data: Readonly<NonEmptyPrefix<T>>,
+) => R;
+
+/**
+ * Helper type for lazy data-last type predicates (because TypeScript doesn't
+ * support the syntax `LazyCallback<T, is S>`).
+ *
+ * @see NonEmptyPrefix
+ */
+export type LazyTypePredicate<T extends IterableContainer, S> = (
+  value: T[number],
+  index: number,
+  data: Readonly<NonEmptyPrefix<T>>,
+) => value is S;

--- a/packages/remeda/src/internal/types/LazyCallback.ts
+++ b/packages/remeda/src/internal/types/LazyCallback.ts
@@ -2,7 +2,7 @@ import type { IterableContainer } from "./IterableContainer";
 import type { NonEmptyPrefix } from "./NonEmptyPrefix";
 
 /**
- * Helper type for lazy data-last callbacks.
+ * Helper type for lazy callbacks.
  *
  * @see NonEmptyPrefix
  */
@@ -13,8 +13,8 @@ export type LazyCallback<T extends IterableContainer, R> = (
 ) => R;
 
 /**
- * Helper type for lazy data-last type predicates (because TypeScript doesn't
- * support the syntax `LazyCallback<T, is S>`).
+ * Helper type for lazy type predicates (because TypeScript doesn't support a
+ * syntax like `LazyCallback<T, is S>`).
  *
  * @see NonEmptyPrefix
  */

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type { IterableContainer } from "./IterableContainer";
+import type { NonEmptyArray } from "./NonEmptyArray";
 import type { NonEmptyPrefix } from "./NonEmptyPrefix";
 
 declare function nonEmptyPrefix<T extends IterableContainer>(
@@ -70,6 +71,20 @@ describe("tuple shapes", () => {
       | ["a", "b", ..."c"[], "d"]
       | ["a", "b", ..."c"[], "d", "e"]
     >();
+  });
+});
+
+describe("structurally non-empty", () => {
+  test("fixed-suffix array", () => {
+    expectTypeOf(nonEmptyPrefix(["b", "c"] as [..."a"[], "b", "c"])).toExtend<
+      NonEmptyArray<unknown>
+    >();
+  });
+
+  test("fixed-elements array", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b", "d", "e"] as ["a", "b", ..."c"[], "d", "e"]),
+    ).toExtend<NonEmptyArray<unknown>>();
   });
 });
 

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
@@ -1,0 +1,80 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type { IterableContainer } from "./IterableContainer";
+import type { NonEmptyPrefix } from "./NonEmptyPrefix";
+
+declare function nonEmptyPrefix<T extends IterableContainer>(
+  data: T,
+): NonEmptyPrefix<T>;
+
+describe("tuple shapes", () => {
+  test("empty tuple", () => {
+    expectTypeOf(nonEmptyPrefix([])).toEqualTypeOf<never>();
+  });
+
+  test("fixed tuple", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b", "c", "d", "e"] as ["a", "b", "c", "d", "e"]),
+    ).toEqualTypeOf<["a", "b"?, "c"?, "d"?, "e"?]>();
+  });
+
+  test("optional tuple", () => {
+    expectTypeOf(
+      nonEmptyPrefix([] as ["a"?, "b"?, "c"?, "d"?, "e"?]),
+    ).toEqualTypeOf<["a", "b"?, "c"?, "d"?, "e"?]>();
+  });
+
+  test("mixed tuple", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b"] as ["a", "b", "c"?, "d"?, "e"?]),
+    ).toEqualTypeOf<["a", "b"?, "c"?, "d"?, "e"?]>();
+  });
+
+  test("array", () => {
+    expectTypeOf(nonEmptyPrefix([] as "a"[])).toEqualTypeOf<["a", ..."a"[]]>();
+  });
+
+  test("fixed-prefix array", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b"] as ["a", "b", ..."c"[]]),
+    ).toEqualTypeOf<["a", "b"?, ..."c"[]]>();
+  });
+
+  test("optional-prefix array", () => {
+    expectTypeOf(nonEmptyPrefix([] as ["a"?, "b"?, ..."c"[]])).toEqualTypeOf<
+      ["a", "b"?, ..."c"[]]
+    >();
+  });
+
+  test("mixed-prefix array", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b"] as ["a", "b", "c"?, "d"?, ..."e"[]]),
+    ).toEqualTypeOf<["a", "b"?, "c"?, "d"?, ..."e"[]]>();
+  });
+
+  test("fixed-suffix array", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["b", "c"] as [..."a"[], "b", "c"]),
+    ).toEqualTypeOf<
+      | ["a", ..."a"[]]
+      | ["a", ..."a"[], "b"]
+      | ["a", ..."a"[], "b", "c"]
+      | ["b", "c"?]
+    >();
+  });
+
+  test("fixed-elements array", () => {
+    expectTypeOf(
+      nonEmptyPrefix(["a", "b", "d", "e"] as ["a", "b", ..."c"[], "d", "e"]),
+    ).toEqualTypeOf<
+      | ["a", "b"?, ..."c"[]]
+      | ["a", "b", ..."c"[], "d"]
+      | ["a", "b", ..."c"[], "d", "e"]
+    >();
+  });
+});
+
+test("union of tuples with different shapes", () => {
+  expectTypeOf(
+    nonEmptyPrefix(["a", "b"] as ["a", "b"] | ["c", ..."d"[]]),
+  ).toEqualTypeOf<["a", "b"?] | ["c", ..."d"[]]>();
+});

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.test-d.ts
@@ -93,3 +93,24 @@ test("union of tuples with different shapes", () => {
     nonEmptyPrefix(["a", "b"] as ["a", "b"] | ["c", ..."d"[]]),
   ).toEqualTypeOf<["a", "b"?] | ["c", ..."d"[]]>();
 });
+
+describe("known issues!", () => {
+  test("tuple prefixes aren't assignable to arrays", () => {
+    const result = nonEmptyPrefix(["a", "b", "c"]);
+
+    expectTypeOf(result).toEqualTypeOf<[string, string?, string?]>();
+
+    // TypeScript adds `undefined` to reads of optional tuple elements even
+    // under `exactOptionalPropertyTypes`, where `undefined` is rejected as a
+    // value in those slots (@see
+    // https://github.com/microsoft/TypeScript/pull/50831). So the prefix of a
+    // tuple isn't assignable to an array of its items, although every value it
+    // describes would be. Users hit this when the input to `pipe` is a tuple
+    // and the callback passes `data` to something that expects an array (e.g.,
+    // `sum(data)`). If this test fails, TypeScript changed this behavior and
+    // the limitation should be removed from the docs.
+    expectTypeOf(result).items.toEqualTypeOf<string | undefined>();
+    expectTypeOf(result).items.not.toEqualTypeOf<string>();
+    expectTypeOf(result).not.toExtend<readonly ("a" | "b" | "c")[]>();
+  });
+});

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.ts
@@ -43,24 +43,26 @@ export type LazyTypePredicate<T extends IterableContainer, S> = (
  * a required first item (e.g., the array is not empty), similar to calling
  * `hasAtLeast(1)` on the shape we computed.
  *
- * Use this type in all utilities that are computed lazily, but *only* in the
- * data-last overload. When used as a type for a function parameter it should
- * also be wrapped in `Readonly` to discourage mutations.
+ * Use this type for any callback that `pipe` invokes lazily. That is always
+ * the data-last overload, and for utilities built on `purryFromLazy` (which
+ * routes data-first calls through `pipe` as well) it is the data-first overload
+ * too. This is a low-level type, prefer `LazyCallback` and
+ * `LazyTypePredicate` over direct usage.
+ *
+ * When the type is used for a callback used in `pipe` it should be wrapped in
+ * `Readonly` to prevent the callback from mutating it, as it is owned by `pipe`
+ * and can corrupt future iterations.
  *
  * @example
- *   // data-first
+ *   // data-first (eager, via `purry`)
  *   function forEach<T extends IterableContainer>(
  *     data: T,
  *     callbackfn: (value: T[number], index: number, data: T) => void,
  *   ): void;
  *
- *   // data-last
+ *   // data-last (lazy, via `pipe`)
  *   function forEach<T extends IterableContainer>(
- *     callbackfn: (
- *       value: T[number],
- *       index: number,
- *       data: Readonly<LazilyReconstructed<T>>,
- *     ) => void,
+ *     callbackfn: LazyCallback<T, void>,
  *   ): (data: T) => void;
  */
 export type NonEmptyPrefix<T extends IterableContainer> =

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.ts
@@ -5,29 +5,6 @@ import type { PartialArray } from "./PartialArray";
 import type { TupleParts } from "./TupleParts";
 
 /**
- * Helper type for lazy data-last callbacks.
- *
- * @see NonEmptyPrefix
- */
-export type LazyCallback<T extends IterableContainer, R> = (
-  item: T[number],
-  index: number,
-  data: Readonly<NonEmptyPrefix<T>>,
-) => R;
-
-/**
- * Helper type for lazy data-last type predicates (because TypeScript doesn't
- * support the syntax `LazyCallback<T, is S>`).
- *
- * @see NonEmptyPrefix
- */
-export type LazyTypePredicate<T extends IterableContainer, S> = (
-  item: T[number],
-  index: number,
-  data: Readonly<NonEmptyPrefix<T>>,
-) => item is S;
-
-/**
  * For utilities that support lazy evaluation (like `map`, `filter`, etc...)
  * `pipe` computes the 3rd callback parameter (which is usually the same
  * reference as the input array in the standard library) lazily too, item by
@@ -95,31 +72,31 @@ type HeadPrefixes<Prefix, Item> = Prefix extends readonly []
     // exists.
     [...PartialTail<Prefix>, ...CoercedArray<Item>];
 
-// Non-trivial suffixes can only show up in two tuple shapes, fixed-suffix
-// arrays, and fixed-elements arrays (see the definitions in the `TupleParts`
-// docs). Both contain no optional part, contain a non-trivial rest item, and
-// are differentiated by the presence of a required prefix, or lack thereof.
-// TypeScript doesn't support optional elements after the rest element, so we
-// can't just rewrite the suffix and add it to the end of the tuple to support
-// the lazily reconstructed prefixes, instead, we need to consider each prefix
-// of the suffix as it's own type and add them in a union. For **any** other
-// tuple shape this type resolves to `never` (via the TypeScript mechanism that
-// reduces `[...never]` to `never`).
+// Non-trivial suffixes only show up in two tuple shapes: fixed-suffix arrays
+// and fixed-elements arrays (see the definitions in the `TupleParts` docs).
+// Both have no optional part and a non-trivial rest item, and differ only in
+// whether they have a required prefix. TypeScript doesn't support optional
+// elements after a rest element, so the suffix can't be partialized in place;
+// instead each prefix of the suffix becomes it's own union member. For every
+// other tuple shape `Suffix` is `[]`, so `Prefixes<[]>` and `PartialTail<[]>`
+// are both `never` and spreading them collapses the whole member to `never`.
 type SuffixPrefixes<
   Required extends unknown[],
   Item,
   Suffix,
 > = Required extends readonly []
-  ? // For fixed-suffix arrays we have 2 situations we need to handle, the first
-    // handles the rest item, taking the first iteration of it as required and
-    // constructing the rest of the tuple after it.
+  ? // Without a required prefix the general formula below would yield
+    // `[...Item[], ...Suffix]`. TypeScript doesn't consider a tuple with a
+    // leading rest element assignable to `[T, ...T[]]` (`NonEmptyArray`), even
+    // though its minimum length is 1, so `data` could no longer be passed to
+    // anything typed as non-empty. To keep every member structurally non-empty
+    // we hoist the rest item's first iteration into a required slot...
     | [Item, ...Item[], ...Prefixes<Suffix>]
-    // The second situation is that the rest item contributed no elements, in
-    // this case we don't have a rest item at all so we can treat the suffix
-    // the same way we treat the prefix, partializing the tail.
+    // ...and enumerate the zero-iteration case separately, where the suffix is
+    // the whole tuple and can be partialized like a prefix.
     | PartialTail<Suffix>
-  : // For fixed-elements arrays the required prefix is always fully included
-    // when we reach the suffix.
+  : // With a required prefix the first element is already required, so the
+    // rest item can stay a plain rest element.
     [...Required, ...CoercedArray<Item>, ...Prefixes<Suffix>];
 
 /**
@@ -138,13 +115,13 @@ type PartialTail<T> = T extends readonly [infer Head, ...infer Tail]
  * This type assumes that T is a fixed tuple (no optional part and no rest
  * item).
  *
- * @returns The union of the fixed tuples of length L in range `(1, n]`
+ * @returns The union of the fixed tuples of length L in range `[1, n]`
  * where `[T[0], T[1], ..., T[L-1]]`.
  * @example Prefixes<['a', 'b', 'c', 'd']> //=> ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'c', 'd']
  */
-type Prefixes<T, Prefix extends unknown[] = []> = T extends readonly [
-  infer Head,
-  ...infer Rest,
-]
-  ? [...Prefix, Head] | Prefixes<Rest, [...Prefix, Head]>
-  : never;
+type Prefixes<T> = T extends readonly [infer Head, ...infer Rest]
+  ? [Head] | [Head, ...Prefixes<Rest>]
+  : // We return `never` for the empty array to skip adding `[]` to every
+    // output. This also works with the recursion above when `[Head, ...never]`
+    // would fold to `never`.
+    never;

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.ts
@@ -1,0 +1,148 @@
+import type { IsNever } from "type-fest";
+import type { CoercedArray } from "./CoercedArray";
+import type { IterableContainer } from "./IterableContainer";
+import type { PartialArray } from "./PartialArray";
+import type { TupleParts } from "./TupleParts";
+
+/**
+ * Helper type for lazy data-last callbacks.
+ *
+ * @see NonEmptyPrefix
+ */
+export type LazyCallback<T extends IterableContainer, R> = (
+  item: T[number],
+  index: number,
+  data: Readonly<NonEmptyPrefix<T>>,
+) => R;
+
+/**
+ * Helper type for lazy data-last type predicates (because TypeScript doesn't
+ * support the syntax `LazyCallback<T, is S>`).
+ *
+ * @see NonEmptyPrefix
+ */
+export type LazyTypePredicate<T extends IterableContainer, S> = (
+  item: T[number],
+  index: number,
+  data: Readonly<NonEmptyPrefix<T>>,
+) => item is S;
+
+/**
+ * For utilities that support lazy evaluation (like `map`, `filter`, etc...)
+ * `pipe` computes the 3rd callback parameter (which is usually the same
+ * reference as the input array in the standard library) lazily too, item by
+ * item, as the items flow through the pipe. This means that unlike the standard
+ * library, we can't type the parameter as the plain input array T, instead, we
+ * need to compute a shape that represents a partial prefix of the input T, and
+ * we want to maintain as much of the input shape as possible. This will prevent
+ * unchecked array access for items which haven't been computed and added to the
+ * array yet.
+ *
+ * Additionally, because the callback is always called when at least the first
+ * item is already being processed we can further refine our type so that it has
+ * a required first item (e.g., the array is not empty), similar to calling
+ * `hasAtLeast(1)` on the shape we computed.
+ *
+ * Use this type in all utilities that are computed lazily, but *only* in the
+ * data-last overload. When used as a type for a function parameter it should
+ * also be wrapped in `Readonly` to discourage mutations.
+ *
+ * @example
+ *   // data-first
+ *   function forEach<T extends IterableContainer>(
+ *     data: T,
+ *     callbackfn: (value: T[number], index: number, data: T) => void,
+ *   ): void;
+ *
+ *   // data-last
+ *   function forEach<T extends IterableContainer>(
+ *     callbackfn: (
+ *       value: T[number],
+ *       index: number,
+ *       data: Readonly<LazilyReconstructed<T>>,
+ *     ) => void,
+ *   ): (data: T) => void;
+ */
+export type NonEmptyPrefix<T extends IterableContainer> =
+  // Distribute over unions so that each member is decomposed on its own.
+  T extends unknown
+    ? | HeadPrefixes<
+          [...TupleParts<T>["required"], ...TupleParts<T>["optional"]],
+          TupleParts<T>["item"]
+        >
+      | SuffixPrefixes<
+          TupleParts<T>["required"],
+          TupleParts<T>["item"],
+          TupleParts<T>["suffix"]
+        >
+    : never;
+
+// For most tuple shapes (see the suffix cases below) the reconstructed type is
+// dependent on the presence of a prefix (either required and/or optional) and
+// the rest item.
+type HeadPrefixes<Prefix, Item> = Prefix extends readonly []
+  ? IsNever<Item> extends true
+    ? // Only empty tuple types have neither a prefix or a rest item, they also
+      // don't have any prefixes!
+      never
+    : // Without a prefix part the prefix is just a simple non-empty array
+      // shape.
+      [Item, ...Item[]]
+  : // When we have a non-trivial prefix then it has a first item, and all
+    // remaining items are optional by definition. We add the rest item if it
+    // exists.
+    [...PartialTail<Prefix>, ...CoercedArray<Item>];
+
+// Non-trivial suffixes can only show up in two tuple shapes, fixed-suffix
+// arrays, and fixed-elements arrays (see the definitions in the `TupleParts`
+// docs). Both contain no optional part, contain a non-trivial rest item, and
+// are differentiated by the presence of a required prefix, or lack thereof.
+// TypeScript doesn't support optional elements after the rest element, so we
+// can't just rewrite the suffix and add it to the end of the tuple to support
+// the lazily reconstructed prefixes, instead, we need to consider each prefix
+// of the suffix as it's own type and add them in a union. For **any** other
+// tuple shape this type resolves to `never` (via the TypeScript mechanism that
+// reduces `[...never]` to `never`).
+type SuffixPrefixes<
+  Required extends unknown[],
+  Item,
+  Suffix,
+> = Required extends readonly []
+  ? // For fixed-suffix arrays we have 2 situations we need to handle, the first
+    // handles the rest item, taking the first iteration of it as required and
+    // constructing the rest of the tuple after it.
+    | [Item, ...Item[], ...Prefixes<Suffix>]
+    // The second situation is that the rest item contributed no elements, in
+    // this case we don't have a rest item at all so we can treat the suffix
+    // the same way we treat the prefix, partializing the tail.
+    | PartialTail<Suffix>
+  : // For fixed-elements arrays the required prefix is always fully included
+    // when we reach the suffix.
+    [...Required, ...CoercedArray<Item>, ...Prefixes<Suffix>];
+
+/**
+ * This type assumes that T is a fixed tuple (no optional part and no rest
+ * item).
+ *
+ * @returns A reconstructed tuple where the first item in T is required, and
+ * all the rest are optional.
+ * @example PartialTail<['a', 'b', 'c']> //=> ['a', 'b'?, 'c'?]
+ */
+type PartialTail<T> = T extends readonly [infer Head, ...infer Tail]
+  ? [Head, ...PartialArray<Tail>]
+  : never;
+
+/**
+ * This type assumes that T is a fixed tuple (no optional part and no rest
+ * item).
+ *
+ * @returns The union of the fixed tuples of length L in range `(1, n]`
+ * where `[T[0], T[1], ..., T[L-1]]`.
+ * @example Prefixes<['a', 'b', 'c', 'd']> //=> ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'c', 'd']
+ */
+type Prefixes<T, Prefix extends unknown[] = []> = T extends readonly [
+  infer Head,
+  ...infer Rest,
+]
+  ? [...Prefix, Head] | Prefixes<Rest, [...Prefix, Head]>
+  : never;

--- a/packages/remeda/src/internal/types/NonEmptyPrefix.ts
+++ b/packages/remeda/src/internal/types/NonEmptyPrefix.ts
@@ -6,14 +6,13 @@ import type { TupleParts } from "./TupleParts";
 
 /**
  * For utilities that support lazy evaluation (like `map`, `filter`, etc...)
- * `pipe` computes the 3rd callback parameter (which is usually the same
- * reference as the input array in the standard library) lazily too, item by
- * item, as the items flow through the pipe. This means that unlike the standard
- * library, we can't type the parameter as the plain input array T, instead, we
- * need to compute a shape that represents a partial prefix of the input T, and
- * we want to maintain as much of the input shape as possible. This will prevent
- * unchecked array access for items which haven't been computed and added to the
- * array yet.
+ * `pipe` builds the callback's `data` parameter (which in the standard library
+ * is the array reference itself) lazily too, item by item, as the items flow
+ * through the pipe. This means that unlike the standard library, we can't type
+ * the parameter as the plain input array T. Instead, we need to compute a shape
+ * that represents a partial prefix of the input T, and we want to maintain as
+ * much of the input shape as possible. This will prevent unchecked array access
+ * for items which haven't been computed and added to the array yet.
  *
  * Additionally, because the callback is always called when at least the first
  * item is already being processed we can further refine our type so that it has
@@ -32,15 +31,15 @@ import type { TupleParts } from "./TupleParts";
  *
  * @example
  *   // data-first (eager, via `purry`)
- *   function forEach<T extends IterableContainer>(
+ *   function map<T extends IterableContainer, U>(
  *     data: T,
- *     callbackfn: (value: T[number], index: number, data: T) => void,
- *   ): void;
+ *     callbackfn: (value: T[number], index: number, data: T) => U,
+ *   ): Mapped<T, U>;
  *
  *   // data-last (lazy, via `pipe`)
- *   function forEach<T extends IterableContainer>(
- *     callbackfn: LazyCallback<T, void>,
- *   ): (data: T) => void;
+ *   function map<T extends IterableContainer, U>(
+ *     callbackfn: LazyCallback<T, U>,
+ *   ): (data: T) => Mapped<T, U>;
  */
 export type NonEmptyPrefix<T extends IterableContainer> =
   // Distribute over unions so that each member is decomposed on its own.
@@ -61,7 +60,7 @@ export type NonEmptyPrefix<T extends IterableContainer> =
 // the rest item.
 type HeadPrefixes<Prefix, Item> = Prefix extends readonly []
   ? IsNever<Item> extends true
-    ? // Only empty tuple types have neither a prefix or a rest item, they also
+    ? // Only empty tuple types have neither a prefix nor a rest item, they also
       // don't have any prefixes!
       never
     : // Without a prefix part the prefix is just a simple non-empty array
@@ -77,7 +76,7 @@ type HeadPrefixes<Prefix, Item> = Prefix extends readonly []
 // Both have no optional part and a non-trivial rest item, and differ only in
 // whether they have a required prefix. TypeScript doesn't support optional
 // elements after a rest element, so the suffix can't be partialized in place;
-// instead each prefix of the suffix becomes it's own union member. For every
+// instead each prefix of the suffix becomes its own union member. For every
 // other tuple shape `Suffix` is `[]`, so `Prefixes<[]>` and `PartialTail<[]>`
 // are both `never` and spreading them collapses the whole member to `never`.
 type SuffixPrefixes<
@@ -100,11 +99,10 @@ type SuffixPrefixes<
     [...Required, ...CoercedArray<Item>, ...Prefixes<Suffix>];
 
 /**
- * This type assumes that T is a fixed tuple (no optional part and no rest
- * item).
+ * Reconstructs a fixed tuple so that its first item is required and all the
+ * rest are optional. Assumes that T is a fixed tuple (no optional part and no
+ * rest item).
  *
- * @returns A reconstructed tuple where the first item in T is required, and
- * all the rest are optional.
  * @example PartialTail<['a', 'b', 'c']> //=> ['a', 'b'?, 'c'?]
  */
 type PartialTail<T> = T extends readonly [infer Head, ...infer Tail]
@@ -112,11 +110,10 @@ type PartialTail<T> = T extends readonly [infer Head, ...infer Tail]
   : never;
 
 /**
- * This type assumes that T is a fixed tuple (no optional part and no rest
- * item).
+ * The union of every non-empty prefix of a fixed tuple: for each L in
+ * `[1, n]`, the tuple `[T[0], ..., T[L-1]]`. Assumes that T is a fixed tuple
+ * (no optional part and no rest item).
  *
- * @returns The union of the fixed tuples of length L in range `[1, n]`
- * where `[T[0], T[1], ..., T[L-1]]`.
  * @example Prefixes<['a', 'b', 'c', 'd']> //=> ['a'] | ['a', 'b'] | ['a', 'b', 'c'] | ['a', 'b', 'c', 'd']
  */
 type Prefixes<T> = T extends readonly [infer Head, ...infer Rest]

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -215,7 +215,7 @@ describe("limited type inference through `NoInfer` (#1364)", () => {
   });
 });
 
-describe("data param", () => {
+describe("callback data param", () => {
   test("complete in data-first", () => {
     map([1, 2, 3] as const, (_value, _index, data) => {
       expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();

--- a/packages/remeda/src/map.test-d.ts
+++ b/packages/remeda/src/map.test-d.ts
@@ -214,3 +214,24 @@ describe("limited type inference through `NoInfer` (#1364)", () => {
     ).toEqualTypeOf<number[]>();
   });
 });
+
+describe("data param", () => {
+  test("complete in data-first", () => {
+    map([1, 2, 3] as const, (_value, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+
+      return 0;
+    });
+  });
+
+  test("lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3] as const,
+      map((_value, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+        return 0;
+      }),
+    );
+  });
+});

--- a/packages/remeda/src/map.ts
+++ b/packages/remeda/src/map.ts
@@ -1,6 +1,7 @@
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { Mapped } from "./internal/types/Mapped";
+import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**
@@ -46,7 +47,7 @@ export function map<T extends IterableContainer, U>(
  * @category Array
  */
 export function map<T extends IterableContainer, U>(
-  callbackfn: (value: T[number], index: number, data: T) => U,
+  callbackfn: LazyCallback<T, U>,
 ): (data: T) => Mapped<T, U>;
 
 export function map(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/map.ts
+++ b/packages/remeda/src/map.ts
@@ -1,7 +1,7 @@
 import type { IterableContainer } from "./internal/types/IterableContainer";
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { Mapped } from "./internal/types/Mapped";
-import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { purry } from "./purry";
 
 /**

--- a/packages/remeda/src/mapWithFeedback.test-d.ts
+++ b/packages/remeda/src/mapWithFeedback.test-d.ts
@@ -54,3 +54,26 @@ test("the items array passed to the callback should be an array type containing 
     100,
   );
 });
+
+test("data param is complete in data-first", () => {
+  mapWithFeedback(
+    [1, 2, 3] as const,
+    (_previousValue, _currentValue, _currentIndex, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+
+      return 0;
+    },
+    0,
+  );
+});
+
+test("data param is lazily reconstructed in data-last", () => {
+  pipe(
+    [1, 2, 3] as const,
+    mapWithFeedback((_previousValue, _currentValue, _currentIndex, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+      return 0;
+    }, 0),
+  );
+});

--- a/packages/remeda/src/mapWithFeedback.test-d.ts
+++ b/packages/remeda/src/mapWithFeedback.test-d.ts
@@ -43,23 +43,11 @@ test("should correctly infer type with a non-literal array type", () => {
   expectTypeOf(result).toEqualTypeOf<number[]>();
 });
 
-test("the items array passed to the callback should be an array type containing the union type of all of the members in the original array", () => {
-  mapWithFeedback(
-    [1, 2, 3, 4, 5] as const,
-    (acc, x, _index, items) => {
-      expectTypeOf(items).toEqualTypeOf<readonly [1, 2, 3, 4, 5]>();
-
-      return acc + x;
-    },
-    100,
-  );
-});
-
-test("data param is complete in data-first", () => {
+test("data param is lazily reconstructed in data-first", () => {
   mapWithFeedback(
     [1, 2, 3] as const,
     (_previousValue, _currentValue, _currentIndex, data) => {
-      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
 
       return 0;
     },

--- a/packages/remeda/src/mapWithFeedback.test.ts
+++ b/packages/remeda/src/mapWithFeedback.test.ts
@@ -38,20 +38,23 @@ describe("data first", () => {
     expect(result).not.toBe(data);
   });
 
-  test("should track index and provide entire items array", () => {
-    const data = [1, 2, 3, 4, 5];
+  test("should provide the items processed so far", () => {
+    const mock = vi.fn<
+      (
+        acc: unknown,
+        x: unknown,
+        index: unknown,
+        items: readonly unknown[],
+      ) => unknown
+    >((_acc, _x, _index, items) => [...items]);
 
-    const mockedReducer = vi.fn<(acc: number, x: number) => number>(
-      (acc, x) => acc + x,
-    );
+    mapWithFeedback([1, 2, 3, 4, 5], mock, []);
 
-    mapWithFeedback(data, mockedReducer, 100);
-
-    expect(mockedReducer).toHaveBeenNthCalledWith(1, 100, 1, 0, data);
-    expect(mockedReducer).toHaveBeenNthCalledWith(2, 101, 2, 1, data);
-    expect(mockedReducer).toHaveBeenNthCalledWith(3, 103, 3, 2, data);
-    expect(mockedReducer).toHaveBeenNthCalledWith(4, 106, 4, 3, data);
-    expect(mockedReducer).toHaveBeenNthCalledWith(5, 110, 5, 4, data);
+    expect(mock).toHaveNthReturnedWith(1, [1]);
+    expect(mock).toHaveNthReturnedWith(2, [1, 2]);
+    expect(mock).toHaveNthReturnedWith(3, [1, 2, 3]);
+    expect(mock).toHaveNthReturnedWith(4, [1, 2, 3, 4]);
+    expect(mock).toHaveNthReturnedWith(5, [1, 2, 3, 4, 5]);
   });
 });
 

--- a/packages/remeda/src/mapWithFeedback.ts
+++ b/packages/remeda/src/mapWithFeedback.ts
@@ -4,6 +4,13 @@ import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { Mapped } from "./internal/types/Mapped";
 import type { NonEmptyPrefix } from "./internal/types/NonEmptyPrefix";
 
+type LazyFeedbackCallback<T extends IterableContainer, U> = (
+  previousValue: U,
+  currentValue: T[number],
+  currentIndex: number,
+  data: Readonly<NonEmptyPrefix<T>>,
+) => U;
+
 /**
  * Applies a function on each element of the array, using the result of the
  * previous application, and returns an array of the successively computed
@@ -29,12 +36,7 @@ import type { NonEmptyPrefix } from "./internal/types/NonEmptyPrefix";
  */
 export function mapWithFeedback<T extends IterableContainer, U>(
   data: T,
-  callbackfn: (
-    previousValue: U,
-    currentValue: T[number],
-    currentIndex: number,
-    data: Readonly<NonEmptyPrefix<T>>,
-  ) => U,
+  callbackfn: LazyFeedbackCallback<T, U>,
   initialValue: U,
 ): Mapped<T, U>;
 
@@ -60,12 +62,7 @@ export function mapWithFeedback<T extends IterableContainer, U>(
  * @category Array
  */
 export function mapWithFeedback<T extends IterableContainer, U>(
-  callbackfn: (
-    previousValue: U,
-    currentValue: T[number],
-    currentIndex: number,
-    data: Readonly<NonEmptyPrefix<T>>,
-  ) => U,
+  callbackfn: LazyFeedbackCallback<T, U>,
   initialValue: U,
 ): (data: T) => Mapped<T, U>;
 

--- a/packages/remeda/src/mapWithFeedback.ts
+++ b/packages/remeda/src/mapWithFeedback.ts
@@ -2,6 +2,7 @@ import { purryFromLazy } from "./internal/purryFromLazy";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import type { Mapped } from "./internal/types/Mapped";
+import type { NonEmptyPrefix } from "./internal/types/NonEmptyPrefix";
 
 /**
  * Applies a function on each element of the array, using the result of the
@@ -63,7 +64,7 @@ export function mapWithFeedback<T extends IterableContainer, U>(
     previousValue: U,
     currentValue: T[number],
     currentIndex: number,
-    data: T,
+    data: Readonly<NonEmptyPrefix<T>>,
   ) => U,
   initialValue: U,
 ): (data: T) => Mapped<T, U>;

--- a/packages/remeda/src/mapWithFeedback.ts
+++ b/packages/remeda/src/mapWithFeedback.ts
@@ -33,7 +33,7 @@ export function mapWithFeedback<T extends IterableContainer, U>(
     previousValue: U,
     currentValue: T[number],
     currentIndex: number,
-    data: T,
+    data: Readonly<NonEmptyPrefix<T>>,
   ) => U,
   initialValue: U,
 ): Mapped<T, U>;

--- a/packages/remeda/src/pipe.test.ts
+++ b/packages/remeda/src/pipe.test.ts
@@ -3,6 +3,7 @@ import { filter } from "./filter";
 import { flat } from "./flat";
 import { identity } from "./identity";
 import { purryFromLazy } from "./internal/purryFromLazy";
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
 import { map } from "./map";
 import { pipe } from "./pipe";
@@ -175,6 +176,17 @@ describe("lazy", () => {
       1, 1,
     ]);
     expect(mockMapper).toHaveBeenCalledTimes(1);
+  });
+
+  test("callbacks receive the items processed so far", () => {
+    const mock = vi.fn<LazyCallback<unknown[], unknown>>(
+      (_value, _index, data) => [...data],
+    );
+    pipe([1, 2, 3], map(mock));
+
+    expect(mock).toHaveNthReturnedWith(1, [1]);
+    expect(mock).toHaveNthReturnedWith(2, [1, 2]);
+    expect(mock).toHaveNthReturnedWith(3, [1, 2, 3]);
   });
 });
 

--- a/packages/remeda/src/uniqueBy.test-d.ts
+++ b/packages/remeda/src/uniqueBy.test-d.ts
@@ -3,9 +3,9 @@ import { pipe } from "./pipe";
 import { uniqueBy } from "./uniqueBy";
 
 describe("data param", () => {
-  test("complete in data-first", () => {
+  test("lazily reconstructed in data-first", () => {
     uniqueBy([1, 2, 3] as const, (_item, _index, data) => {
-      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
 
       return 0;
     });

--- a/packages/remeda/src/uniqueBy.test-d.ts
+++ b/packages/remeda/src/uniqueBy.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { pipe } from "./pipe";
+import { uniqueBy } from "./uniqueBy";
+
+describe("data param", () => {
+  test("complete in data-first", () => {
+    uniqueBy([1, 2, 3] as const, (_item, _index, data) => {
+      expectTypeOf(data).toEqualTypeOf<readonly [1, 2, 3]>();
+
+      return 0;
+    });
+  });
+
+  test("lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3] as const,
+      uniqueBy((_item, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();
+
+        return 0;
+      }),
+    );
+  });
+});

--- a/packages/remeda/src/uniqueBy.test-d.ts
+++ b/packages/remeda/src/uniqueBy.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { uniqueBy } from "./uniqueBy";
 
-describe("data param", () => {
+describe("callback data param", () => {
   test("lazily reconstructed in data-first", () => {
     uniqueBy([1, 2, 3] as const, (_item, _index, data) => {
       expectTypeOf(data).toEqualTypeOf<readonly [1, 2?, 3?]>();

--- a/packages/remeda/src/uniqueBy.test.ts
+++ b/packages/remeda/src/uniqueBy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { identity } from "./identity";
-import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import { pipe } from "./pipe";
 import { take } from "./take";
 import { uniqueBy } from "./uniqueBy";

--- a/packages/remeda/src/uniqueBy.test.ts
+++ b/packages/remeda/src/uniqueBy.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { createLazyInvocationCounter } from "../test/lazyInvocationCounter";
 import { identity } from "./identity";
+import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { pipe } from "./pipe";
 import { take } from "./take";
 import { uniqueBy } from "./uniqueBy";
@@ -48,6 +49,18 @@ test("returns people with uniq first letter of name", () => {
     { name: "Kim", age: 22 },
     { name: "Emily", age: 42 },
   ]);
+});
+
+test("provides the items processed so far to the key function", () => {
+  const mock = vi.fn<LazyCallback<unknown[], unknown>>(
+    (_item, _index, data) => [...data],
+  );
+  uniqueBy([1, 2, 2, 3], mock);
+
+  expect(mock).toHaveNthReturnedWith(1, [1]);
+  expect(mock).toHaveNthReturnedWith(2, [1, 2]);
+  expect(mock).toHaveNthReturnedWith(3, [1, 2, 2]);
+  expect(mock).toHaveNthReturnedWith(4, [1, 2, 2, 3]);
 });
 
 // eslint-disable-next-line vitest/valid-title -- This seems to be a bug in the rule, @see https://github.com/vitest-dev/eslint-plugin-vitest/issues/692

--- a/packages/remeda/src/uniqueBy.ts
+++ b/packages/remeda/src/uniqueBy.ts
@@ -25,7 +25,7 @@ import { SKIP_ITEM } from "./internal/utilityEvaluators";
  */
 export function uniqueBy<T extends IterableContainer>(
   data: T,
-  keyFunction: (item: T[number], index: number, data: T) => unknown,
+  keyFunction: LazyCallback<T, unknown>,
 ): Deduped<T>;
 
 /**

--- a/packages/remeda/src/uniqueBy.ts
+++ b/packages/remeda/src/uniqueBy.ts
@@ -2,8 +2,8 @@ import { purryFromLazy } from "./internal/purryFromLazy";
 import type { BrandedReturn } from "./internal/types/BrandedReturn";
 import type { Deduped } from "./internal/types/Deduped";
 import type { IterableContainer } from "./internal/types/IterableContainer";
+import type { LazyCallback } from "./internal/types/LazyCallback";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
-import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 
 /**

--- a/packages/remeda/src/uniqueBy.ts
+++ b/packages/remeda/src/uniqueBy.ts
@@ -3,6 +3,7 @@ import type { BrandedReturn } from "./internal/types/BrandedReturn";
 import type { Deduped } from "./internal/types/Deduped";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { LazyCallback } from "./internal/types/NonEmptyPrefix";
 import { SKIP_ITEM } from "./internal/utilityEvaluators";
 
 /**
@@ -45,7 +46,7 @@ export function uniqueBy<T extends IterableContainer>(
  * @category Array
  */
 export function uniqueBy<T extends IterableContainer>(
-  keyFunction: (item: T[number], index: number, data: T) => unknown,
+  keyFunction: LazyCallback<T, unknown>,
 ): (data: T) => Deduped<T>;
 
 export function uniqueBy(...args: readonly unknown[]): unknown {

--- a/packages/remeda/src/zipWith.test-d.ts
+++ b/packages/remeda/src/zipWith.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
 import { pipe } from "./pipe";
 import { zipWith } from "./zipWith";
 
@@ -28,4 +28,33 @@ test("data second with initial arg typings", () => {
   );
 
   expectTypeOf(actual).toEqualTypeOf<string[]>();
+});
+
+describe("callback data param", () => {
+  test("complete in data-first", () => {
+    zipWith(
+      [1, 2, 3] as const,
+      ["a", "b"] as const,
+      (_first, _second, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<
+          readonly [readonly [1, 2, 3], readonly ["a", "b"]]
+        >();
+
+        return 0;
+      },
+    );
+  });
+
+  test("first datum is lazily reconstructed in data-last", () => {
+    pipe(
+      [1, 2, 3] as const,
+      zipWith(["a", "b"] as const, (_first, _second, _index, data) => {
+        expectTypeOf(data).toEqualTypeOf<
+          readonly [readonly [1, 2?, 3?], readonly ["a", "b"]]
+        >();
+
+        return 0;
+      }),
+    );
+  });
 });

--- a/packages/remeda/src/zipWith.test.ts
+++ b/packages/remeda/src/zipWith.test.ts
@@ -86,6 +86,23 @@ describe("data second with initial arg", () => {
     expect(mockFn).toHaveBeenCalledTimes(0);
   });
 
+  test("provides the first items processed so far", () => {
+    const other = ["a", "b", "c"];
+    const mock = vi.fn<
+      (
+        first: unknown,
+        second: unknown,
+        index: unknown,
+        data: readonly [readonly unknown[], readonly unknown[]],
+      ) => unknown
+    >((_first, _second, _index, data) => structuredClone(data));
+    pipe([1, 2, 3], zipWith(other, mock));
+
+    expect(mock).toHaveNthReturnedWith(1, [[1], other]);
+    expect(mock).toHaveNthReturnedWith(2, [[1, 2], other]);
+    expect(mock).toHaveNthReturnedWith(3, [[1, 2, 3], other]);
+  });
+
   test("should return empty when first is empty", () => {
     expect(
       pipe(

--- a/packages/remeda/src/zipWith.ts
+++ b/packages/remeda/src/zipWith.ts
@@ -1,7 +1,8 @@
 import { lazyDataLastImpl } from "./internal/lazyDataLastImpl";
-import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 import type { IterableContainer } from "./internal/types/IterableContainer";
 import type { LazyEvaluator } from "./internal/types/LazyEvaluator";
+import type { NonEmptyPrefix } from "./internal/types/NonEmptyPrefix";
+import { lazyEmptyEvaluator } from "./internal/utilityEvaluators";
 
 type ZippingFunction<
   T1 extends IterableContainer = IterableContainer,
@@ -12,6 +13,20 @@ type ZippingFunction<
   second: T2[number],
   index: number,
   data: readonly [first: T1, second: T2],
+) => Value;
+
+// Inside `pipe` the first list flows through lazily, so the callback only sees
+// the items processed so far, while the second list is provided upfront and is
+// always complete.
+type LazyZippingFunction<
+  T1 extends IterableContainer = IterableContainer,
+  T2 extends IterableContainer = IterableContainer,
+  Value = unknown,
+> = (
+  first: T1[number],
+  second: T2[number],
+  index: number,
+  data: readonly [first: Readonly<NonEmptyPrefix<T1>>, second: T2],
 ) => Value;
 
 /**
@@ -47,7 +62,7 @@ export function zipWith<
   T1 extends IterableContainer,
   T2 extends IterableContainer,
   Value,
->(second: T2, fn: ZippingFunction<T1, T2, Value>): (first: T1) => Value[];
+>(second: T2, fn: LazyZippingFunction<T1, T2, Value>): (first: T1) => Value[];
 
 /**
  * Creates a new list from two supplied lists by calling the supplied function
@@ -72,7 +87,7 @@ export function zipWith<
 
 export function zipWith(
   arg0: IterableContainer | ZippingFunction,
-  arg1?: IterableContainer | ZippingFunction,
+  arg1?: IterableContainer | LazyZippingFunction | ZippingFunction,
   arg2?: ZippingFunction,
 ): unknown {
   if (typeof arg0 === "function") {


### PR DESCRIPTION
We were providing a bare `T` to our callback functions even when they are evaluated lazily, this meant that users might try to access "future" items which haven't been computed lazily yet unchecked and might hit a runtime error due to this.

Our new type is safer as it makes the whole type optional. To make the type more ergonomic, we also make the first item required so that the array type is never empty.

This was previously an undocumented gotcha that was simply rare enough that users didn't hit it often.

NOTE: Because we can't differentiate between data-last calls inside `pipe` and calls as callbacks (e.g., `map(find(...))`) the data param would always use the narrower type introduced in this PR, even in cases where the previous non-narrowed (`T`) type would be more accurate.